### PR TITLE
LPS-67714

### DIFF
--- a/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
+++ b/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
@@ -240,8 +240,6 @@ public class DocumentLibraryConvertProcess
 					dynamicQuery.add(
 						classNameIdProperty.ne(backgroundTaskClassNameId));
 					dynamicQuery.add(
-						classNameIdProperty.ne(mbAttachmentClassNameId));
-					dynamicQuery.add(
 						classNameIdProperty.ne(wikiAttachmentClassNameId));
 				}
 
@@ -251,9 +249,21 @@ public class DocumentLibraryConvertProcess
 
 				@Override
 				public void performAction(DLFileEntry dlFileEntry) {
+					long classNameId = dlFileEntry.getClassNameId();
+					long dataRepositoryId;
+
+					if (classNameId == mbAttachmentClassNameId) {
+						dataRepositoryId =
+							DLFolderConstants.getDataRepositoryId(
+								dlFileEntry.getRepositoryId(),
+								dlFileEntry.getFolderId());
+					}
+					else {
+						dataRepositoryId = dlFileEntry.getDataRepositoryId();
+					}
+
 					migrateDLFileEntry(
-						dlFileEntry.getCompanyId(),
-						dlFileEntry.getDataRepositoryId(),
+						dlFileEntry.getCompanyId(), dataRepositoryId,
 						new LiferayFileEntry(dlFileEntry));
 				}
 
@@ -317,46 +327,9 @@ public class DocumentLibraryConvertProcess
 		actionableDynamicQuery.performActions();
 	}
 
-	protected void migrateMB() throws PortalException {
-		int count = MBMessageLocalServiceUtil.getMBMessagesCount();
-
-		MaintenanceUtil.appendStatus(
-			"Migrating message boards attachments in " + count + " messages");
-
-		ActionableDynamicQuery actionableDynamicQuery =
-			MBMessageLocalServiceUtil.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setPerformActionMethod(
-			new ActionableDynamicQuery.PerformActionMethod<MBMessage>() {
-
-				@Override
-				public void performAction(MBMessage mbMessage)
-					throws PortalException {
-
-					for (FileEntry fileEntry :
-							mbMessage.getAttachmentsFileEntries()) {
-
-						DLFileEntry dlFileEntry =
-							(DLFileEntry)fileEntry.getModel();
-
-						migrateDLFileEntry(
-							mbMessage.getCompanyId(),
-							DLFolderConstants.getDataRepositoryId(
-								dlFileEntry.getRepositoryId(),
-								dlFileEntry.getFolderId()),
-							new LiferayFileEntry(dlFileEntry));
-					}
-				}
-
-			});
-
-		actionableDynamicQuery.performActions();
-	}
-
 	protected void migratePortlets() throws Exception {
 		migrateImages();
 		migrateDL();
-		migrateMB();
 
 		Collection<DLStoreConvertProcess> dlStoreConvertProcesses =
 			_getDLStoreConvertProcesses();

--- a/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
+++ b/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Image;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -212,6 +213,16 @@ public class DocumentLibraryConvertProcess
 	protected void migrateDL() throws PortalException {
 		int count = DLFileEntryLocalServiceUtil.getFileEntriesCount();
 
+		final long backgroundTaskClassNameId =
+			ClassNameLocalServiceUtil.getClassNameId(
+				"com.liferay.portal.background.task.model.BackgroundTask");
+		final long mbAttachmentClassNameId =
+			ClassNameLocalServiceUtil.getClassNameId(
+				"com.liferay.message.boards.kernel.model.MBMessage");
+		final long wikiAttachmentClassNameId =
+			ClassNameLocalServiceUtil.getClassNameId(
+				"com.liferay.wiki.model.WikiPage");
+
 		MaintenanceUtil.appendStatus(
 			"Migrating " + count + " documents and media files");
 
@@ -226,7 +237,12 @@ public class DocumentLibraryConvertProcess
 					Property classNameIdProperty = PropertyFactoryUtil.forName(
 						"classNameId");
 
-					dynamicQuery.add(classNameIdProperty.eq(0L));
+					dynamicQuery.add(
+						classNameIdProperty.ne(backgroundTaskClassNameId));
+					dynamicQuery.add(
+						classNameIdProperty.ne(mbAttachmentClassNameId));
+					dynamicQuery.add(
+						classNameIdProperty.ne(wikiAttachmentClassNameId));
 				}
 
 			});

--- a/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
+++ b/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
@@ -20,8 +20,6 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLPreviewableProcessor;
 import com.liferay.document.library.kernel.util.comparator.FileVersionVersionComparator;
-import com.liferay.message.boards.kernel.model.MBMessage;
-import com.liferay.message.boards.kernel.service.MBMessageLocalServiceUtil;
 import com.liferay.portal.convert.BaseConvertProcess;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPS-67714
https://issues.liferay.com/browse/LPP-22264

This is essentially undoing a change from LPS-39303 that effectively prevented migrating any DL file entries with a non-zero classNameId, other than Message Boards and Wikis, which were separated out into their own methods with minor differences. This was apparently to prevent attempting to migrate the same DL file entries multiple times. However, the correct functionality is to generally migrate any DL file entry regardless of classNameId (see here for discussion https://in.liferay.com/web/support/forums/-/message_boards/view_message/23950239), with exceptions only where it wouldn't work properly otherwise. The main issue is fixed by removing the constraint that requires the classNameId be equal to 0.

In 6.2, the correct fix would apparently be to allow all DL file entries to be migrated using the migrateDL() method, removing the migrateMB() and migrateWiki() methods, as they unnecessarily complicate the code. However, in master, the Wiki attachments have diverged even further from this pattern, as a result of https://issues.liferay.com/browse/LPS-50604; Wiki attachments in master are now migrated via a WikiDLStoreConvertProcess (which seems to be the only DLStoreConvertProcess implemented at this time).

The WikiDLStoreConvertProcess was implemented when the Wiki portlet were made into an OSGi module, so I think we would not want to undo this. However, I think that to maintain consistency, it would probably make more sense to have the message board attachments follow the same pattern. However, because I was not totally sure, and also wasn't sure whether that should be done together with this ticket, I just made the message boards use the more generalized migrateDL() method. I would like to know what others think about this though.

Additionally, I added one more exception for the migrateDL() method to prevent BackgroundTasks from being migrated, since they weren't being migrated previously, and I don't want to change this and potentially cause regressions with them.

Please let me know if there are any concerns with all of this, or if my reasoning as for the MB and Wiki portlets' pattern was wrong. Thanks.