### PR TITLE
LPS-66798

### DIFF
--- a/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
+++ b/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
@@ -428,8 +428,15 @@ public class CounterFinderImpl
 
 			return counterHolder;
 		}
-		catch (Exception e) {
-			throw processException(e);
+		catch (SQLException sqle) {
+			if (sqle.getSQLState().equals("40001") ||
+				(sqle.getErrorCode() == 8177)) {
+
+				return _obtainIncrement(counterName, range, size);
+			}
+			else {
+				throw processException(sqle);
+			}
 		}
 		finally {
 			DataAccess.cleanUp(connection, preparedStatement, resultSet);

--- a/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
+++ b/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
@@ -22,7 +22,6 @@ import com.liferay.counter.model.impl.CounterImpl;
 import com.liferay.portal.kernel.cache.CacheRegistryItem;
 import com.liferay.portal.kernel.concurrent.CompeteLatch;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.dao.orm.LockMode;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -368,15 +367,45 @@ public class CounterFinderImpl
 	private CounterHolder _obtainIncrement(
 		String counterName, long range, long size) {
 
-		Session session = null;
+		Connection connection = null;
+		PreparedStatement preparedStatement = null;
+		ResultSet resultSet = null;
 
 		try {
-			session = openSession();
+			connection = getConnection();
 
-			Counter counter = (Counter)session.get(
-				CounterImpl.class, counterName, LockMode.UPGRADE);
+			connection.setTransactionIsolation(
+				Connection.TRANSACTION_SERIALIZABLE);
+			connection.setAutoCommit(false);
 
-			long newValue = counter.getCurrentId();
+			// Get an exclusive lock with a no-op query
+
+			preparedStatement = connection.prepareStatement(
+				_SQL_UPDATE_NO_OP_BY_NAME);
+
+			preparedStatement.setString(1, counterName);
+
+			preparedStatement.executeUpdate();
+
+			preparedStatement.close();
+
+			// Retrieve the Counter value
+
+			preparedStatement = connection.prepareStatement(
+				_SQL_SELECT_ID_BY_NAME);
+
+			preparedStatement.setString(1, counterName);
+
+			resultSet = preparedStatement.executeQuery();
+
+			resultSet.next();
+
+			long newValue = resultSet.getLong("currentId");
+
+			resultSet.close();
+			preparedStatement.close();
+
+			// Computer and update the value
 
 			if (size > newValue) {
 				newValue = size;
@@ -384,13 +413,18 @@ public class CounterFinderImpl
 
 			long rangeMax = newValue + range;
 
-			counter.setCurrentId(rangeMax);
+			preparedStatement = connection.prepareStatement(
+				_SQL_UPDATE_CURRENT_ID_BY_NAME);
+
+			preparedStatement.setLong(1, rangeMax);
+			preparedStatement.setString(2, counterName);
+
+			preparedStatement.executeUpdate();
+			preparedStatement.close();
+
+			connection.commit();
 
 			CounterHolder counterHolder = new CounterHolder(newValue, rangeMax);
-
-			session.saveOrUpdate(counter);
-
-			session.flush();
 
 			return counterHolder;
 		}
@@ -398,7 +432,7 @@ public class CounterFinderImpl
 			throw processException(e);
 		}
 		finally {
-			closeSession(session);
+			DataAccess.cleanUp(connection, preparedStatement, resultSet);
 		}
 	}
 
@@ -417,8 +451,14 @@ public class CounterFinderImpl
 	private static final String _SQL_SELECT_NAMES =
 		"select name from Counter order by name asc";
 
+	private static final String _SQL_UPDATE_CURRENT_ID_BY_NAME =
+		"update Counter set currentId = ? where name = ?";
+
 	private static final String _SQL_UPDATE_NAME_BY_NAME =
 		"update Counter set name = ? where name = ?";
+
+	private static final String _SQL_UPDATE_NO_OP_BY_NAME =
+		"update Counter set currentId = currentId where name = ?";
 
 	private final Map<String, CounterRegister> _counterRegisterMap =
 		new ConcurrentHashMap<>();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-66798

Our usage of Hibernate currently in place does not prevent concurrent access to Counters when clustering through certain methods (Hibernate does not successfully acquire an exclusive lock in the database). This can cause race conditions in which our failure to acquire a lock causes multiple nodes in a cluster to use the same Counter values, creating duplicate ID's when more entities are created.

This was found using a client's login hook in 6.1, which automatically creates users and signs in whenever signed out. However, because this hook only works in 6.1, this issue couldn't be easily tested in 6.2+ (as even through the use of breakpoints, it seems this issue cannot be reproduced unless through similar means, because of the normal method paths using the UI). Additionally, because we have other methods in place to prevent race conditions between threads on the same node, this can only be reproduced with clustering, which I could not successfully test in master. However, the pieces of code in question are exactly the same between all versions 6.1 through master, and our versions indicate that we use the same version of Hibernate between them as well, so I think it could be reasonably presumed a similar issue exists in master as well.

We tried updating our use of Hibernate's API to force it to acquire a true lock on the Counter, but none of this works, probably because of a bug with Hibernate. Thus, this fix is implemented by bypassing Hibernate for Counter updates altogether, instead using a Serializable isolation level together with a no-op update query in advance to force a true exclusive lock.

There are two possible concerns I can see with this:

- the Serializable isolation level locks the whole table, rather than just the Counter row being updated (it may be the only way to guarantee an exclusive lock); this shouldn't cause any problems logically but could cause some performance decrease for concurrent requests for different Counters
- different databases, depending on their implementation of serializing the transactions, can sometimes fail to do so, and throw different errors/exceptions (one of the requests will fail and rollback, although it can simply be tried again). I tested with multiple kinds of databases and caught the exceptions I found (SQLState 40,001, and ORA-08177), but unfortunately there's always the possibility a different database type or version sometimes can fail with an error code that doesn't fit these conventions (see [this link](https://issues.liferay.com/browse/LPS-66798?focusedCommentId=820043&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-820043) for the types and versions I was able to test with through one way or another, though all using the client's login hook in 6.1).

Still, this was the best way we found to ensure safety in accessing the Counter table for concurrently running clustered nodes without requiring a Hibernate upgrade (which would be extensive, considering we are using the last version of 3.6).