### PR TITLE
LPS-67714

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/convert/documentlibrary/MBDLStoreConvertProcess.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/convert/documentlibrary/MBDLStoreConvertProcess.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.internal.convert.documentlibrary;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.message.boards.kernel.model.MBMessage;
+import com.liferay.message.boards.kernel.service.MBMessageLocalService;
+import com.liferay.portal.convert.documentlibrary.DLStoreConvertProcess;
+import com.liferay.portal.convert.documentlibrary.DLStoreConverter;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.util.MaintenanceUtil;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alec Shay
+ */
+@Component(service = DLStoreConvertProcess.class)
+public class MBDLStoreConvertProcess implements DLStoreConvertProcess {
+
+	@Override
+	public void migrate(final DLStoreConverter dlStoreConverter)
+		throws PortalException {
+
+		int count =	_mbMessageLocalService.getMBMessagesCount();
+
+		MaintenanceUtil.appendStatus(
+			"Migrating message boards attachments in " + count + " messages");
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_mbMessageLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setPerformActionMethod(
+			new ActionableDynamicQuery.PerformActionMethod<MBMessage>() {
+
+				@Override
+				public void performAction(MBMessage mbMessage)
+					throws PortalException {
+
+					for (FileEntry fileEntry :
+						mbMessage.getAttachmentsFileEntries()) {
+
+						DLFileEntry dlFileEntry =
+							(DLFileEntry)fileEntry.getModel();
+
+						dlStoreConverter.migrateDLFileEntry(
+							mbMessage.getCompanyId(),
+							DLFolderConstants.getDataRepositoryId(
+								dlFileEntry.getRepositoryId(),
+								dlFileEntry.getFolderId()),
+							new LiferayFileEntry(dlFileEntry));
+					}
+				}
+
+			});
+
+		actionableDynamicQuery.performActions();
+	}
+
+	@Reference(unbind ="-")
+	public void setWikiPageLocalService(
+		MBMessageLocalService mbMessageLocalService) {
+
+		_mbMessageLocalService = mbMessageLocalService;
+	}
+
+	private MBMessageLocalService _mbMessageLocalService;
+}

--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/convert/documentlibrary/MBDLStoreConvertProcess.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/convert/documentlibrary/MBDLStoreConvertProcess.java
@@ -39,7 +39,7 @@ public class MBDLStoreConvertProcess implements DLStoreConvertProcess {
 	public void migrate(final DLStoreConverter dlStoreConverter)
 		throws PortalException {
 
-		int count =	_mbMessageLocalService.getMBMessagesCount();
+		int count = _mbMessageLocalService.getMBMessagesCount();
 
 		MaintenanceUtil.appendStatus(
 			"Migrating message boards attachments in " + count + " messages");
@@ -55,7 +55,7 @@ public class MBDLStoreConvertProcess implements DLStoreConvertProcess {
 					throws PortalException {
 
 					for (FileEntry fileEntry :
-						mbMessage.getAttachmentsFileEntries()) {
+							mbMessage.getAttachmentsFileEntries()) {
 
 						DLFileEntry dlFileEntry =
 							(DLFileEntry)fileEntry.getModel();
@@ -82,4 +82,5 @@ public class MBDLStoreConvertProcess implements DLStoreConvertProcess {
 	}
 
 	private MBMessageLocalService _mbMessageLocalService;
+
 }

--- a/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
+++ b/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
@@ -301,46 +301,9 @@ public class DocumentLibraryConvertProcess
 		actionableDynamicQuery.performActions();
 	}
 
-	protected void migrateMB() throws PortalException {
-		int count = MBMessageLocalServiceUtil.getMBMessagesCount();
-
-		MaintenanceUtil.appendStatus(
-			"Migrating message boards attachments in " + count + " messages");
-
-		ActionableDynamicQuery actionableDynamicQuery =
-			MBMessageLocalServiceUtil.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setPerformActionMethod(
-			new ActionableDynamicQuery.PerformActionMethod<MBMessage>() {
-
-				@Override
-				public void performAction(MBMessage mbMessage)
-					throws PortalException {
-
-					for (FileEntry fileEntry :
-							mbMessage.getAttachmentsFileEntries()) {
-
-						DLFileEntry dlFileEntry =
-							(DLFileEntry)fileEntry.getModel();
-
-						migrateDLFileEntry(
-							mbMessage.getCompanyId(),
-							DLFolderConstants.getDataRepositoryId(
-								dlFileEntry.getRepositoryId(),
-								dlFileEntry.getFolderId()),
-							new LiferayFileEntry(dlFileEntry));
-					}
-				}
-
-			});
-
-		actionableDynamicQuery.performActions();
-	}
-
 	protected void migratePortlets() throws Exception {
 		migrateImages();
 		migrateDL();
-		migrateMB();
 
 		Collection<DLStoreConvertProcess> dlStoreConvertProcesses =
 			_getDLStoreConvertProcesses();

--- a/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
+++ b/portal-impl/src/com/liferay/portal/convert/documentlibrary/DocumentLibraryConvertProcess.java
@@ -15,13 +15,10 @@
 package com.liferay.portal.convert.documentlibrary;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLPreviewableProcessor;
 import com.liferay.document.library.kernel.util.comparator.FileVersionVersionComparator;
-import com.liferay.message.boards.kernel.model.MBMessage;
-import com.liferay.message.boards.kernel.service.MBMessageLocalServiceUtil;
 import com.liferay.portal.convert.BaseConvertProcess;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;


### PR DESCRIPTION
See previous pull request: https://github.com/sergiogonzalez/liferay-portal/pull/3405

Relevant tickets:

https://issues.liferay.com/browse/LPS-67714
https://issues.liferay.com/browse/LPP-22264


Re-sending pull for this ticket with changes as requested here: https://github.com/sergiogonzalez/liferay-portal/pull/3405#issuecomment-243447830

For master, we have decided to use a separate pattern for DL migration for non-zero classNameId's; any of these documents that need to be migrated should have their own DLStoreConvertProcess, similar to the WikiDLStoreConvertProcess that exists now.

Thus, for master this change is just refactoring the MB attachments to match the pattern. So this change adds an MBDLStoreConvertProcess for this purpose.

For reference here is a post discussing necessary changes more specific to 6.2 (not included in this pull): https://in.liferay.com/web/support/forums/-/message_boards/message/23911669#_19_message_23950239