### PR TITLE
LPS-62906 Skip re-loading js files when loading more comments to a page

### DIFF
--- a/portal-web/docroot/html/taglib/ui/discussion/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/discussion/page.jsp
@@ -468,8 +468,14 @@ CommentSectionDisplayContext commentSectionDisplayContext = CommentDisplayContex
 						}
 					);
 
+					<%
+					String paginationURL = discussionTaglibHelper.getPaginationURL();
+					paginationURL = HttpUtil.addParameter(paginationURL, "namespace", namespace);
+					paginationURL = HttpUtil.addParameter(paginationURL, "skipEditorLoading", "true");
+					%>
+
 					$.ajax(
-						'<%= HttpUtil.addParameter(discussionTaglibHelper.getPaginationURL(), "namespace", namespace) %>',
+						'<%= paginationURL %>',
 						{
 							data: data,
 							error: function() {


### PR DESCRIPTION
JavaScript files for the editor were being loaded again every time "More Comments" was clicked, which would cause problems with trying to show the editor when it was being re-created. Fix adds a parameter to the paginationURL so that it skips loading the editor again for comments.