### PR TITLE
LPS-64821

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/category_action.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/category_action.jsp
@@ -21,7 +21,7 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 
 MBCategory category = (MBCategory)row.getObject();
 
-Set<Long> categorySubscriptionClassPKs = (Set<Long>)row.getParameter("categorySubscriptionClassPKs");
+Set<Long> categorySubscriptionClassPKs = (Set<Long>)request.getAttribute("view.jsp-categorySubscriptionClassPKs");
 
 boolean defaultParentCategory = false;
 


### PR DESCRIPTION
Related tickets:
https://issues.liferay.com/browse/LPP-22709
https://issues.liferay.com/browse/LPS-68421

This is an issue unique to master and ee-7.0.x. The problem is that, in category_action.jsp, we no longer pass the list of category subscriptions as a row parameter, so the list it tries to receive is null. I believe this may have been caused by a refactoring change, although I haven't pinpointed the ticket.

An alternative fix could be to also attach this list as a row parameter for every category, but I believe this way makes more sense, because the list is already present and usable in the request.