### PR TITLE
LPS-65011

### DIFF
--- a/portal-web/docroot/html/taglib/ui/captcha/simplecaptcha.jsp
+++ b/portal-web/docroot/html/taglib/ui/captcha/simplecaptcha.jsp
@@ -19,6 +19,8 @@
 <%
 String url = (String)request.getAttribute("liferay-ui:captcha:url");
 
+String urlWithTimestamp = HttpUtil.addParameter(url, "timestamp", String.valueOf(System.currentTimeMillis()));
+
 boolean captchaEnabled = false;
 
 try {
@@ -36,7 +38,7 @@ catch (CaptchaMaxChallengesException cmce) {
 
 <c:if test="<%= captchaEnabled %>">
 	<div class="taglib-captcha">
-		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha" id="<portlet:namespace />captcha" src="<%= url %>" />
+		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha" id="<portlet:namespace />captcha" src="<%= urlWithTimestamp %>" />
 
 		<liferay-ui:icon cssClass="refresh" iconCssClass="icon-refresh" id="refreshCaptcha" label="<%= false %>" localizeMessage="<%= true %>" message="refresh-captcha" url="javascript:;" />
 


### PR DESCRIPTION
The request to generate a new Captcha and get a new image to display was not being used on successive attempts to load the "Forgot Password" screen, in favor of the cached first Captcha image.

This fix adds a timestamp to the resource URL to force the Captcha to refresh with the rest of the page each time instead of using a cached image, preventing an invalid Captcha from being used.