### PR TITLE
Lps 64632

### DIFF
--- a/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -47,6 +48,8 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletSession;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -272,6 +275,11 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 		LoginUtil.sendPassword(
 			actionRequest, emailFromName, emailFromAddress, emailToAddress,
 			subject, body);
+
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			actionRequest);
+
+		SessionMessages.add(request, "passwordSentTo", emailToAddress);
 
 		sendRedirect(actionRequest, actionResponse, null);
 	}

--- a/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/util/LoginUtil.java
+++ b/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/util/LoginUtil.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.security.auth.session.AuthenticatedSessionManag
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -240,8 +239,6 @@ public class LoginUtil {
 		UserLocalServiceUtil.sendPassword(
 			company.getCompanyId(), toAddress, fromName, fromAddress, subject,
 			body, serviceContext);
-
-		SessionMessages.add(actionRequest, "requestProcessed", toAddress);
 	}
 
 	/**

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -99,6 +99,16 @@
 						<liferay-ui:message arguments="<%= userEmailAddress %>" key="thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved" translateArguments="<%= false %>" />
 					</div>
 				</c:when>
+				<c:when test='<%= SessionMessages.contains(request, "passwordSentTo") %>'>
+
+					<%
+					String userEmailAddress = (String)SessionMessages.get(request, "passwordSentTo");
+					%>
+
+					<div class="alert alert-success">
+						<liferay-ui:message arguments="<%= userEmailAddress %>" key="your-password-has-been-sent-to-x" translateArguments="<%= false %>" />
+					</div>
+				</c:when>
 			</c:choose>
 
 			<liferay-ui:error exception="<%= AuthException.class %>" message="authentication-failed" />

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/ModifiedFacetTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/ModifiedFacetTest.java
@@ -157,6 +157,8 @@ public class ModifiedFacetTest {
 	protected static JSONObject createDataJSONObject(String... ranges)
 		throws Exception {
 
+		JSONObject dataJSONObject = JSONFactoryUtil.createJSONObject();
+
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (String range : ranges) {
@@ -167,11 +169,9 @@ public class ModifiedFacetTest {
 			jsonArray.put(jsonObject);
 		}
 
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+		dataJSONObject.put("ranges", jsonArray);
 
-		jsonObject.put("ranges", jsonArray);
-
-		return jsonObject;
+		return dataJSONObject;
 	}
 
 	protected static SearchContext getSearchContext(String keywords)

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/ModifiedFacetTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/ModifiedFacetTest.java
@@ -157,8 +157,6 @@ public class ModifiedFacetTest {
 	protected static JSONObject createDataJSONObject(String... ranges)
 		throws Exception {
 
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (String range : ranges) {
@@ -168,6 +166,8 @@ public class ModifiedFacetTest {
 
 			jsonArray.put(jsonObject);
 		}
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 		jsonObject.put("ranges", jsonArray);
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
@@ -21,10 +21,9 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTable;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTableFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.upgrade.v7_0_0.util.ClassNameTable;
 import com.liferay.portal.upgrade.v7_0_0.util.ClusterGroupTable;
 import com.liferay.portal.upgrade.v7_0_0.util.CounterTable;
@@ -78,16 +77,8 @@ public class UpgradeSharding extends UpgradeProcess {
 				return;
 			}
 
-			String defaultShardName = PropsUtil.get("shard.default.name");
-
-			if (Validator.isNull(defaultShardName)) {
-				String shardNamesString = StringUtil.merge(shardNames, ", ");
-
-				throw new RuntimeException(
-					"The property \"shard.default.name\" is not set in " +
-						"portal.properties. Please specify a default shard " +
-							"name from: " + shardNamesString + ".");
-			}
+			String defaultShardName = GetterUtil.getString(
+				PropsUtil.get("shard.default.name"), "default");
 
 			for (String uniqueShardName : uniqueShardNames) {
 				if (!uniqueShardName.equals(defaultShardName)) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
@@ -70,8 +70,8 @@ public class UpgradeSharding extends UpgradeProcess {
 			if (uniqueShardNames.size() == 1) {
 				if (_log.isInfoEnabled()) {
 					_log.info(
-						"All companies are located in the default shard, so " +
-							"it's not necessary to copy the control tables.");
+						"All companies are located in the same shard. " +
+							"It's not necessary to copy the control tables.");
 				}
 
 				return;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
@@ -70,8 +70,8 @@ public class UpgradeSharding extends UpgradeProcess {
 			if (uniqueShardNames.size() == 1) {
 				if (_log.isInfoEnabled()) {
 					_log.info(
-						"All companies are located in the same shard. " +
-							"It's not necessary to copy the control tables.");
+						"Skip copying of control tables because all " +
+							"companies are located in the same shard");
 				}
 
 				return;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSharding.java
@@ -65,20 +65,22 @@ public class UpgradeSharding extends UpgradeProcess {
 	}
 
 	protected void copyControlTables(List<String> shardNames) throws Exception {
-		boolean defaultPartitioningEnabled = false;
-
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			List<String> uniqueShardNames = ListUtil.unique(shardNames);
 
-			if (uniqueShardNames.size() < shardNames.size()) {
-				defaultPartitioningEnabled = true;
+			if (uniqueShardNames.size() == 1) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"All companies are located in the default shard, so " +
+							"it's not necessary to copy the control tables.");
+				}
+
+				return;
 			}
 
 			String defaultShardName = PropsUtil.get("shard.default.name");
 
-			if (!defaultPartitioningEnabled &&
-				Validator.isNull(defaultShardName)) {
-
+			if (Validator.isNull(defaultShardName)) {
 				String shardNamesString = StringUtil.merge(shardNames, ", ");
 
 				throw new RuntimeException(

--- a/portal-impl/src/com/liferay/portal/verify/VerifyLayout.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyLayout.java
@@ -44,7 +44,7 @@ public class VerifyLayout extends VerifyProcess {
 			runSQL(
 				"delete from Layout where layoutPrototypeUuid != '' and " +
 					"layoutPrototypeUuid not in (select uuid_ from " +
-						"LayoutPrototype) and layoutPrototypeLinkEnabled = 1");
+						"LayoutPrototype) and layoutPrototypeLinkEnabled = TRUE");
 		}
 	}
 
@@ -97,7 +97,7 @@ public class VerifyLayout extends VerifyProcess {
 			sb.append("update Layout set layoutPrototypeUuid = null where ");
 			sb.append("layoutPrototypeUuid != '' and layoutPrototypeUuid not ");
 			sb.append("in (select uuid_ from LayoutPrototype) and ");
-			sb.append("layoutPrototypeLinkEnabled = 0");
+			sb.append("layoutPrototypeLinkEnabled = FALSE");
 
 			runSQL(sb.toString());
 		}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyLayout.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyLayout.java
@@ -41,10 +41,13 @@ public class VerifyLayout extends VerifyProcess {
 
 	protected void deleteLinkedOrphanedLayouts() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			runSQL(
-				"delete from Layout where layoutPrototypeUuid != '' and " +
-					"layoutPrototypeUuid not in (select uuid_ from " +
-						"LayoutPrototype) and layoutPrototypeLinkEnabled = TRUE");
+			StringBundler sb  = new StringBundler(3);
+
+			sb.append("delete from Layout where layoutPrototypeUuid != '' ");
+			sb.append("and layoutPrototypeUuid not in (select uuid_ from ");
+			sb.append("LayoutPrototype) and layoutPrototypeLinkEnabled = TRUE");
+
+			runSQL(sb.toString());
 		}
 	}
 


### PR DESCRIPTION
I couldn't see much of a reason why the success message for the "/login/forgot_password" action was different from other ones for the login module and using a generic "requestProcessed" success message instead of one specific to the action like most are, so I changed it to match the pattern used by the other success messages, e.g. /login/create_account.