### PR TITLE
LPS-64687 Hide default message when modifying a list within DDLDisplayPortlet

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -120,7 +121,7 @@ public class BlogsEntryStagedModelDataHandler
 			Image smallImage = _imageLocalService.fetchImage(
 				entry.getSmallImageId());
 
-			if (smallImage != null) {
+			if ((smallImage != null) && (smallImage.getTextObj() != null)) {
 				String smallImagePath = ExportImportPathUtil.getModelPath(
 					entry,
 					smallImage.getImageId() + StringPool.PERIOD +
@@ -132,6 +133,21 @@ public class BlogsEntryStagedModelDataHandler
 
 				portletDataContext.addZipEntry(
 					smallImagePath, smallImage.getTextObj());
+			}
+			else {
+				if (_log.isWarnEnabled()) {
+					StringBundler sb = new StringBundler(4);
+
+					sb.append("Unable to export small image with id ");
+					sb.append(entry.getSmallImageId());
+					sb.append(" to blog entry ");
+					sb.append(entry.getEntryId());
+
+					_log.warn(sb.toString());
+				}
+
+				entry.setSmallImage(false);
+				entry.setSmallImageId(0);
 			}
 		}
 

--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
@@ -135,7 +135,7 @@ public class BlogsEntryStagedModelDataHandler
 					String smallImagePath = ExportImportPathUtil.getModelPath(
 						entry,
 						smallImage.getImageId() + StringPool.PERIOD +
-						smallImage.getType());
+							smallImage.getType());
 
 					entryElement.addAttribute(
 						"small-image-path", smallImagePath);
@@ -149,9 +149,9 @@ public class BlogsEntryStagedModelDataHandler
 					if (_log.isWarnEnabled()) {
 						StringBundler sb = new StringBundler(4);
 
-						sb.append("Unable to export small image with id ");
+						sb.append("Unable to export small image ");
 						sb.append(entry.getSmallImageId());
-						sb.append(" to blog entry ");
+						sb.append(" to blogs entry ");
 						sb.append(entry.getEntryId());
 
 						_log.warn(sb.toString());

--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/lar/BlogsEntryStagedModelDataHandler.java
@@ -118,46 +118,49 @@ public class BlogsEntryStagedModelDataHandler
 		Element entryElement = portletDataContext.getExportDataElement(entry);
 
 		if (entry.isSmallImage()) {
-			Image smallImage = _imageLocalService.fetchImage(
-				entry.getSmallImageId());
+			if (entry.getSmallImageFileEntryId() > 0) {
+				FileEntry fileEntry =
+					PortletFileRepositoryUtil.getPortletFileEntry(
+						entry.getSmallImageFileEntryId());
 
-			if ((smallImage != null) && (smallImage.getTextObj() != null)) {
-				String smallImagePath = ExportImportPathUtil.getModelPath(
-					entry,
-					smallImage.getImageId() + StringPool.PERIOD +
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, entry, fileEntry,
+					PortletDataContext.REFERENCE_TYPE_WEAK);
+			}
+			else if (entry.getSmallImageId() > 0) {
+				Image smallImage = _imageLocalService.fetchImage(
+					entry.getSmallImageId());
+
+				if ((smallImage != null) && (smallImage.getTextObj() != null)) {
+					String smallImagePath = ExportImportPathUtil.getModelPath(
+						entry,
+						smallImage.getImageId() + StringPool.PERIOD +
 						smallImage.getType());
 
-				entryElement.addAttribute("small-image-path", smallImagePath);
+					entryElement.addAttribute(
+						"small-image-path", smallImagePath);
 
-				entry.setSmallImageType(smallImage.getType());
+					entry.setSmallImageType(smallImage.getType());
 
-				portletDataContext.addZipEntry(
-					smallImagePath, smallImage.getTextObj());
-			}
-			else {
-				if (_log.isWarnEnabled()) {
-					StringBundler sb = new StringBundler(4);
-
-					sb.append("Unable to export small image with id ");
-					sb.append(entry.getSmallImageId());
-					sb.append(" to blog entry ");
-					sb.append(entry.getEntryId());
-
-					_log.warn(sb.toString());
+					portletDataContext.addZipEntry(
+						smallImagePath, smallImage.getTextObj());
 				}
+				else {
+					if (_log.isWarnEnabled()) {
+						StringBundler sb = new StringBundler(4);
 
-				entry.setSmallImage(false);
-				entry.setSmallImageId(0);
+						sb.append("Unable to export small image with id ");
+						sb.append(entry.getSmallImageId());
+						sb.append(" to blog entry ");
+						sb.append(entry.getEntryId());
+
+						_log.warn(sb.toString());
+					}
+
+					entry.setSmallImage(false);
+					entry.setSmallImageId(0);
+				}
 			}
-		}
-
-		if (entry.getSmallImageFileEntryId() != 0) {
-			FileEntry fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
-				entry.getSmallImageFileEntryId());
-
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, entry, fileEntry,
-				PortletDataContext.REFERENCE_TYPE_WEAK);
 		}
 
 		if (entry.getCoverImageFileEntryId() != 0) {

--- a/modules/apps/collaboration/ratings/ratings-service/src/main/java/com/liferay/ratings/lar/RatingsEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/ratings/ratings-service/src/main/java/com/liferay/ratings/lar/RatingsEntryStagedModelDataHandler.java
@@ -126,8 +126,7 @@ public class RatingsEntryStagedModelDataHandler
 		catch (PortalException pe) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to import ratings entry with id " +
-						entry.getEntryId());
+					"Unable to import ratings entry " + entry.getEntryId());
 			}
 
 			return;

--- a/modules/apps/collaboration/ratings/ratings-service/src/main/java/com/liferay/ratings/lar/RatingsEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/ratings/ratings-service/src/main/java/com/liferay/ratings/lar/RatingsEntryStagedModelDataHandler.java
@@ -19,8 +19,12 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.lar.BaseStagedModelDataHandler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
@@ -112,6 +116,23 @@ public class RatingsEntryStagedModelDataHandler
 		long newClassPK = MapUtil.getLong(
 			relatedClassPKs, entry.getClassPK(), entry.getClassPK());
 
+		try {
+			PersistedModelLocalService persistedModelLocalService =
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalService(entry.getClassName());
+
+			persistedModelLocalService.getPersistedModel(newClassPK);
+		}
+		catch (PortalException pe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to import ratings entry with id " +
+						entry.getEntryId());
+			}
+
+			return;
+		}
+
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			entry);
 
@@ -133,6 +154,9 @@ public class RatingsEntryStagedModelDataHandler
 
 		_ratingsEntryLocalService = ratingsEntryLocalService;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RatingsEntryStagedModelDataHandler.class);
 
 	private GroupLocalService _groupLocalService;
 	private RatingsEntryLocalService _ratingsEntryLocalService;

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_selected_record_set_options.jspf
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_selected_record_set_options.jspf
@@ -173,6 +173,7 @@
 
 			<c:if test="<%= ddlDisplayContext.isShowAddRecordSetIcon() %>">
 				<liferay-portlet:renderURL portletName="<%= DDLPortletKeys.DYNAMIC_DATA_LISTS %>" var="addRecordSetURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="hideDefaultSuccessMessage" value="<%= Boolean.TRUE.toString() %>" />
 					<portlet:param name="mvcPath" value="/edit_record_set.jsp" />
 					<portlet:param name="redirect" value="<%= redirectURL.toString() %>" />
 					<portlet:param name="portletResource" value="<%= portletDisplay.getId() %>" />
@@ -194,6 +195,7 @@
 
 			<c:if test="<%= ddlDisplayContext.isShowEditRecordSetIcon() %>">
 				<liferay-portlet:renderURL portletName="<%= DDLPortletKeys.DYNAMIC_DATA_LISTS %>" var="editRecordSetURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+					<portlet:param name="hideDefaultSuccessMessage" value="<%= Boolean.TRUE.toString() %>" />
 					<portlet:param name="mvcPath" value="/edit_record_set.jsp" />
 					<portlet:param name="redirect" value="<%= redirectURL.toString() %>" />
 					<portlet:param name="portletResource" value="<%= portletDisplay.getId() %>" />

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
@@ -1875,7 +1875,7 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 			return ddmFolderId;
 		}
 
-		protected void addDLFileEntry(
+		protected DLFileEntry addDLFileEntry(
 				String uuid, long fileEntryId, long groupId, long companyId,
 				long userId, String userName, Timestamp createDate,
 				Timestamp modifiedDate, long classNameId, long classPK,
@@ -1919,7 +1919,7 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 			dlFileEntry.setCustom2ImageId(custom2ImageId);
 			dlFileEntry.setManualCheckInRequired(manualCheckInRequired);
 
-			_dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
+			return dlFileEntry;
 		}
 
 		protected void addDLFileVersion(
@@ -2135,7 +2135,7 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 				File file = DLStoreUtil.getFile(
 					_companyId, CompanyConstants.SYSTEM, filePath);
 
-				addDLFileEntry(
+				DLFileEntry dlFileEntry = addDLFileEntry(
 					fileEntryUuid, fileEntryId, _groupId, _companyId, _userId,
 					_userName, _createDate, _createDate, 0, 0, _groupId,
 					dlFolderId, StringPool.BLANK, name, fileName, extension,
@@ -2144,6 +2144,21 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 					DLFileEntryConstants.VERSION_DEFAULT, file.length(),
 					DLFileEntryConstants.DEFAULT_READ_COUNT, 0, 0, 0, 0, false);
+
+				// File version
+
+				addDLFileVersion(
+					fileEntryUuid, increment(), _groupId, _companyId, _userId,
+					_userName, _createDate, _createDate, _groupId, dlFolderId,
+					fileEntryId, StringPool.BLANK, fileName, extension,
+					MimeTypesUtil.getContentType(fileName), fileName,
+					StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+					DLFileEntryConstants.VERSION_DEFAULT, file.length(),
+					StringPool.BLANK, WorkflowConstants.STATUS_APPROVED,
+					_userId, _userName, _createDate);
+
+				_dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
 
 				// Resource permissions
 
@@ -2163,19 +2178,6 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 					DLFileEntry.class.getName(), RoleConstants.GUEST,
 					ResourceConstants.SCOPE_INDIVIDUAL,
 					getActionIdsLong(_guestPermissions));
-
-				// File version
-
-				addDLFileVersion(
-					fileEntryUuid, increment(), _groupId, _companyId, _userId,
-					_userName, _createDate, _createDate, _groupId, dlFolderId,
-					fileEntryId, StringPool.BLANK, fileName, extension,
-					MimeTypesUtil.getContentType(fileName), fileName,
-					StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					DLFileEntryConstants.VERSION_DEFAULT, file.length(),
-					StringPool.BLANK, WorkflowConstants.STATUS_APPROVED,
-					_userId, _userName, _createDate);
 
 				// Asset entry
 

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
@@ -2078,17 +2078,14 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 		protected long getDLFolderId(
 			long groupId, long parentFolderId, String name) {
 
-			try {
-				DLFolder dlFolder = _dlFolderLocalService.getFolder(
-					groupId, parentFolderId, name);
+			DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
+				groupId, parentFolderId, name);
 
-				return dlFolder.getFolderId();
-			}
-			catch (PortalException pe) {
-				_log.error("Unable to get DLfolder ID " + pe);
-
+			if (dlFolder == null) {
 				return 0;
 			}
+
+			return dlFolder.getFolderId();
 		}
 
 		protected String getExtension(String fileName) {

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/lar/DDMTemplateStagedModelDataHandler.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/lar/DDMTemplateStagedModelDataHandler.java
@@ -227,7 +227,7 @@ public class DDMTemplateStagedModelDataHandler
 					if (_log.isWarnEnabled()) {
 						StringBundler sb = new StringBundler(4);
 
-						sb.append("Unable to export small image with id ");
+						sb.append("Unable to export small image ");
 						sb.append(template.getSmallImageId());
 						sb.append(" to template ");
 						sb.append(template.getTemplateKey());

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
@@ -239,17 +239,14 @@ public class XMLWorkflowModelParser implements WorkflowModelParser {
 			for (Element roleAssignmentElement : roleAssignmentElements) {
 				long roleId = GetterUtil.getLong(
 					roleAssignmentElement.elementText("role-id"));
-				String roleType = roleAssignmentElement.elementText(
-					"role-type");
+				String roleType = GetterUtil.getString(
+					roleAssignmentElement.elementText("role-type"),
+					RoleConstants.TYPE_REGULAR_LABEL);
 				String name = roleAssignmentElement.elementText("name");
 
 				RoleAssignment roleAssignment = null;
 
 				if (Validator.isNotNull(name)) {
-					if (Validator.isNull(roleType)) {
-						roleType = RoleConstants.TYPE_REGULAR_LABEL;
-					}
-
 					roleAssignment = new RoleAssignment(name, roleType);
 
 					boolean autoCreate = GetterUtil.getBoolean(
@@ -493,13 +490,9 @@ public class XMLWorkflowModelParser implements WorkflowModelParser {
 			for (Element roleReceipientElement : roleReceipientElements) {
 				long roleId = GetterUtil.getLong(
 					roleReceipientElement.elementText("role-id"));
-				String roleType = roleReceipientElement.elementText(
-					"role-type");
-
-				if (Validator.isNull(roleType)) {
-					roleType = RoleConstants.TYPE_REGULAR_LABEL;
-				}
-
+				String roleType = GetterUtil.getString(
+					roleReceipientElement.elementText("role-type"),
+					RoleConstants.TYPE_REGULAR_LABEL);
 				String name = roleReceipientElement.elementText("name");
 
 				RoleRecipient roleRecipient = null;

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow.kaleo.definition.internal.parser;
 
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -245,6 +246,10 @@ public class XMLWorkflowModelParser implements WorkflowModelParser {
 				RoleAssignment roleAssignment = null;
 
 				if (Validator.isNotNull(name)) {
+					if (Validator.isNull(roleType)) {
+						roleType = RoleConstants.TYPE_REGULAR_LABEL;
+					}
+
 					roleAssignment = new RoleAssignment(name, roleType);
 
 					boolean autoCreate = GetterUtil.getBoolean(
@@ -490,6 +495,11 @@ public class XMLWorkflowModelParser implements WorkflowModelParser {
 					roleReceipientElement.elementText("role-id"));
 				String roleType = roleReceipientElement.elementText(
 					"role-type");
+
+				if (Validator.isNull(roleType)) {
+					roleType = RoleConstants.TYPE_REGULAR_LABEL;
+				}
+
 				String name = roleReceipientElement.elementText("name");
 
 				RoleRecipient roleRecipient = null;

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/StagingImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/staging/StagingImpl.java
@@ -803,7 +803,8 @@ public class StagingImpl implements Staging {
 				errorMessage = LanguageUtil.get(
 					locale,
 					"there-are-missing-references-that-could-not-be-found-in-" +
-						"the-live-environment");
+						"the-live-environment-the-following-elements-are-" +
+							"published-from-their-own-site");
 			}
 			else {
 				errorMessage = LanguageUtil.get(

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
@@ -53,7 +53,7 @@ catch (Exception e) {
 				</c:otherwise>
 			</c:choose>
 
-			<span class="error-message"><%= HtmlUtil.escape(LanguageUtil.get(request, jsonObject.getString("message"))) %></span>
+			<span class="error-message"><%= HtmlUtil.escape(jsonObject.getString("message")) %></span>
 
 			<%
 			JSONArray messageListItemsJSONArray = jsonObject.getJSONArray("messageListItems");

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -331,7 +331,7 @@ public class JournalArticleStagedModelDataHandler
 					if (_log.isWarnEnabled()) {
 						StringBundler sb = new StringBundler(4);
 
-						sb.append("Unable to export small image with id ");
+						sb.append("Unable to export small image ");
 						sb.append(article.getSmallImageId());
 						sb.append(" to article ");
 						sb.append(article.getArticleId());

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -325,6 +325,11 @@ public class JournalArticleStagedModelDataHandler
 				portletDataContext.addZipEntry(
 					smallImagePath, smallImage.getTextObj());
 			}
+			else if ((smallImage != null) &&
+					 (smallImage.getTextObj() == null)) {
+
+				article.setSmallImage(false);
+			}
 		}
 
 		List<JournalArticleImage> articleImages =

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -297,9 +297,6 @@ public class JournalArticleStagedModelDataHandler
 		}
 
 		if (article.isSmallImage()) {
-			Image smallImage = _imageLocalService.fetchImage(
-				article.getSmallImageId());
-
 			if (Validator.isNotNull(article.getSmallImageURL())) {
 				String smallImageURL =
 					_journalArticleExportImportContentProcessor.
@@ -310,25 +307,27 @@ public class JournalArticleStagedModelDataHandler
 
 				article.setSmallImageURL(smallImageURL);
 			}
-			else if ((smallImage != null) &&
-					 (smallImage.getTextObj() != null)) {
+			else {
+				Image smallImage = _imageLocalService.fetchImage(
+					article.getSmallImageId());
 
-				String smallImagePath = ExportImportPathUtil.getModelPath(
-					article,
-					smallImage.getImageId() + StringPool.PERIOD +
-						smallImage.getType());
+				if ((smallImage != null) && (smallImage.getTextObj() != null)) {
+					String smallImagePath = ExportImportPathUtil.getModelPath(
+						article,
+						smallImage.getImageId() + StringPool.PERIOD +
+							smallImage.getType());
 
-				articleElement.addAttribute("small-image-path", smallImagePath);
+					articleElement.addAttribute(
+						"small-image-path", smallImagePath);
 
-				article.setSmallImageType(smallImage.getType());
+					article.setSmallImageType(smallImage.getType());
 
-				portletDataContext.addZipEntry(
-					smallImagePath, smallImage.getTextObj());
-			}
-			else if ((smallImage != null) &&
-					 (smallImage.getTextObj() == null)) {
-
-				article.setSmallImage(false);
+					portletDataContext.addZipEntry(
+						smallImagePath, smallImage.getTextObj());
+				}
+				else {
+					article.setSmallImage(false);
+				}
 			}
 		}
 

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -310,7 +310,9 @@ public class JournalArticleStagedModelDataHandler
 
 				article.setSmallImageURL(smallImageURL);
 			}
-			else if (smallImage != null) {
+			else if ((smallImage != null) &&
+					 (smallImage.getTextObj() != null)) {
+
 				String smallImagePath = ExportImportPathUtil.getModelPath(
 					article,
 					smallImage.getImageId() + StringPool.PERIOD +

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/lar/JournalArticleStagedModelDataHandler.java
@@ -39,6 +39,8 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
 import com.liferay.portal.kernel.model.Layout;
@@ -326,7 +328,19 @@ public class JournalArticleStagedModelDataHandler
 						smallImagePath, smallImage.getTextObj());
 				}
 				else {
+					if (_log.isWarnEnabled()) {
+						StringBundler sb = new StringBundler(4);
+
+						sb.append("Unable to export small image with id ");
+						sb.append(article.getSmallImageId());
+						sb.append(" to article ");
+						sb.append(article.getArticleId());
+
+						_log.warn(sb.toString());
+					}
+
 					article.setSmallImage(false);
+					article.setSmallImageId(0);
 				}
 			}
 		}
@@ -962,6 +976,9 @@ public class JournalArticleStagedModelDataHandler
 	protected void setUserLocalService(UserLocalService userLocalService) {
 		_userLocalService = userLocalService;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalArticleStagedModelDataHandler.class);
 
 	private DDMStructureLocalService _ddmStructureLocalService;
 	private DDMTemplateLocalService _ddmTemplateLocalService;

--- a/modules/apps/web-experience/journal/journal-terms-of-use/bnd.bnd
+++ b/modules/apps/web-experience/journal/journal-terms-of-use/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-Name: Journal Terms Of Use
+Bundle-Name: Liferay Journal Terms Of Use
 Bundle-SymbolicName: com.liferay.journal.terms.of.use
 Bundle-Version: 2.0.4
 Import-Package: com.liferay.portal.kernel.util;version="${range;[=,=+)}",*

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/lar/LayoutStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/lar/LayoutStagedModelDataHandler.java
@@ -693,7 +693,7 @@ public class LayoutStagedModelDataHandler
 			if (_log.isWarnEnabled()) {
 				StringBundler sb = new StringBundler(4);
 
-				sb.append("Unable to export icon image with id ");
+				sb.append("Unable to export icon image ");
 				sb.append(layout.getIconImageId());
 				sb.append(" to layout ");
 				sb.append(layout.getLayoutId());

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/lar/LayoutStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/lar/LayoutStagedModelDataHandler.java
@@ -677,7 +677,7 @@ public class LayoutStagedModelDataHandler
 
 		Image image = _imageLocalService.getImage(layout.getIconImageId());
 
-		if (image != null) {
+		if ((image != null) && (image.getTextObj() != null)) {
 			String iconPath = ExportImportPathUtil.getModelPath(
 				portletDataContext.getScopeGroupId(), Image.class.getName(),
 				image.getImageId());
@@ -688,6 +688,20 @@ public class LayoutStagedModelDataHandler
 			iconImagePathElement.addText(iconPath);
 
 			portletDataContext.addZipEntry(iconPath, image.getTextObj());
+		}
+		else {
+			if (_log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append("Unable to export icon image with id ");
+				sb.append(layout.getIconImageId());
+				sb.append(" to layout ");
+				sb.append(layout.getLayoutId());
+
+				_log.warn(sb.toString());
+			}
+
+			layout.setIconImageId(0);
 		}
 	}
 

--- a/modules/apps/web-experience/site/site-browser-web/src/main/java/com/liferay/site/browser/web/display/context/SiteBrowserDisplayContext.java
+++ b/modules/apps/web-experience/site/site-browser-web/src/main/java/com/liferay/site/browser/web/display/context/SiteBrowserDisplayContext.java
@@ -124,6 +124,8 @@ public class SiteBrowserDisplayContext {
 
 		_groupParams = new LinkedHashMap<>();
 
+		_groupParams.put("active", Boolean.TRUE);
+
 		if (isManualMembership()) {
 			_groupParams.put("manualMembership", Boolean.TRUE);
 		}

--- a/modules/apps/web-experience/staging/staging-configuration-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
+++ b/modules/apps/web-experience/staging/staging-configuration-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
@@ -53,7 +53,7 @@ catch (Exception e) {
 				</c:otherwise>
 			</c:choose>
 
-			<span class="error-message"><%= HtmlUtil.escape(LanguageUtil.get(request, jsonObject.getString("message"))) %></span>
+			<span class="error-message"><%= HtmlUtil.escape(jsonObject.getString("message")) %></span>
 
 			<%
 			JSONArray messageListItemsJSONArray = jsonObject.getJSONArray("messageListItems");

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/publish_process_message_task_details.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/publish_process_message_task_details.jsp
@@ -53,7 +53,7 @@ catch (Exception e) {
 				</c:otherwise>
 			</c:choose>
 
-			<span class="error-message"><%= HtmlUtil.escape(LanguageUtil.get(request, jsonObject.getString("message"))) %></span>
+			<span class="error-message"><%= HtmlUtil.escape(jsonObject.getString("message")) %></span>
 
 			<%
 			JSONArray messageListItemsJSONArray = jsonObject.getJSONArray("messageListItems");

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/SyncEngine.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/SyncEngine.java
@@ -16,7 +16,6 @@ package com.liferay.sync.engine;
 
 import com.j256.ormlite.support.ConnectionSource;
 
-import com.liferay.sync.engine.documentlibrary.util.BatchEventManager;
 import com.liferay.sync.engine.documentlibrary.util.FileEventUtil;
 import com.liferay.sync.engine.documentlibrary.util.ServerEventUtil;
 import com.liferay.sync.engine.filesystem.SyncWatchEventProcessor;
@@ -357,8 +356,6 @@ public class SyncEngine {
 						syncSite.getGroupId(), syncAccount.getSyncAccountId(),
 						syncSite, true);
 				}
-
-				BatchEventManager.fireBatchDownloadEvents();
 			}
 
 		};

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
@@ -17,6 +17,7 @@ package com.liferay.sync.engine.documentlibrary.handler;
 import com.liferay.sync.engine.documentlibrary.event.Event;
 import com.liferay.sync.engine.documentlibrary.event.GetSyncContextEvent;
 import com.liferay.sync.engine.documentlibrary.model.SyncDLObjectUpdate;
+import com.liferay.sync.engine.documentlibrary.util.BatchEventManager;
 import com.liferay.sync.engine.documentlibrary.util.FileEventUtil;
 import com.liferay.sync.engine.documentlibrary.util.comparator.SyncFileSizeComparator;
 import com.liferay.sync.engine.filesystem.Watcher;
@@ -238,6 +239,8 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 						getParameterValue("retrieveFromCache")));
 			}
 		}
+
+		BatchEventManager.fireBatchDownloadEvents();
 	}
 
 	protected void addFile(SyncFile syncFile, String filePathName)

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
@@ -174,12 +174,14 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 		SyncSite syncSite = (SyncSite)getParameterValue("syncSite");
 
-		syncSite = SyncSiteService.fetchSyncSite(
-			syncSite.getGroupId(), syncSite.getSyncAccountId());
+		if (syncSite != null) {
+			syncSite = SyncSiteService.fetchSyncSite(
+				syncSite.getGroupId(), syncSite.getSyncAccountId());
 
-		syncSite.setState(SyncSite.STATE_SYNCED);
+			syncSite.setState(SyncSite.STATE_SYNCED);
 
-		SyncSiteService.update(syncSite);
+			SyncSiteService.update(syncSite);
+		}
 	}
 
 	@Override
@@ -248,8 +250,10 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 		Path filePath = Paths.get(filePathName);
 
-		if (Files.exists(filePath) &&
-			(syncFile.isFolder() || !FileUtil.isModified(syncFile, filePath))) {
+		if (isParentUnsynced(syncFile) ||
+			(Files.exists(filePath) &&
+			 (syncFile.isFolder() ||
+			  !FileUtil.isModified(syncFile, filePath)))) {
 
 			return;
 		}
@@ -462,6 +466,26 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 		return FileUtil.isIgnoredFilePath(FileUtil.getFilePath(filePathName));
 	}
 
+	protected boolean isParentUnsynced(SyncFile syncFile) {
+		Path filePath = Paths.get(syncFile.getFilePathName());
+
+		if (FileUtil.isUnsynced(filePath.getParent())) {
+			if (syncFile.isFolder()) {
+				syncFile.setFilePathName(filePath.toString());
+				syncFile.setModifiedTime(0);
+				syncFile.setState(SyncFile.STATE_UNSYNCED);
+				syncFile.setUiEvent(SyncFile.UI_EVENT_NONE);
+				syncFile.setSyncAccountId(getSyncAccountId());
+
+				SyncFileService.update(syncFile);
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
 	@Override
 	protected void logResponse(String response) {
 		try {
@@ -495,13 +519,28 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 			String targetFilePathName)
 		throws Exception {
 
+		if (isParentUnsynced(targetSyncFile)) {
+			deleteFile(sourceSyncFile, targetSyncFile);
+
+			return;
+		}
+
 		Path sourceFilePath = Paths.get(sourceSyncFile.getFilePathName());
 		Path targetFilePath = Paths.get(targetFilePathName);
 
 		sourceSyncFile = SyncFileService.updateSyncFile(
 			targetFilePath, targetSyncFile.getParentFolderId(), sourceSyncFile);
 
-		if (Files.exists(sourceFilePath)) {
+		if (sourceSyncFile.isUnsynced()) {
+			List<SyncFile> syncFiles = new ArrayList<>();
+
+			syncFiles.add(sourceSyncFile);
+
+			SyncFileService.resyncFolders(syncFiles);
+
+			return;
+		}
+		else if (Files.exists(sourceFilePath)) {
 			FileUtil.moveFile(sourceFilePath, targetFilePath);
 
 			sourceSyncFile.setState(SyncFile.STATE_SYNCED);
@@ -529,7 +568,7 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 		List<SyncFile> dependentSyncFiles = _dependentSyncFilesMap.remove(
 			getSyncAccountId() + "#" + syncFile.getTypePK());
 
-		if (dependentSyncFiles == null) {
+		if (syncFile.isUnsynced() || (dependentSyncFiles == null)) {
 			return;
 		}
 
@@ -615,6 +654,9 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 					processDependentSyncFiles(sourceSyncFile);
 
+					return;
+				}
+				else if (isParentUnsynced(targetSyncFile)) {
 					return;
 				}
 
@@ -703,9 +745,13 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 		SyncFileService.update(sourceSyncFile);
 
+		if (isParentUnsynced(sourceSyncFile)) {
+			return;
+		}
+
 		Path filePath = Paths.get(targetSyncFile.getFilePathName());
 
-		if (filePathChanged && !Files.exists(filePath)) {
+		if (!Files.exists(filePath)) {
 			if (targetSyncFile.isFolder()) {
 				Path targetFilePath = Paths.get(filePathName);
 

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
@@ -622,13 +622,10 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 				if (sourceSyncFile != null) {
 					updateFile(sourceSyncFile, targetSyncFile, filePathName);
-
-					processDependentSyncFiles(sourceSyncFile);
-
-					return;
 				}
-
-				addFile(targetSyncFile, filePathName);
+				else {
+					addFile(targetSyncFile, filePathName);
+				}
 			}
 			else if (event.equals(SyncFile.EVENT_DELETE)) {
 				if (sourceSyncFile == null) {
@@ -640,40 +637,30 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 			else if (event.equals(SyncFile.EVENT_MOVE)) {
 				if (sourceSyncFile == null) {
 					addFile(targetSyncFile, filePathName);
-
-					processDependentSyncFiles(targetSyncFile);
-
-					return;
 				}
 				else if (sourceSyncFile.getParentFolderId() ==
 							targetSyncFile.getParentFolderId()) {
 
 					updateFile(sourceSyncFile, targetSyncFile, filePathName);
-
-					processDependentSyncFiles(targetSyncFile);
-
-					return;
 				}
-
-				moveFile(sourceSyncFile, targetSyncFile, filePathName);
+				else {
+					moveFile(sourceSyncFile, targetSyncFile, filePathName);
+				}
 			}
 			else if (event.equals(SyncFile.EVENT_RESTORE)) {
 				if (sourceSyncFile != null) {
 					updateFile(sourceSyncFile, targetSyncFile, filePathName);
-
-					processDependentSyncFiles(sourceSyncFile);
-
-					return;
 				}
 				else if (isParentUnsynced(targetSyncFile)) {
 					return;
 				}
+				else {
+					targetSyncFile.setLocalExtraSetting("restoreEvent", true);
 
-				targetSyncFile.setLocalExtraSetting("restoreEvent", true);
+					SyncFileService.update(targetSyncFile);
 
-				SyncFileService.update(targetSyncFile);
-
-				addFile(targetSyncFile, filePathName);
+					addFile(targetSyncFile, filePathName);
+				}
 			}
 			else if (event.equals(SyncFile.EVENT_TRASH)) {
 				if (sourceSyncFile == null) {
@@ -685,13 +672,10 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 			else if (event.equals(SyncFile.EVENT_UPDATE)) {
 				if (sourceSyncFile == null) {
 					addFile(targetSyncFile, filePathName);
-
-					processDependentSyncFiles(targetSyncFile);
-
-					return;
 				}
-
-				updateFile(sourceSyncFile, targetSyncFile, filePathName);
+				else {
+					updateFile(sourceSyncFile, targetSyncFile, filePathName);
+				}
 			}
 
 			processDependentSyncFiles(targetSyncFile);

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
@@ -18,7 +18,7 @@ import com.liferay.sync.engine.documentlibrary.event.Event;
 import com.liferay.sync.engine.documentlibrary.event.GetSyncContextEvent;
 import com.liferay.sync.engine.documentlibrary.model.SyncDLObjectUpdate;
 import com.liferay.sync.engine.documentlibrary.util.FileEventUtil;
-import com.liferay.sync.engine.documentlibrary.util.comparator.SyncFileComparator;
+import com.liferay.sync.engine.documentlibrary.util.comparator.SyncFileSizeComparator;
 import com.liferay.sync.engine.filesystem.Watcher;
 import com.liferay.sync.engine.filesystem.util.WatcherManager;
 import com.liferay.sync.engine.model.SyncAccount;
@@ -750,7 +750,7 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 	private static final ScheduledExecutorService _scheduledExecutorService =
 		Executors.newScheduledThreadPool(5);
 	private static final Comparator<SyncFile> _syncFileComparator =
-		new SyncFileComparator();
+		new SyncFileSizeComparator();
 
 	private final ScheduledFuture<?> _scheduledFuture;
 	private SyncDLObjectUpdate _syncDLObjectUpdate;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
@@ -182,6 +182,18 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 			SyncSiteService.update(syncSite);
 		}
+		else {
+			SyncFile syncFile = SyncFileService.fetchSyncFile(
+				(Long)getParameterValue("repositoryId"), getSyncAccountId(),
+				(Long)getParameterValue("parentFolderId"));
+
+			if (syncFile != null) {
+				syncFile.setState(SyncFile.STATE_SYNCED);
+				syncFile.setUiEvent(SyncFile.UI_EVENT_NONE);
+
+				SyncFileService.update(syncFile);
+			}
+		}
 	}
 
 	@Override
@@ -679,6 +691,19 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 			}
 
 			processDependentSyncFiles(targetSyncFile);
+
+			if (getParameterValue("parentFolderId") != null) {
+				SyncFile syncFile = SyncFileService.fetchSyncFile(
+					(Long)getParameterValue("repositoryId"), getSyncAccountId(),
+					(Long)getParameterValue("parentFolderId"));
+
+				if (syncFile != null) {
+					syncFile.setState(SyncFile.STATE_IN_PROGRESS);
+					syncFile.setUiEvent(SyncFile.UI_EVENT_RESYNCING);
+
+					SyncFileService.update(syncFile);
+				}
+			}
 		}
 		catch (FileSystemException fse) {
 			String message = fse.getMessage();

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetSyncDLObjectUpdateHandler.java
@@ -645,6 +645,15 @@ public class GetSyncDLObjectUpdateHandler extends BaseSyncDLObjectHandler {
 
 					return;
 				}
+				else if (sourceSyncFile.getParentFolderId() ==
+							targetSyncFile.getParentFolderId()) {
+
+					updateFile(sourceSyncFile, targetSyncFile, filePathName);
+
+					processDependentSyncFiles(targetSyncFile);
+
+					return;
+				}
 
 				moveFile(sourceSyncFile, targetSyncFile, filePathName);
 			}

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetUserSitesGroupsHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetUserSitesGroupsHandler.java
@@ -62,13 +62,8 @@ public class GetUserSitesGroupsHandler extends BaseJSONHandler {
 
 			String remoteSyncSiteName = remoteSyncSite.getName();
 
-			if (!FileUtil.isValidFileName(remoteSyncSiteName)) {
-				remoteSyncSiteName = String.valueOf(
-					remoteSyncSite.getGroupId());
-			}
-
-			String filePathName = FileUtil.getFilePathName(
-				syncAccount.getFilePathName(), remoteSyncSiteName);
+			String filePathName = FileUtil.getSiteFilePathName(
+				syncAccount.getFilePathName(), remoteSyncSite);
 
 			if (localSyncSite == null) {
 				SyncSite deletedSyncSite = SyncSiteService.fetchSyncSite(

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetUserSitesGroupsHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetUserSitesGroupsHandler.java
@@ -60,8 +60,6 @@ public class GetUserSitesGroupsHandler extends BaseJSONHandler {
 			SyncAccount syncAccount = SyncAccountService.fetchSyncAccount(
 				getSyncAccountId());
 
-			String remoteSyncSiteName = remoteSyncSite.getName();
-
 			String filePathName = FileUtil.getFilePathName(
 				syncAccount.getFilePathName(),
 				remoteSyncSite.getSanitizedName());

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetUserSitesGroupsHandler.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/handler/GetUserSitesGroupsHandler.java
@@ -62,8 +62,9 @@ public class GetUserSitesGroupsHandler extends BaseJSONHandler {
 
 			String remoteSyncSiteName = remoteSyncSite.getName();
 
-			String filePathName = FileUtil.getSiteFilePathName(
-				syncAccount.getFilePathName(), remoteSyncSite);
+			String filePathName = FileUtil.getFilePathName(
+				syncAccount.getFilePathName(),
+				remoteSyncSite.getSanitizedName());
 
 			if (localSyncSite == null) {
 				SyncSite deletedSyncSite = SyncSiteService.fetchSyncSite(

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/FileEventUtil.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/FileEventUtil.java
@@ -455,6 +455,13 @@ public class FileEventUtil {
 		}
 
 		BatchEventManager.fireBatchEvents();
+
+		List<SyncFile> resyncingSyncFiles = SyncFileService.findSyncFiles(
+			syncAccountId, SyncFile.UI_EVENT_RESYNCING, "syncFileId", true);
+
+		for (SyncFile resyncingSyncFile : resyncingSyncFiles) {
+			resyncFolder(syncAccountId, resyncingSyncFile);
+		}
 	}
 
 	public static void updateFile(

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/comparator/SyncFileFilePathNameComparator.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/comparator/SyncFileFilePathNameComparator.java
@@ -28,7 +28,7 @@ public class SyncFileFilePathNameComparator implements Comparator<SyncFile> {
 		String filePathName1 = syncFile1.getFilePathName();
 		String filePathName2 = syncFile2.getFilePathName();
 
-		return filePathName1.compareTo(filePathName2);
+		return filePathName1.compareToIgnoreCase(filePathName2);
 	}
 
 }

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/comparator/SyncFileFilePathNameComparator.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/comparator/SyncFileFilePathNameComparator.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.sync.engine.documentlibrary.util.comparator;
+
+import com.liferay.sync.engine.model.SyncFile;
+
+import java.util.Comparator;
+
+/**
+ * @author Shinn Lok
+ */
+public class SyncFileFilePathNameComparator implements Comparator<SyncFile> {
+
+	@Override
+	public int compare(SyncFile syncFile1, SyncFile syncFile2) {
+		String filePathName1 = syncFile1.getFilePathName();
+		String filePathName2 = syncFile2.getFilePathName();
+
+		return filePathName1.compareTo(filePathName2);
+	}
+
+}

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/comparator/SyncFileSizeComparator.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/documentlibrary/util/comparator/SyncFileSizeComparator.java
@@ -21,7 +21,7 @@ import java.util.Comparator;
 /**
  * @author Shinn Lok
  */
-public class SyncFileComparator implements Comparator<SyncFile> {
+public class SyncFileSizeComparator implements Comparator<SyncFile> {
 
 	@Override
 	public int compare(SyncFile syncFile1, SyncFile syncFile2) {

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/filesystem/Watcher.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/filesystem/Watcher.java
@@ -209,7 +209,9 @@ public abstract class Watcher implements Runnable {
 
 		String fileName = String.valueOf(filePath.getFileName());
 
-		if (FileUtil.isIgnoredFilePath(filePath) || (fileName.length() > 255)) {
+		if (FileUtil.isIgnoredFilePath(filePath) ||
+			FileUtil.isUnsynced(filePath) || (fileName.length() > 255)) {
+
 			if (_logger.isDebugEnabled()) {
 				_logger.debug("Ignored file path {}", filePath);
 			}

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListener.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListener.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,7 @@ public class SyncSiteWatchEventListener extends BaseWatchEventListener {
 					}
 
 					SyncSiteService.activateSyncSite(
-						syncSite.getSyncSiteId(), false);
+						syncSite.getSyncSiteId(), new ArrayList<>(), false);
 				}
 
 				return;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListener.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListener.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import java.util.ArrayList;
 
 import org.slf4j.Logger;
@@ -91,7 +92,8 @@ public class SyncSiteWatchEventListener extends BaseWatchEventListener {
 					}
 
 					SyncSiteService.activateSyncSite(
-						syncSite.getSyncSiteId(), new ArrayList<>(), false);
+						syncSite.getSyncSiteId(), new ArrayList<SyncFile>(),
+						false);
 				}
 
 				return;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/model/SyncFile.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/model/SyncFile.java
@@ -305,6 +305,14 @@ public class SyncFile extends StateAwareModel {
 		return type.equals(TYPE_SYSTEM);
 	}
 
+	public boolean isUnsynced() {
+		if (state == STATE_UNSYNCED) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public void setChangeLog(String changeLog) {
 		this.changeLog = changeLog;
 	}

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/model/SyncFile.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/model/SyncFile.java
@@ -107,6 +107,8 @@ public class SyncFile extends StateAwareModel {
 
 	public static final int UI_EVENT_RESTORED_REMOTE = 27;
 
+	public static final int UI_EVENT_RESYNCING = 28;
+
 	public static final int UI_EVENT_TRASHED_LOCAL = 15;
 
 	public static final int UI_EVENT_TRASHED_REMOTE = 16;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/model/SyncSite.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/model/SyncSite.java
@@ -20,6 +20,7 @@ import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
 
 import com.liferay.sync.engine.service.persistence.BasePersistenceImpl;
+import com.liferay.sync.engine.util.FileUtil;
 
 /**
  * @author Shinn Lok
@@ -106,6 +107,16 @@ public class SyncSite extends StateAwareModel {
 
 	public long getRemoteSyncTime() {
 		return remoteSyncTime;
+	}
+
+	public String getSanitizedName() {
+		String name = getName();
+
+		if (!FileUtil.isValidFileName(name)) {
+			name = String.valueOf(getGroupId());
+		}
+
+		return name;
 	}
 
 	public boolean getSite() {

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
@@ -130,8 +130,8 @@ public class SyncAccountService {
 
 			SyncSite syncSite = entry.getKey();
 
-			String siteFilePathName = FileUtil.getSiteFilePathName(
-				syncAccount.getFilePathName(), syncSite);
+			String siteFilePathName = FileUtil.getFilePathName(
+				syncAccount.getFilePathName(), syncSite.getSanitizedName());
 
 			syncSite.setFilePathName(siteFilePathName);
 			syncSite.setRemoteSyncTime(-1);

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
@@ -82,7 +82,7 @@ public class SyncAccountService {
 			String oAuthConsumerKey, String oAuthConsumerSecret,
 			boolean oAuthEnabled, String oAuthToken, String oAuthTokenSecret,
 			String password, int pollInterval,
-			Map<SyncSite, List<SyncFile>> syncSites, SyncUser syncUser,
+			Map<SyncSite, List<SyncFile>> ignoredSyncFiles, SyncUser syncUser,
 			boolean trustSelfSigned, String url)
 		throws Exception {
 
@@ -123,7 +123,8 @@ public class SyncAccountService {
 
 		// Sync sites
 
-		for (Map.Entry<SyncSite, List<SyncFile>> entry : syncSites.entrySet()) {
+		for (Map.Entry<SyncSite, List<SyncFile>> entry :
+				ignoredSyncFiles.entrySet()) {
 
 			// Sync site
 
@@ -161,18 +162,8 @@ public class SyncAccountService {
 			// Sync files
 
 			for (SyncFile childSyncFile : entry.getValue()) {
-				SyncFile parentSyncFile = SyncFileService.fetchSyncFile(
-					childSyncFile.getRepositoryId(),
-					syncSite.getSyncAccountId(),
-					childSyncFile.getParentFolderId());
-
-				String childFilePathName = FileUtil.getFilePathName(
-					parentSyncFile.getFilePathName(),
-					FileUtil.getSanitizedFileName(
-						childSyncFile.getName(), null));
-
-				childSyncFile.setFilePathName(childFilePathName);
 				childSyncFile.setModifiedTime(0);
+				childSyncFile.setState(SyncFile.STATE_UNSYNCED);
 				childSyncFile.setSyncAccountId(syncSite.getSyncAccountId());
 
 				SyncFileService.update(childSyncFile);

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
@@ -78,17 +78,6 @@ public class SyncAccountService {
 
 	public static SyncAccount addSyncAccount(
 			String filePathName, String login, int maxConnections,
-			String password, int pollInterval, SyncSite[] syncSites,
-			SyncUser syncUser, boolean trustSelfSigned, String url)
-		throws Exception {
-
-		return addSyncAccount(
-			filePathName, login, maxConnections, "", "", false, "", "",
-			password, pollInterval, syncSites, syncUser, trustSelfSigned, url);
-	}
-
-	public static SyncAccount addSyncAccount(
-			String filePathName, String login, int maxConnections,
 			String oAuthConsumerKey, String oAuthConsumerSecret,
 			boolean oAuthEnabled, String oAuthToken, String oAuthTokenSecret,
 			String password, int pollInterval, SyncSite[] syncSites,

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncAccountService.java
@@ -130,16 +130,10 @@ public class SyncAccountService {
 
 			SyncSite syncSite = entry.getKey();
 
-			String syncSiteName = syncSite.getName();
+			String siteFilePathName = FileUtil.getSiteFilePathName(
+				syncAccount.getFilePathName(), syncSite);
 
-			if (!FileUtil.isValidFileName(syncSiteName)) {
-				syncSiteName = String.valueOf(syncSite.getGroupId());
-			}
-
-			syncSite.setFilePathName(
-				FileUtil.getFilePathName(
-					syncAccount.getFilePathName(), syncSiteName));
-
+			syncSite.setFilePathName(siteFilePathName);
 			syncSite.setRemoteSyncTime(-1);
 			syncSite.setSyncAccountId(syncAccount.getSyncAccountId());
 

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
@@ -16,6 +16,9 @@ package com.liferay.sync.engine.service;
 
 import com.liferay.sync.engine.SyncEngine;
 import com.liferay.sync.engine.documentlibrary.util.FileEventUtil;
+import com.liferay.sync.engine.documentlibrary.util.comparator.SyncFileFilePathNameComparator;
+import com.liferay.sync.engine.filesystem.Watcher;
+import com.liferay.sync.engine.filesystem.util.WatcherManager;
 import com.liferay.sync.engine.model.ModelListener;
 import com.liferay.sync.engine.model.SyncFile;
 import com.liferay.sync.engine.model.SyncFileModelListener;
@@ -25,14 +28,24 @@ import com.liferay.sync.engine.util.FileUtil;
 import com.liferay.sync.engine.util.IODeltaUtil;
 import com.liferay.sync.engine.util.MSOfficeFileUtil;
 
+import java.io.IOException;
+
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import java.sql.SQLException;
 
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
@@ -681,18 +694,37 @@ public class SyncFileService {
 		}
 	}
 
-	public static SyncFile resyncFolder(SyncFile syncFile) throws Exception {
-		if (syncFile.getState() != SyncFile.STATE_UNSYNCED) {
-			return syncFile;
-		}
+	public static void resyncFolders(List<SyncFile> syncFiles)
+		throws Exception {
 
-		setStatuses(syncFile, SyncFile.STATE_SYNCED, SyncFile.UI_EVENT_NONE);
+		Map<Long, SyncFile> resyncedSyncFileMap = new HashMap<>();
+
+		Set<Long> resyncedSyncFileIds = resyncedSyncFileMap.keySet();
+
+		syncFiles.sort(_syncFileFilePathNameComparator);
+
+		for (SyncFile syncFile : syncFiles) {
+			if (syncFile.getState() != SyncFile.STATE_UNSYNCED) {
+				continue;
+			}
+
+			syncFile.setState(SyncFile.STATE_IN_PROGRESS);
+			syncFile.setUiEvent(SyncFile.UI_EVENT_RESYNCING);
+
+			SyncFileService.update(syncFile);
+
+			if (isAncestorInList(syncFile, resyncedSyncFileIds)) {
+				continue;
+			}
+
+			resyncedSyncFileMap.put(syncFile.getTypePK(), syncFile);
+		}
 
 		// Remote
 
-		FileEventUtil.resyncFolder(syncFile.getSyncAccountId(), syncFile);
-
-		return syncFile;
+		for (SyncFile syncFile : resyncedSyncFileMap.values()) {
+			FileEventUtil.resyncFolder(syncFile.getSyncAccountId(), syncFile);
+		}
 	}
 
 	public static void setStatuses(
@@ -722,51 +754,76 @@ public class SyncFileService {
 		_syncFilePersistence.unregisterModelListener(modelListener);
 	}
 
-	public static SyncFile unsyncFolder(
-			long syncAccountId, SyncFile targetSyncFile)
+	public static void unsyncFolders(List<SyncFile> syncFiles)
 		throws Exception {
 
-		if (targetSyncFile.getState() == SyncFile.STATE_UNSYNCED) {
-			return targetSyncFile;
-		}
+		Set<Long> unsyncedSyncFileIds = new HashSet<>();
 
-		SyncFile parentSyncFile = SyncFileService.fetchSyncFile(
-			targetSyncFile.getRepositoryId(), syncAccountId,
-			targetSyncFile.getParentFolderId());
+		syncFiles.sort(_syncFileFilePathNameComparator);
 
-		if (parentSyncFile == null) {
-			return targetSyncFile;
-		}
+		for (SyncFile syncFile : syncFiles) {
+			if (syncFile.getState() == SyncFile.STATE_UNSYNCED) {
+				continue;
+			}
 
-		String filePathName = FileUtil.getFilePathName(
-			parentSyncFile.getFilePathName(),
-			FileUtil.getSanitizedFileName(targetSyncFile.getName(), null));
+			syncFile.setModifiedTime(0);
+			syncFile.setState(SyncFile.STATE_UNSYNCED);
+			syncFile.setUiEvent(SyncFile.UI_EVENT_NONE);
 
-		SyncFile sourceSyncFile = SyncFileService.fetchSyncFile(filePathName);
+			SyncFileService.update(syncFile);
 
-		if (sourceSyncFile == null) {
-			targetSyncFile.setFilePathName(filePathName);
-			targetSyncFile.setModifiedTime(0);
-			targetSyncFile.setState(SyncFile.STATE_UNSYNCED);
-			targetSyncFile.setSyncAccountId(syncAccountId);
+			if (isAncestorInList(syncFile, unsyncedSyncFileIds) ||
+				!Files.exists(Paths.get(syncFile.getFilePathName()))) {
 
-			return update(targetSyncFile);
-		}
+				continue;
+			}
 
-		sourceSyncFile.setModifiedTime(0);
+			final Watcher watcher = WatcherManager.getWatcher(
+				syncFile.getSyncAccountId());
 
-		setStatuses(
-			sourceSyncFile, SyncFile.STATE_UNSYNCED, SyncFile.UI_EVENT_NONE);
+			Files.walkFileTree(
+				Paths.get(syncFile.getFilePathName()),
+				new SimpleFileVisitor<Path>() {
 
-		return sourceSyncFile;
-	}
+					@Override
+					public FileVisitResult postVisitDirectory(
+							Path filePath, IOException ioe)
+						throws IOException {
 
-	public static void unsyncFolders(
-			long syncAccountId, List<SyncFile> targetSyncFiles)
-		throws Exception {
+						if (ioe != null) {
+							return super.postVisitDirectory(filePath, ioe);
+						}
 
-		for (SyncFile targetSyncFile : targetSyncFiles) {
-			unsyncFolder(syncAccountId, targetSyncFile);
+						watcher.addDeletedFilePathName(filePath.toString());
+
+						FileUtil.deleteFile(filePath);
+
+						return FileVisitResult.CONTINUE;
+					}
+
+					@Override
+					public FileVisitResult visitFile(
+							Path filePath,
+							BasicFileAttributes basicFileAttributes)
+						throws IOException {
+
+						watcher.addDeletedFilePathName(filePath.toString());
+
+						FileUtil.deleteFile(filePath);
+
+						SyncFile childSyncFile = fetchSyncFile(
+							filePath.toString());
+
+						if (childSyncFile != null) {
+							deleteSyncFile(childSyncFile, true);
+						}
+
+						return FileVisitResult.CONTINUE;
+					}
+
+				});
+
+			unsyncedSyncFileIds.add(syncFile.getSyncFileId());
 		}
 	}
 
@@ -914,6 +971,24 @@ public class SyncFileService {
 		_syncFilePersistence.delete(syncFile, notify);
 	}
 
+	protected static boolean isAncestorInList(
+		SyncFile syncFile, Set<Long> folderIds) {
+
+		if (folderIds.contains(syncFile.getParentFolderId())) {
+			return true;
+		}
+
+		if (syncFile.getParentFolderId() == 0) {
+			return false;
+		}
+
+		SyncFile parentSyncFile = SyncFileService.fetchSyncFile(
+			syncFile.getRepositoryId(), syncFile.getSyncAccountId(),
+			syncFile.getParentFolderId());
+
+		return isAncestorInList(parentSyncFile, folderIds);
+	}
+
 	private static String _getName(Path filePath, SyncFile syncFile) {
 		String name = String.valueOf(filePath.getFileName());
 
@@ -932,6 +1007,8 @@ public class SyncFileService {
 	private static final Logger _logger = LoggerFactory.getLogger(
 		SyncFileService.class);
 
+	private static final Comparator<SyncFile> _syncFileFilePathNameComparator =
+		new SyncFileFilePathNameComparator();
 	private static SyncFilePersistence _syncFilePersistence =
 		getSyncFilePersistence();
 

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
@@ -850,7 +850,7 @@ public class SyncFileService {
 							filePath.toString());
 
 						if (childSyncFile != null) {
-							deleteSyncFile(childSyncFile, true);
+							deleteSyncFile(childSyncFile, false);
 						}
 
 						return FileVisitResult.CONTINUE;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
@@ -704,8 +704,15 @@ public class SyncFileService {
 		syncFiles.sort(_syncFileFilePathNameComparator);
 
 		for (SyncFile syncFile : syncFiles) {
-			if (syncFile.getState() != SyncFile.STATE_UNSYNCED) {
-				continue;
+			SyncFile localSyncFile = SyncFileService.fetchSyncFile(
+				syncFile.getFilePathName());
+
+			if (localSyncFile != null) {
+				if (localSyncFile.getState() != SyncFile.STATE_UNSYNCED) {
+					continue;
+				}
+
+				syncFile = localSyncFile;
 			}
 
 			syncFile.setState(SyncFile.STATE_IN_PROGRESS);
@@ -762,8 +769,15 @@ public class SyncFileService {
 		syncFiles.sort(_syncFileFilePathNameComparator);
 
 		for (SyncFile syncFile : syncFiles) {
-			if (syncFile.getState() == SyncFile.STATE_UNSYNCED) {
-				continue;
+			SyncFile localSyncFile = SyncFileService.fetchSyncFile(
+				syncFile.getFilePathName());
+
+			if (localSyncFile != null) {
+				if (localSyncFile.getState() == SyncFile.STATE_UNSYNCED) {
+					continue;
+				}
+
+				syncFile = localSyncFile;
 			}
 
 			syncFile.setModifiedTime(0);

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncFileService.java
@@ -417,6 +417,22 @@ public class SyncFileService {
 	}
 
 	public static List<SyncFile> findSyncFiles(
+		long repositoryId, long syncAccountId, String type) {
+
+		try {
+			return _syncFilePersistence.findByR_S_T(
+				repositoryId, syncAccountId, type);
+		}
+		catch (SQLException sqle) {
+			if (_logger.isDebugEnabled()) {
+				_logger.debug(sqle.getMessage(), sqle);
+			}
+
+			return Collections.emptyList();
+		}
+	}
+
+	public static List<SyncFile> findSyncFiles(
 		String filePathName, long localSyncTime) {
 
 		try {
@@ -485,6 +501,28 @@ public class SyncFileService {
 		try {
 			SyncFile syncFile = _syncFilePersistence.fetchByS_U_First(
 				syncAccountId, uiEvent);
+
+			if (syncFile == null) {
+				return false;
+			}
+
+			return true;
+		}
+		catch (SQLException sqle) {
+			if (_logger.isDebugEnabled()) {
+				_logger.debug(sqle.getMessage(), sqle);
+			}
+
+			return false;
+		}
+	}
+
+	public static boolean hasSyncFiles(
+		long repositoryId, int state, long syncAccountId) {
+
+		try {
+			SyncFile syncFile = _syncFilePersistence.fetchByR_S_S_First(
+				repositoryId, state, syncAccountId);
 
 			if (syncFile == null) {
 				return false;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncSiteService.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/SyncSiteService.java
@@ -52,7 +52,8 @@ import org.slf4j.LoggerFactory;
  */
 public class SyncSiteService {
 
-	public static SyncSite activateSyncSite(long syncSiteId, boolean reset)
+	public static SyncSite activateSyncSite(
+			long syncSiteId, List<SyncFile> ignoredSyncFiles, boolean reset)
 		throws Exception {
 
 		// Sync site
@@ -87,6 +88,16 @@ public class SyncSiteService {
 			FileKeyUtil.writeFileKey(
 				Paths.get(filePathName),
 				String.valueOf(syncFile.getSyncFileId()), true);
+		}
+
+		// Sync files
+
+		for (SyncFile syncFile : ignoredSyncFiles) {
+			syncFile.setModifiedTime(0);
+			syncFile.setState(SyncFile.STATE_UNSYNCED);
+			syncFile.setSyncAccountId(syncSite.getSyncAccountId());
+
+			SyncFileService.update(syncFile);
 		}
 
 		return syncSite;

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/persistence/SyncFilePersistence.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/service/persistence/SyncFilePersistence.java
@@ -97,6 +97,29 @@ public class SyncFilePersistence extends BasePersistenceImpl<SyncFile, Long> {
 		return where.queryForFirst();
 	}
 
+	public SyncFile fetchByR_S_S_First(
+			long repositoryId, int state, long syncAccountId)
+		throws SQLException {
+
+		QueryBuilder<SyncFile, Long> queryBuilder = queryBuilder();
+
+		queryBuilder.limit(1L);
+
+		Where<SyncFile, Long> where = queryBuilder.where();
+
+		where.eq("repositoryId", repositoryId);
+		where.eq("state", state);
+		where.eq("syncAccountId", syncAccountId);
+		where.ne("uiEvent", SyncFile.UI_EVENT_DELETED_LOCAL);
+		where.ne("uiEvent", SyncFile.UI_EVENT_DELETED_REMOTE);
+		where.ne("uiEvent", SyncFile.UI_EVENT_TRASHED_LOCAL);
+		where.ne("uiEvent", SyncFile.UI_EVENT_TRASHED_REMOTE);
+
+		where.and(7);
+
+		return where.queryForFirst();
+	}
+
 	public SyncFile fetchByPF_S_First(String parentFilePathName, int state)
 		throws SQLException {
 
@@ -294,6 +317,19 @@ public class SyncFilePersistence extends BasePersistenceImpl<SyncFile, Long> {
 		};
 
 		callBatchTasks(callable);
+	}
+
+	public List<SyncFile> findByR_S_T(
+			long repositoryId, long syncAccountId, String type)
+		throws SQLException {
+
+		Map<String, Object> fieldValues = new HashMap<>();
+
+		fieldValues.put("repositoryId", repositoryId);
+		fieldValues.put("syncAccountId", syncAccountId);
+		fieldValues.put("type", type);
+
+		return queryForFieldValues(fieldValues);
 	}
 
 	public void updateByParentFilePathName(

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
@@ -17,6 +17,7 @@ package com.liferay.sync.engine.util;
 import com.liferay.sync.engine.documentlibrary.util.FileEventUtil;
 import com.liferay.sync.engine.model.SyncAccount;
 import com.liferay.sync.engine.model.SyncFile;
+import com.liferay.sync.engine.model.SyncSite;
 import com.liferay.sync.engine.service.SyncAccountService;
 import com.liferay.sync.engine.service.SyncFileService;
 
@@ -375,6 +376,18 @@ public class FileUtil {
 		}
 
 		return fileName;
+	}
+
+	public static String getSiteFilePathName(
+		String syncAccountFilePathName, SyncSite syncSite) {
+
+		String syncSiteName = syncSite.getName();
+
+		if (!FileUtil.isValidFileName(syncSiteName)) {
+			syncSiteName = String.valueOf(syncSite.getGroupId());
+		}
+
+		return FileUtil.getFilePathName(syncAccountFilePathName, syncSiteName);
 	}
 
 	public static Path getTempFilePath(SyncFile syncFile) {

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
@@ -423,12 +423,6 @@ public class FileUtil {
 			return isIgnoredFilePath(filePath.getParent());
 		}
 
-		if (!syncFile.isSystem() &&
-			(syncFile.getState() == SyncFile.STATE_UNSYNCED)) {
-
-			return true;
-		}
-
 		return false;
 	}
 
@@ -529,6 +523,20 @@ public class FileUtil {
 
 	public static boolean isTempFile(Path filePath) {
 		if (MSOfficeFileUtil.isTempCreatedFile(filePath)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static boolean isUnsynced(Path filePath) {
+		SyncFile syncFile = SyncFileService.fetchSyncFile(filePath.toString());
+
+		if (syncFile == null) {
+			return isUnsynced(filePath.getParent());
+		}
+
+		if (syncFile.getState() == SyncFile.STATE_UNSYNCED) {
 			return true;
 		}
 

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
@@ -17,7 +17,6 @@ package com.liferay.sync.engine.util;
 import com.liferay.sync.engine.documentlibrary.util.FileEventUtil;
 import com.liferay.sync.engine.model.SyncAccount;
 import com.liferay.sync.engine.model.SyncFile;
-import com.liferay.sync.engine.model.SyncSite;
 import com.liferay.sync.engine.service.SyncAccountService;
 import com.liferay.sync.engine.service.SyncFileService;
 
@@ -376,18 +375,6 @@ public class FileUtil {
 		}
 
 		return fileName;
-	}
-
-	public static String getSiteFilePathName(
-		String syncAccountFilePathName, SyncSite syncSite) {
-
-		String syncSiteName = syncSite.getName();
-
-		if (!FileUtil.isValidFileName(syncSiteName)) {
-			syncSiteName = String.valueOf(syncSite.getGroupId());
-		}
-
-		return FileUtil.getFilePathName(syncAccountFilePathName, syncSiteName);
 	}
 
 	public static Path getTempFilePath(SyncFile syncFile) {

--- a/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
+++ b/modules/util/sync-engine/src/main/java/com/liferay/sync/engine/util/FileUtil.java
@@ -536,11 +536,7 @@ public class FileUtil {
 			return isUnsynced(filePath.getParent());
 		}
 
-		if (syncFile.getState() == SyncFile.STATE_UNSYNCED) {
-			return true;
-		}
-
-		return false;
+		return syncFile.isUnsynced();
 	}
 
 	public static boolean isValidChecksum(Path filePath) throws IOException {

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/BaseTestCase.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/BaseTestCase.java
@@ -15,6 +15,8 @@
 package com.liferay.sync.engine;
 
 import com.liferay.sync.engine.model.SyncAccount;
+import com.liferay.sync.engine.model.SyncFile;
+import com.liferay.sync.engine.model.SyncSite;
 import com.liferay.sync.engine.service.SyncAccountService;
 import com.liferay.sync.engine.upgrade.util.UpgradeUtil;
 import com.liferay.sync.engine.util.FileUtil;
@@ -31,6 +33,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.io.FileUtils;
@@ -85,7 +89,8 @@ public abstract class BaseTestCase {
 
 		syncAccount = SyncAccountService.addSyncAccount(
 			filePathName, "test@liferay.com", 1, "", "", false, "", "", "test",
-			5, null, null, false, "http://localhost:8080");
+			5, Collections.<SyncSite, List<SyncFile>>emptyMap(), null, false,
+			"http://localhost:8080");
 
 		syncAccount.setActive(true);
 		syncAccount.setState(SyncAccount.STATE_CONNECTED);

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/BaseTestCase.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/BaseTestCase.java
@@ -84,8 +84,8 @@ public abstract class BaseTestCase {
 			System.getProperty("user.home"), "liferay-sync-test");
 
 		syncAccount = SyncAccountService.addSyncAccount(
-			filePathName, "test@liferay.com", 1, "test", 5, null, null, false,
-			"http://localhost:8080");
+			filePathName, "test@liferay.com", 1, "", "", false, "", "", "test",
+			5, null, null, false, "http://localhost:8080");
 
 		syncAccount.setActive(true);
 		syncAccount.setState(SyncAccount.STATE_CONNECTED);

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/documentlibrary/util/SyncFileSizeComparatorTest.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/documentlibrary/util/SyncFileSizeComparatorTest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.sync.engine.documentlibrary.util;
 
-import com.liferay.sync.engine.documentlibrary.util.comparator.SyncFileComparator;
+import com.liferay.sync.engine.documentlibrary.util.comparator.SyncFileSizeComparator;
 import com.liferay.sync.engine.model.SyncFile;
 
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ import org.junit.Test;
 /**
  * @author Shinn Lok
  */
-public class SyncFileComparatorTest {
+public class SyncFileSizeComparatorTest {
 
 	@Test
 	public void testSort() {
@@ -38,7 +38,7 @@ public class SyncFileComparatorTest {
 		SyncFile syncFile5 = addSyncFile(5, SyncFile.EVENT_UPDATE, 0);
 		SyncFile syncFile6 = addSyncFile(6, SyncFile.EVENT_MOVE, 0);
 
-		Collections.sort(_syncFiles, new SyncFileComparator());
+		Collections.sort(_syncFiles, new SyncFileSizeComparator());
 
 		Assert.assertArrayEquals(
 			new SyncFile[] {

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListenerTest.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListenerTest.java
@@ -24,6 +24,8 @@ import com.liferay.sync.engine.util.test.SyncSiteTestUtil;
 
 import java.nio.file.Paths;
 
+import java.util.ArrayList;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,13 +45,15 @@ public class SyncSiteWatchEventListenerTest extends BaseTestCase {
 			10158, FileUtil.getFilePathName(filePathName, "test-site1"), 10185,
 			syncAccount.getSyncAccountId());
 
-		SyncSiteService.activateSyncSite(_syncSite1.getSyncSiteId(), true);
+		SyncSiteService.activateSyncSite(
+			_syncSite1.getSyncSiteId(), new ArrayList<>(), true);
 
 		_syncSite2 = SyncSiteTestUtil.addSyncSite(
 			10158, FileUtil.getFilePathName(filePathName, "test-site2"), 10186,
 			syncAccount.getSyncAccountId());
 
-		SyncSiteService.activateSyncSite(_syncSite2.getSyncSiteId(), true);
+		SyncSiteService.activateSyncSite(
+			_syncSite2.getSyncSiteId(), new ArrayList<>(), true);
 	}
 
 	@After

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListenerTest.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListenerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.sync.engine.filesystem.listener;
 
 import com.liferay.sync.engine.BaseTestCase;
+import com.liferay.sync.engine.model.SyncFile;
 import com.liferay.sync.engine.model.SyncSite;
 import com.liferay.sync.engine.model.SyncWatchEvent;
 import com.liferay.sync.engine.service.SyncSiteService;
@@ -46,14 +47,14 @@ public class SyncSiteWatchEventListenerTest extends BaseTestCase {
 			syncAccount.getSyncAccountId());
 
 		SyncSiteService.activateSyncSite(
-			_syncSite1.getSyncSiteId(), new ArrayList<>(), true);
+			_syncSite1.getSyncSiteId(), new ArrayList<SyncFile>(), true);
 
 		_syncSite2 = SyncSiteTestUtil.addSyncSite(
 			10158, FileUtil.getFilePathName(filePathName, "test-site2"), 10186,
 			syncAccount.getSyncAccountId());
 
 		SyncSiteService.activateSyncSite(
-			_syncSite2.getSyncSiteId(), new ArrayList<>(), true);
+			_syncSite2.getSyncSiteId(), new ArrayList<SyncFile>(), true);
 	}
 
 	@After

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncAccountServiceTest.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncAccountServiceTest.java
@@ -49,8 +49,8 @@ public class SyncAccountServiceTest extends BaseTestCase {
 			System.getProperty("user.home"), "liferay-sync-test3");
 
 		SyncAccount syncAccount2 = SyncAccountService.addSyncAccount(
-			targetFilePathName, "test3@liferay.com", 1, "test", 5, null, null,
-			false, "http://localhost:8080");
+			targetFilePathName, "test3@liferay.com", 1, "", "", false, "", "",
+			"test", 5, null, null, false, "http://localhost:8080");
 
 		syncAccount2 = SyncAccountService.fetchSyncAccount(
 			syncAccount2.getSyncAccountId());

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncAccountServiceTest.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncAccountServiceTest.java
@@ -28,6 +28,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +53,8 @@ public class SyncAccountServiceTest extends BaseTestCase {
 
 		SyncAccount syncAccount2 = SyncAccountService.addSyncAccount(
 			targetFilePathName, "test3@liferay.com", 1, "", "", false, "", "",
-			"test", 5, null, null, false, "http://localhost:8080");
+			"test", 5, Collections.<SyncSite, List<SyncFile>>emptyMap(), null,
+			false, "http://localhost:8080");
 
 		syncAccount2 = SyncAccountService.fetchSyncAccount(
 			syncAccount2.getSyncAccountId());

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncFileServiceTest.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncFileServiceTest.java
@@ -202,7 +202,8 @@ public class SyncFileServiceTest extends BaseTestCase {
 
 		int previousSyncedSyncFilesSize = syncedSyncFiles.size();
 
-		SyncFileService.unsyncFolders(syncFiles);
+		SyncFileService.unsyncFolders(
+			syncAccount.getSyncAccountId(), syncFiles);
 
 		syncedSyncFiles = syncFilePersistence.queryForEq(
 			"state", SyncFile.STATE_SYNCED);
@@ -254,7 +255,8 @@ public class SyncFileServiceTest extends BaseTestCase {
 
 		PowerMockito.mockStatic(FileEventUtil.class);
 
-		SyncFileService.resyncFolders(syncFiles);
+		SyncFileService.resyncFolders(
+			syncAccount.getSyncAccountId(), syncFiles);
 
 		PowerMockito.verifyStatic(Mockito.times(expectedExecutionCount));
 

--- a/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/util/test/SyncFileTestUtil.java
+++ b/modules/util/sync-engine/src/test/java/com/liferay/sync/engine/util/test/SyncFileTestUtil.java
@@ -42,7 +42,7 @@ public class SyncFileTestUtil {
 
 		SyncFile syncFile = SyncFileService.addSyncFile(
 			null, null, true, null, filePathName, null, null, parentFolderId,
-			repositoryId, SyncFile.STATE_SYNCED, 0, syncAccountId,
+			repositoryId, 0, SyncFile.STATE_SYNCED, syncAccountId,
 			SyncFile.TYPE_FILE);
 
 		if (typePK == 0) {
@@ -55,10 +55,27 @@ public class SyncFileTestUtil {
 	}
 
 	public static SyncFile addFolderSyncFile(
+			String filePathName, int state, long syncAccountId)
+		throws Exception {
+
+		return addFolderSyncFile(filePathName, 0, state, syncAccountId);
+	}
+
+	public static SyncFile addFolderSyncFile(
 			String filePathName, long syncAccountId)
 		throws Exception {
 
-		return addFolderSyncFile(filePathName, 0, syncAccountId);
+		return addFolderSyncFile(
+			filePathName, SyncFile.STATE_SYNCED, syncAccountId);
+	}
+
+	public static SyncFile addFolderSyncFile(
+			String filePathName, long parentFolderId, int state,
+			long syncAccountId)
+		throws Exception {
+
+		return addFolderSyncFile(
+			filePathName, parentFolderId, 0, state, syncAccountId, 0);
 	}
 
 	public static SyncFile addFolderSyncFile(
@@ -66,20 +83,19 @@ public class SyncFileTestUtil {
 		throws Exception {
 
 		return addFolderSyncFile(
-			filePathName, parentFolderId, 0, syncAccountId, 0);
+			filePathName, parentFolderId, SyncFile.STATE_SYNCED, syncAccountId);
 	}
 
 	public static SyncFile addFolderSyncFile(
 			String filePathName, long parentFolderId, long repositoryId,
-			long syncAccountId, long typePK)
+			int state, long syncAccountId, long typePK)
 		throws Exception {
 
 		Files.createDirectory(Paths.get(filePathName));
 
 		SyncFile syncFile = SyncFileService.addSyncFile(
 			null, null, false, null, filePathName, null, null, parentFolderId,
-			repositoryId, SyncFile.STATE_SYNCED, 0, syncAccountId,
-			SyncFile.TYPE_FOLDER);
+			repositoryId, 0, state, syncAccountId, SyncFile.TYPE_FOLDER);
 
 		if (typePK == 0) {
 			syncFile.setTypePK(syncFile.getSyncFileId());

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Smoke.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Smoke.macro
@@ -28,7 +28,7 @@
 		</execute>
 
 		<var name="pageName" value="Test Page1" />
-		<var name="portletBody" value="Welcome to Liferay Portal" />
+		<var name="portletBody" value="Welcome to Liferay" />
 		<var name="portletName" value="Hello World" />
 
 		<task summary="Add a '${portletName}' portlet to the page named '${pageName}'">
@@ -100,8 +100,7 @@
 	</command>
 
 	<command name="viewWelcomePage" summary="View default welcome page while signed in as '${userFirstName} ${userLastName}'">
-
 		<execute function="AssertTextEquals#assertText" locator1="HelloWorld#PORTLET_TITLE" value1="Hello World" />
-		<execute function="AssertTextEquals#assertPartialText" locator1="HelloWorld#PORTLET_CONTENT" value1="Welcome to Liferay Portal" />
+		<execute function="AssertTextEquals#assertPartialText" locator1="HelloWorld#PORTLET_CONTENT" value1="Welcome to Liferay" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -303,6 +303,7 @@
 			<equals arg1="${contentDateRange}" arg2="All" />
 			<then>
 				<execute function="Click" locator1="StagingPublishToLive#CONTENT_CHOOSE_CONTENT" />
+
 				<execute function="Click" locator1="StagingPublishToLive#CHOOSE_CONTENT_DATE_RANGE_CHANGE" />
 
 				<execute function="Check" locator1="Radio#RANGE_ALL" />
@@ -315,6 +316,7 @@
 			<equals arg1="${contentDateRange}" arg2="Date Range" />
 			<then>
 				<execute function="Click" locator1="StagingPublishToLive#CONTENT_CHOOSE_CONTENT" />
+
 				<execute function="Click" locator1="StagingPublishToLive#CHOOSE_CONTENT_DATE_RANGE_CHANGE" />
 
 				<var name="key_contentDateRange" value="${contentDateRange}" />
@@ -377,6 +379,7 @@
 				<execute function="AssertClick" locator1="StagingPublishtolivenow#CONTENT_CHOOSE_CONTENT_CONTENT_CHANGE_LINK" value1="Change" />
 
 				<execute function="Uncheck" locator1="StagingPublishtolivenow#CONTENT_CHOOSE_CONTENT_SUBCONTENT_CHECKBOX" />
+
 				<execute function="AssertClick" locator1="Button#OK" value1="OK" />
 			</then>
 		</if>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -300,7 +300,19 @@
 		</if>
 
 		<if>
-			<isset var="contentDateRange" />
+			<equals arg1="${contentDateRange}" arg2="All" />
+			<then>
+				<execute function="Click" locator1="StagingPublishToLive#CONTENT_CHOOSE_CONTENT" />
+				<execute function="Click" locator1="StagingPublishToLive#CHOOSE_CONTENT_DATE_RANGE_CHANGE" />
+
+				<execute function="Check" locator1="Radio#RANGE_ALL" />
+
+				<execute function="Click" locator1="StagingPublishToLive#REFRESH_COUNTS" />
+			</then>
+		</if>
+
+		<if>
+			<equals arg1="${contentDateRange}" arg2="Date Range" />
 			<then>
 				<execute function="Click" locator1="StagingPublishToLive#CONTENT_CHOOSE_CONTENT" />
 				<execute function="Click" locator1="StagingPublishToLive#CHOOSE_CONTENT_DATE_RANGE_CHANGE" />
@@ -309,6 +321,8 @@
 
 				<execute function="Type" locator1="StagingPublishToLive#DATE_RANGE_START_DATE" value1="${dateRangeStartDate}" />
 				<execute function="Type" locator1="StagingPublishToLive#DATE_RANGE_END_DATE" value1="${dateRangeEndDate}" />
+
+				<execute function="Click" locator1="StagingPublishToLive#REFRESH_COUNTS" />
 			</then>
 		</if>
 
@@ -358,12 +372,9 @@
 			<then>
 				<execute function="Click" locator1="StagingPublishToLive#CONTENT_CHOOSE_CONTENT" />
 
-				<var name="key_contentName" value="${contentName}" />
+				<var name="key_uncheckSubContent" value="${uncheckSubContent}" />
 
-				<execute function="Check" locator1="PagesConfiguration#CONTENT_CHOOSE_CONTENT_CONTENT_CHECKBOX" />
 				<execute function="AssertClick" locator1="StagingPublishtolivenow#CONTENT_CHOOSE_CONTENT_CONTENT_CHANGE_LINK" value1="Change" />
-
-				<var name="key_subContent" value="${uncheckSubContent}" />
 
 				<execute function="Uncheck" locator1="StagingPublishtolivenow#CONTENT_CHOOSE_CONTENT_SUBCONTENT_CHECKBOX" />
 				<execute function="AssertClick" locator1="Button#OK" value1="OK" />
@@ -595,7 +606,15 @@
 
 		<execute function="Pause" locator1="5000" />
 
-		<execute function="AssertTextEquals" locator1="Staging#PROCESS_SUCCESSFUL" value1="Successful" />
+		<if>
+			<isset var="failureExpected" />
+			<then>
+				<execute function="AssertTextEquals" locator1="Staging#PROCESS_FAILED" value1="Failed" />
+			</then>
+			<else>
+				<execute function="AssertTextEquals" locator1="Staging#PROCESS_SUCCESSFUL" value1="Successful" />
+			</else>
+		</if>
 
 		<execute function="SelectFrameTop" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -430,6 +430,31 @@
 		<execute macro="PortletEntry#publish" />
 	</command>
 
+	<command name="addWithDocumentCP">
+		<execute macro="WebContent#addCP">
+			<var name="webContentContent" value="${webContentContent}" />
+			<var name="webContentTitle" value="${webContentTitle}" />
+		</execute>
+
+		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
+		<execute function="Click" locator1="AlloyEditor#CONTENT_ADD_BUTTON" />
+		<execute function="Click" locator1="AlloyEditor#CONTENT_ADD_MENUBAR_IMAGE" />
+
+		<execute function="SelectFrame" locator1="IFrame#METADATA_SETS_IFRAME" />
+
+		<var name="key_imageFileName" value="${dmDocumentTitle}" />
+
+		<var method="StringUtil#replace('${dmDocumentTitle}', ' ', '+')" name="key_imageFileName" />
+
+		<execute function="Click" locator1="ItemSelector#SELECT_FILE_IMAGE_PREVIEW" />
+
+		<execute function="SelectFrameTop" value1="relative=top" />
+
+		<execute function="AssertClick" locator1="ItemSelector#ADD_BUTTON" value1="Add" />
+
+		<execute macro="PortletEntry#publish" />
+	</command>
+
 	<command name="addWithGlobalStructurePGViaWCD">
 		<execute macro="WebContentNavigator#gotoAddPGViaWCD">
 			<var name="structureName" value="${selectStructureName}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -437,7 +437,9 @@
 		</execute>
 
 		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
+
 		<execute function="Click" locator1="AlloyEditor#CONTENT_ADD_BUTTON" />
+
 		<execute function="Click" locator1="AlloyEditor#CONTENT_ADD_MENUBAR_IMAGE" />
 
 		<execute function="SelectFrame" locator1="IFrame#METADATA_SETS_IFRAME" />

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Radio.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Radio.path
@@ -74,6 +74,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>RANGE_ALL</td>
+	<td>//label[contains(.,'All')]/input[contains(@id,'rangeAll')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>REMOTE_LIVE</td>
 	<td>//label[contains(.,'Remote Live')]/input[@type='radio']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/Staging.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/Staging.path
@@ -39,6 +39,11 @@
 	<td>//h6[contains(.,'Successful')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>PROCESS_FAILED</td>
+	<td>//h6[contains(.,'Failed')]</td>
+	<td></td>
+</tr>
 <!--STAGING-->
 <tr>
 	<td>STAGING_NEW_PUBLICATION_PROCESS_NAVIGATION</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishtolivenow.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishtolivenow.path
@@ -159,12 +159,12 @@
 </tr>
 <tr>
 	<td>CONTENT_CHOOSE_CONTENT_CONTENT_CHANGE_LINK</td>
-	<td>//a[@data-portlettitle='${key_contentName}']</td>
+	<td>//a[@data-portlettitle='${key_uncheckSubContent}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>CONTENT_CHOOSE_CONTENT_SUBCONTENT_CHECKBOX</td>
-	<td>//div[contains(@class,'widget-content-expanded') and contains(.,'${key_contentName}')]//div[contains(@class,'modal-body')]//input[contains(@data-name,'${key_subContent}')]</td>
+	<td>//input[contains(@data-name,'Referenced Content')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
@@ -4066,6 +4066,150 @@
 		</execute>
 	</command>
 
+	<command name="TrashEntryReferencePublishing" priority="5">
+		<execute macro="Navigator#openSiteURL">
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoSitesPublishing">
+			<var name="portlet" value="Staging" />
+		</execute>
+
+		<execute macro="Staging#activateStagingCP">
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoSitesContent">
+			<var name="portlet" value="Documents and Media" />
+			<var name="siteScopeName" value="Site Name" />
+		</execute>
+
+		<execute macro="DMDocument#addCP">
+			<var name="dmDocumentDescription" value="DM Document Description" />
+			<var name="dmDocumentFile" value="Document_1.jpg" />
+			<var name="dmDocumentTitle" value="DM Document Title" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoSitesContent">
+			<var name="portlet" value="Web Content" />
+			<var name="siteScopeName" value="Site Name" />
+		</execute>
+
+		<execute macro="WebContentNavigator#gotoAddCP" />
+
+		<execute macro="WebContent#addWithDocumentCP">
+			<var name="dmDocumentTitle" value="DM Document Title" />
+			<var name="webContentContent" value="Web Content Content" />
+			<var name="webContentTitle" value="Web Content Title" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="Portlet#addPG">
+			<var name="portletName" value="Web Content Display" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="WebContentDisplayPortlet#selectWebContent">
+			<var name="portletName" value="Web Content Display" />
+			<var name="webContentTitle" value="Web Content Title" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="Portlet#addPG">
+			<var name="portletName" value="Documents and Media" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="Staging#gotoPublishToLive" />
+
+		<execute macro="Staging#configurePublishToLive">
+			<var name="checkContentNameList" value="Documents and Media" />
+			<var name="contentDateRange" value="All" />
+		</execute>
+
+		<execute macro="Staging#publishToLive" />
+
+		<execute macro="Navigator#gotoSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoSitesContent">
+			<var name="portlet" value="Documents and Media" />
+			<var name="siteScopeName" value="Site Name" />
+		</execute>
+
+		<execute macro="DMDocument#deleteCP">
+			<var name="dmDocumentTitle" value="DM Document Title" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="Staging#gotoPublishToLive" />
+
+		<execute macro="Staging#configurePublishToLive">
+			<var name="contentDateRange" value="All" />
+			<var name="uncheckContentNameList" value="Documents and Media" />
+			<var name="uncheckSubContent" value="Web Content" />
+		</execute>
+
+		<execute macro="Staging#publishToLive">
+			<var name="failureExpected" value="true" />
+		</execute>
+
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="Staging#gotoPublishToLive" />
+
+		<execute macro="Staging#configurePublishToLive">
+			<var name="checkContentNameList" value="Documents and Media" />
+			<var name="contentDateRange" value="All" />
+		</execute>
+
+		<execute macro="Staging#publishToLive" />
+
+		<execute macro="Navigator#gotoSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoSitesContent">
+			<var name="portlet" value="Documents and Media" />
+			<var name="siteScopeName" value="Site Name" />
+		</execute>
+
+		<execute macro="DMDocument#viewPG">
+			<var name="dmDocumentTitle" value="DM Document Title" />
+		</execute>
+	</command>
+
 	<command name="ViewHistoryVersionWithDeletedUser" priority="4">
 		<execute macro="ProductMenu#gotoControlPanelUsers">
 			<var name="portlet" value="Users and Organizations" />

--- a/test.properties
+++ b/test.properties
@@ -840,20 +840,20 @@
         functional-tomcat8-mysql56-jdk7-quarantine,\
         functional-tomcat8-postgresql94-jdk8,\
         functional-wildfly10-mariadb100-jdk8,\
-        integration-db2105-jdk7,\
+        #integration-db2105-jdk7,\
         integration-hypersonic20-jdk7,\
         integration-mysql56-jdk7,\
-        integration-oracle12-jdk7,\
+        #integration-oracle12-jdk7,\
         integration-postgresql94-jdk7,\
-        integration-sybase160-jdk7,\
+        #integration-sybase160-jdk7,\
         modules-functional-jdk7,\
         modules-functional-tomcat8-mysql56-jdk7,\
-        modules-integration-db2105-jdk7,\
+        #modules-integration-db2105-jdk7,\
         modules-integration-hypersonic20-jdk7,\
         modules-integration-mysql56-jdk7,\
-        modules-integration-oracle12-jdk7,\
+        #modules-integration-oracle12-jdk7,\
         modules-integration-postgresql94-jdk7,\
-        modules-integration-sybase160-jdk7,\
+        #modules-integration-sybase160-jdk7,\
         modules-unit-jdk7,\
         plugins-compile-jdk7,\
         plugins-functional-bundle-tomcat-mysql56-jdk7,\

--- a/test.properties
+++ b/test.properties
@@ -840,14 +840,20 @@
         functional-tomcat8-mysql56-jdk7-quarantine,\
         functional-tomcat8-postgresql94-jdk8,\
         functional-wildfly10-mariadb100-jdk8,\
+        integration-db2105-jdk7,\
         integration-hypersonic20-jdk7,\
         integration-mysql56-jdk7,\
+        integration-oracle12-jdk7,\
         integration-postgresql94-jdk7,\
+        integration-sybase160-jdk7,\
         modules-functional-jdk7,\
         modules-functional-tomcat8-mysql56-jdk7,\
+        modules-integration-db2105-jdk7,\
         modules-integration-hypersonic20-jdk7,\
         modules-integration-mysql56-jdk7,\
+        modules-integration-oracle12-jdk7,\
         modules-integration-postgresql94-jdk7,\
+        modules-integration-sybase160-jdk7,\
         modules-unit-jdk7,\
         plugins-compile-jdk7,\
         plugins-functional-bundle-tomcat-mysql56-jdk7,\


### PR DESCRIPTION
Hey Sam,

After looking through other portlets, such as Web Content Display and Asset Publisher, it looked like the options that involve a pop up generally hide the default success message after the action completes.

This fix basically hides the default success message when modifying a list within the DDLDisplayPortlet.
If you would like to see some examples, you can search "hideDefaultSuccessMessage" in master.

Please let me know if you have any questions.
Thanks.