### PR TITLE
LPS-63687 Make flags portlet use language key in view.jsp

### DIFF
--- a/modules/apps/collaboration/flags/flags-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/collaboration/flags/flags-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,6 +24,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.flags.configuration.FlagsGroupServiceConfiguration" %><%@
 page import="com.liferay.flags.web.constants.PageFlagsPortletKeys" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@

--- a/modules/apps/collaboration/flags/flags-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/collaboration/flags/flags-web/src/main/resources/META-INF/resources/view.jsp
@@ -30,6 +30,6 @@ if (group.isUser()) {
 	className="<%= Layout.class.getName() %>"
 	classPK="<%= layout.getPlid() %>"
 	contentTitle="<%= layout.getHTMLTitle(LocaleUtil.getDefault()) %>"
-	message="flag-this-page"
+	message='<%= LanguageUtil.get(request, "flag-this-page") %>'
 	reportedUserId="<%= reportedUserId %>"
 />


### PR DESCRIPTION
The message field for the page flags portlet in view.jsp was using the String key value as the message instead of using the key to get the message from Language.properties.