### PR TITLE
Lps 64632

### DIFF
--- a/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -279,7 +279,7 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 		HttpServletRequest request = PortalUtil.getHttpServletRequest(
 			actionRequest);
 
-		SessionMessages.add(request, "passwordSent", emailToAddress);
+		SessionMessages.add(request, "passwordSent");
 
 		sendRedirect(actionRequest, actionResponse, null);
 	}

--- a/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -47,6 +48,8 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletSession;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -272,6 +275,11 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 		LoginUtil.sendPassword(
 			actionRequest, emailFromName, emailFromAddress, emailToAddress,
 			subject, body);
+
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			actionRequest);
+
+		SessionMessages.add(request, "passwordSentTo", emailToAddress);
 
 		sendRedirect(actionRequest, actionResponse, null);
 	}

--- a/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -279,7 +279,7 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 		HttpServletRequest request = PortalUtil.getHttpServletRequest(
 			actionRequest);
 
-		SessionMessages.add(request, "passwordSentTo", emailToAddress);
+		SessionMessages.add(request, "passwordSent", emailToAddress);
 
 		sendRedirect(actionRequest, actionResponse, null);
 	}

--- a/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/util/LoginUtil.java
+++ b/modules/apps/foundation/login/login-web/src/main/java/com/liferay/login/web/portlet/util/LoginUtil.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.security.auth.session.AuthenticatedSessionManag
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -240,8 +239,6 @@ public class LoginUtil {
 		UserLocalServiceUtil.sendPassword(
 			company.getCompanyId(), toAddress, fromName, fromAddress, subject,
 			body, serviceContext);
-
-		SessionMessages.add(actionRequest, "requestProcessed", toAddress);
 	}
 
 	/**

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -99,6 +99,16 @@
 						<liferay-ui:message arguments="<%= userEmailAddress %>" key="thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved" translateArguments="<%= false %>" />
 					</div>
 				</c:when>
+				<c:when test='<%= SessionMessages.contains(request, "passwordSentTo") %>'>
+
+					<%
+					String userEmailAddress = (String)SessionMessages.get(request, "passwordSentTo");
+					%>
+
+					<div class="alert alert-success">
+						<liferay-ui:message arguments="<%= userEmailAddress %>" key="your-password-has-been-sent-to-x" translateArguments="<%= false %>" />
+					</div>
+				</c:when>
 			</c:choose>
 
 			<liferay-ui:error exception="<%= AuthException.class %>" message="authentication-failed" />

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -65,12 +65,8 @@
 			<c:choose>
 				<c:when test='<%= SessionMessages.contains(request, "passwordSent") %>'>
 
-					<%
-						String userEmailAddress = (String)SessionMessages.get(request, "passwordSentTo");
-					%>
-
 					<div class="alert alert-success">
-						<liferay-ui:message arguments="<%= userEmailAddress %>" key="your-password-has-been-sent-to-x" translateArguments="<%= false %>" />
+						<liferay-ui:message key="your-password-has-been-sent-to-the-provided-email-address" />
 					</div>
 				</c:when>
 				<c:when test='<%= SessionMessages.contains(request, "userAdded") %>'>

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -63,6 +63,16 @@
 			<div class="inline-alert-container lfr-alert-container"></div>
 
 			<c:choose>
+				<c:when test='<%= SessionMessages.contains(request, "passwordSent") %>'>
+
+					<%
+						String userEmailAddress = (String)SessionMessages.get(request, "passwordSentTo");
+					%>
+
+					<div class="alert alert-success">
+						<liferay-ui:message arguments="<%= userEmailAddress %>" key="your-password-has-been-sent-to-x" translateArguments="<%= false %>" />
+					</div>
+				</c:when>
 				<c:when test='<%= SessionMessages.contains(request, "userAdded") %>'>
 
 					<%
@@ -97,16 +107,6 @@
 
 					<div class="alert alert-success">
 						<liferay-ui:message arguments="<%= userEmailAddress %>" key="thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved" translateArguments="<%= false %>" />
-					</div>
-				</c:when>
-				<c:when test='<%= SessionMessages.contains(request, "passwordSentTo") %>'>
-
-					<%
-					String userEmailAddress = (String)SessionMessages.get(request, "passwordSentTo");
-					%>
-
-					<div class="alert alert-success">
-						<liferay-ui:message arguments="<%= userEmailAddress %>" key="your-password-has-been-sent-to-x" translateArguments="<%= false %>" />
 					</div>
 				</c:when>
 			</c:choose>

--- a/modules/apps/foundation/login/login-web/src/main/resources/content/Language.properties
+++ b/modules/apps/foundation/login/login-web/src/main/resources/content/Language.properties
@@ -7,4 +7,5 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>.
 you-are-signed-in-as-x=You are signed in as {0}.
 your-email-verification-code-has-been-sent-to-x=Your email verification code has been sent to {0}.
+your-password-has-been-sent-to-the-provided-email-address=Your password has been sent to the provided email address.
 your-password-has-been-sent-to-x=Your password has been sent to {0}.

--- a/modules/apps/foundation/login/login-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/foundation/login/login-web/src/main/resources/content/Language_en.properties
@@ -7,4 +7,5 @@ thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your
 thank-you-for-creating-an-account.-your-password-is-x=Thank you for creating an account. Your password is <strong>{0}</strong>.
 you-are-signed-in-as-x=You are signed in as {0}.
 your-email-verification-code-has-been-sent-to-x=Your email verification code has been sent to {0}.
+your-password-has-been-sent-to-the-provided-email-address=Your password has been sent to the provided email address.
 your-password-has-been-sent-to-x=Your password has been sent to {0}.


### PR DESCRIPTION
Re-submitting this change. Previously it was changed to use "your-password-has-been-sent-to-x" (x being the email address of the user) for the success message. However, since this may inadvertently reveal the user's email address if the authentication is not already by email address, I think the best alternative would be to change it in favor of a new, more generic message.

I suppose if we do not want to make a new language key, the even more generic "The request was successful" could also be appropriate, but I think a new key makes the most sense.