### PR TITLE
Lps 65353

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.dynamic.data.mapping.util.DDMXML;
 import com.liferay.dynamic.data.mapping.util.impl.DDMFormTemplateSynchonizer;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidator;
+import com.liferay.portal.background.task.constants.BackgroundTaskContextMapConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
@@ -1685,6 +1686,9 @@ public class DDMStructureLocalServiceImpl
 		Map<String, Serializable> taskContextMap = new HashMap<>();
 
 		taskContextMap.put("structureId", structure.getStructureId());
+
+		taskContextMap.put(
+			BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
 
 		backgroundTaskmanager.addBackgroundTask(
 			structure.getUserId(), structure.getGroupId(), backgroundTaskName,

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/verify/BackgroundTaskServiceVerifyProcess.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/verify/BackgroundTaskServiceVerifyProcess.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.verify;
+
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.verify.VerifyProcess;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alec Shay
+ */
+@Component(
+    immediate = true,
+    property = {"verify.process.name=com.liferay.background.task.service"},
+    service = VerifyProcess.class
+)
+public class BackgroundTaskServiceVerifyProcess extends VerifyProcess {
+
+    @Override
+    protected void doVerify() throws Exception {
+        deleteBackgroundTasks();
+    }
+
+    protected void deleteBackgroundTasks() {
+        try {
+            if (_log.isInfoEnabled()) {
+                _log.info("Deleting unnecessary backgroundtask entries");
+            }
+
+            java.util.List<BackgroundTask> tasksToRemove =
+                _backgroundTaskLocalService.getBackgroundTasks(
+                    "com.liferay.portal.lar.backgroundtask." +
+                        "StagingIndexingBackgroundTaskExecutor",
+                    BackgroundTaskConstants.STATUS_SUCCESSFUL);
+
+            if (tasksToRemove != null) {
+                for (int i = 0; i < tasksToRemove.size(); i++) {
+                    BackgroundTask backgroundTask = tasksToRemove.get(i);
+
+                    _backgroundTaskLocalService.deleteBackgroundTask(
+                        backgroundTask);
+                }
+
+                if (_log.isInfoEnabled()) {
+                    _log.info("Deleted StagingIndexingBackgroundTaskExecutors");
+                }
+            }
+        }
+        catch (Exception e) {
+            _log.error(e, e);
+        }
+    }
+
+    @Reference(unbind = "-")
+    protected void setBackgroundTaskLocalService(
+        BackgroundTaskLocalService backgroundTaskLocalService) {
+
+        _backgroundTaskLocalService = backgroundTaskLocalService;
+    }
+
+    private static final Log _log = LogFactoryUtil.getLog(
+        BackgroundTaskServiceVerifyProcess.class);
+
+    private BackgroundTaskLocalService _backgroundTaskLocalService;
+}


### PR DESCRIPTION
In master, DDMStructureIndexerBackgroundTaskExecutors (along with their entire serialized context maps) would be left in the database indefinitely without a need for them, and without an easy way to remove them any time a LAR import or staging publish caused a re-index for DDM structures using DDMStructureIndexer (see DDMStructureLocalServiceImpl's reindexStructure()). For very large imports/publishes, these could potentially cause concerns with the amount of space used in the database.

A similar effect exists in 6.2, where StagingIndexingBackgroundTaskExecutors would be left in the database with no purpose for any page import/publish.

This fix allows the DDMStructureIndexerBackgroundTaskExecutors to be removed once they are completed, and also adds a VerifyProcess to be able to remove any StagingIndexingBackgroundTaskExecutors that might still exist as the result of an upgrade.