### PR TITLE
Lps 65584

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/display/context/SearchDisplayContext.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/display/context/SearchDisplayContext.java
@@ -69,7 +69,7 @@ public class SearchDisplayContext {
 		_renderResponse = renderResponse;
 		_portletPreferences = portletPreferences;
 
-		if (Validator.isNull(getKeywords())) {
+		if ((getKeywords() == null) || (getKeywords().length() == 0)) {
 			_hits = null;
 			_searchContext = null;
 			_searchContainer = null;


### PR DESCRIPTION
Using Validator's isNotNull() when creating a search display context will cause a NullPointerException when trying to render the results, since it expects an object to be able to get the hits from but IsNotNull() treats the word "null" as actually null. This causes the searchDisplayContext to not be properly initialized.