### PR TITLE
LPS-68514 

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -435,13 +435,17 @@ app.server.type=@{app.server.type}]]></echo>
 /*/*/javadoc
 /*/*/lib
 /*/*/tmp
+/*/*/*/build/node
 /*/*/*/ivy.xml.MD5
 /*/*/*/javadoc
 /*/*/*/lib
+/*/*/*/node_modules
 /*/*/*/tmp
+/*/*/*/*/build/node
 /*/*/*/*/ivy.xml.MD5
 /*/*/*/*/javadoc
 /*/*/*/*/lib
+/*/*/*/*/node_modules
 /*/*/*/*/tmp</echo>
 
 			<delete>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1806,7 +1806,15 @@ ${output.content}</echo>
 			</test-action>
 
 			<test-set-up>
-				<prepare-test-build />
+				<if>
+					<isset property="env.DIST_PATH" />
+					<then>
+						<prepare-test-environment />
+					</then>
+					<else>
+						<prepare-test-build />
+					</else>
+				</if>
 			</test-set-up>
 		</run-batch-test>
 	</target>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
@@ -306,6 +306,11 @@
 	.kb-select-article-breadcrumbs {
 		margin: 0 0 5px;
 	}
+
+	.lfr-dynamic-uploader {
+		position: relative;
+		top: 0;
+	}
 }
 
 #wrapper .knowledge-base-portlet .card-horizontal.main-content-card {

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -148,9 +148,6 @@ public class GroupFinderImpl
 	public static final String JOIN_BY_USERS_GROUPS =
 		GroupFinder.class.getName() + ".joinByUsersGroups";
 
-	public static final String JOIN_BY_USERS_USER_GROUPS =
-		GroupFinder.class.getName() + ".joinByUsersUserGroups";
-
 	@Override
 	public int countByLayouts(
 		long companyId, long parentGroupId, boolean site) {
@@ -367,7 +364,7 @@ public class GroupFinderImpl
 			params4 = new LinkedHashMap<>(params1);
 
 			params4.remove("usersGroups");
-			params4.put("usersUserGroups", userId);
+			params4.put("groupsUserGroups", userId);
 
 			params2.put("classNameIds", groupOrganizationClassNameIds[1]);
 			params3.put("classNameIds", groupOrganizationClassNameIds[0]);
@@ -1413,9 +1410,6 @@ public class GroupFinderImpl
 		joinMap.put(
 			"usersGroups",
 			_removeWhere(CustomSQLUtil.get(JOIN_BY_USERS_GROUPS)));
-		joinMap.put(
-			"usersUserGroups",
-			_removeWhere(CustomSQLUtil.get(JOIN_BY_USERS_USER_GROUPS)));
 
 		_joinMap = joinMap;
 
@@ -1471,9 +1465,6 @@ public class GroupFinderImpl
 		whereMap.put(
 			"usersGroups",
 			_getCondition(CustomSQLUtil.get(JOIN_BY_USERS_GROUPS)));
-		whereMap.put(
-			"usersUserGroups",
-			_getCondition(CustomSQLUtil.get(JOIN_BY_USERS_USER_GROUPS)));
 
 		_whereMap = whereMap;
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -347,31 +347,17 @@ public class GroupFinderImpl
 			doUnion = true;
 		}
 
-		long[] groupOrganizationClassNameIds =
-			_getGroupOrganizationClassNameIds();
-
 		if (doUnion) {
 			params2 = new LinkedHashMap<>(params1);
-
-			params2.remove("usersGroups");
-			params2.put("groupOrg", userId);
-
 			params3 = new LinkedHashMap<>(params1);
-
-			params3.remove("usersGroups");
-			params3.put("groupsOrgs", userId);
-
 			params4 = new LinkedHashMap<>(params1);
 
-			params4.remove("usersGroups");
-			params4.put("groupsUserGroups", userId);
-
-			params2.put("classNameIds", groupOrganizationClassNameIds[1]);
-			params3.put("classNameIds", groupOrganizationClassNameIds[0]);
-			params4.put("classNameIds", groupOrganizationClassNameIds[0]);
+			_populateUnionParams(
+				userId, null, params1, params2, params3, params4);
 		}
-
-		params1.put("classNameIds", _getGroupOrganizationClassNameIds());
+		else {
+			params1.put("classNameIds", _getGroupOrganizationClassNameIds());
+		}
 
 		String sqlKey = _buildSQLCacheKey(
 			obc, params1, params2, params3, params4);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -148,6 +148,9 @@ public class GroupFinderImpl
 	public static final String JOIN_BY_USERS_GROUPS =
 		GroupFinder.class.getName() + ".joinByUsersGroups";
 
+	public static final String JOIN_BY_USERS_USER_GROUPS =
+		GroupFinder.class.getName() + ".joinByUsersUserGroups";
+
 	@Override
 	public int countByLayouts(
 		long companyId, long parentGroupId, boolean site) {
@@ -336,6 +339,8 @@ public class GroupFinderImpl
 
 		LinkedHashMap<String, Object> params3 = null;
 
+		LinkedHashMap<String, Object> params4 = null;
+
 		Long userId = (Long)params.get("usersGroups");
 		boolean inherit = GetterUtil.getBoolean(params.get("inherit"), true);
 
@@ -359,13 +364,20 @@ public class GroupFinderImpl
 			params3.remove("usersGroups");
 			params3.put("groupsOrgs", userId);
 
+			params4 = new LinkedHashMap<>(params1);
+
+			params4.remove("usersGroups");
+			params4.put("usersUserGroups", userId);
+
 			params2.put("classNameIds", groupOrganizationClassNameIds[1]);
 			params3.put("classNameIds", groupOrganizationClassNameIds[0]);
+			params4.put("classNameIds", groupOrganizationClassNameIds[0]);
 		}
 
 		params1.put("classNameIds", _getGroupOrganizationClassNameIds());
 
-		String sqlKey = _buildSQLCacheKey(obc, params1, params2, params3);
+		String sqlKey = _buildSQLCacheKey(
+			obc, params1, params2, params3, params4);
 
 		String sql = _findByCompanyIdSQLCache.get(sqlKey);
 
@@ -390,6 +402,8 @@ public class GroupFinderImpl
 				sb.append(replaceJoinAndWhere(findByCompanyIdSQL, params2));
 				sb.append(") UNION (");
 				sb.append(replaceJoinAndWhere(findByCompanyIdSQL, params3));
+				sb.append(") UNION (");
+				sb.append(replaceJoinAndWhere(findByCompanyIdSQL, params4));
 			}
 
 			sb.append(StringPool.CLOSE_PARENTHESIS);
@@ -425,6 +439,10 @@ public class GroupFinderImpl
 				qPos.add(companyId);
 
 				setJoin(qPos, params3);
+
+				qPos.add(companyId);
+
+				setJoin(qPos, params4);
 
 				qPos.add(companyId);
 			}
@@ -1395,6 +1413,9 @@ public class GroupFinderImpl
 		joinMap.put(
 			"usersGroups",
 			_removeWhere(CustomSQLUtil.get(JOIN_BY_USERS_GROUPS)));
+		joinMap.put(
+			"usersUserGroups",
+			_removeWhere(CustomSQLUtil.get(JOIN_BY_USERS_USER_GROUPS)));
 
 		_joinMap = joinMap;
 
@@ -1450,6 +1471,9 @@ public class GroupFinderImpl
 		whereMap.put(
 			"usersGroups",
 			_getCondition(CustomSQLUtil.get(JOIN_BY_USERS_GROUPS)));
+		whereMap.put(
+			"usersUserGroups",
+			_getCondition(CustomSQLUtil.get(JOIN_BY_USERS_USER_GROUPS)));
 
 		_whereMap = whereMap;
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1547,7 +1547,6 @@ public class GroupFinderImpl
 	private volatile Map<String, String> _joinMap;
 	private final Map<String, String> _replaceJoinAndWhereSQLCache =
 		new ConcurrentHashMap<>();
-	private volatile Long _userGroupClassNameId;
 	private volatile Map<String, String> _whereMap;
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
@@ -236,10 +236,10 @@ public class MainServlet extends ActionServlet {
 			if (!StringPool.DEFAULT_CHARSET_NAME.startsWith("UTF-")) {
 				StringBundler sb = new StringBundler(4);
 
-				sb.append("Default JVM charset \"");
+				sb.append("The default JVM character set \"");
 				sb.append(StringPool.DEFAULT_CHARSET_NAME);
-				sb.append("\" is not UTF, please review JVM file.encoding ");
-				sb.append("property");
+				sb.append("\" is not UTF. Please review the JVM property ");
+				sb.append("\"file.encoding\".");
 
 				_log.warn(sb.toString());
 			}
@@ -251,10 +251,10 @@ public class MainServlet extends ActionServlet {
 
 				StringBundler sb = new StringBundler(4);
 
-				sb.append("Default JVM timezone \"");
+				sb.append("The default JVM time zone \"");
 				sb.append(userTimeZone);
-				sb.append("\" is not UTC or GMT, please review JVM ");
-				sb.append("user.timezone property");
+				sb.append("\" is not UTC or GMT. Please review the JVM ");
+				sb.append("property \"user.timezone\".");
 
 				_log.warn(sb.toString());
 			}

--- a/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
@@ -227,6 +227,27 @@ public class MainServlet extends ActionServlet {
 		}
 
 		if (_log.isDebugEnabled()) {
+			_log.debug("Verify JVM configuration");
+		}
+
+		String defaultCharsetName = StringPool.DEFAULT_CHARSET_NAME;
+
+		if (!defaultCharsetName.startsWith("UTF-")) {
+			_log.error(
+				"Default JVM charset configuration [" + defaultCharsetName +
+				"] is not UTF, please review JVM file.encoding configuration");
+		}
+
+		String userTimeZone = System.getProperty("user.timezone");
+
+		if (!"UTC".equals(userTimeZone) && !"GMT".equals(userTimeZone)) {
+			_log.error(
+				"Default JVM timezone configuration [" + userTimeZone + "] " +
+				"is not UTC or GMT, please review JVM user.timezone " +
+				"configuration");
+		}
+
+		if (_log.isDebugEnabled()) {
 			_log.debug("Process startup events");
 		}
 

--- a/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.util.PortalLifecycleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -110,6 +111,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.portlet.PortletConfig;
@@ -230,21 +232,32 @@ public class MainServlet extends ActionServlet {
 			_log.debug("Verify JVM configuration");
 		}
 
-		String defaultCharsetName = StringPool.DEFAULT_CHARSET_NAME;
+		if (_log.isWarnEnabled()) {
+			if (!StringPool.DEFAULT_CHARSET_NAME.startsWith("UTF-")) {
+				StringBundler sb = new StringBundler(4);
 
-		if (!defaultCharsetName.startsWith("UTF-")) {
-			_log.error(
-				"Default JVM charset configuration [" + defaultCharsetName +
-				"] is not UTF, please review JVM file.encoding configuration");
-		}
+				sb.append("Default JVM charset \"");
+				sb.append(StringPool.DEFAULT_CHARSET_NAME);
+				sb.append("\" is not UTF, please review JVM file.encoding ");
+				sb.append("property");
 
-		String userTimeZone = System.getProperty("user.timezone");
+				_log.warn(sb.toString());
+			}
 
-		if (!"UTC".equals(userTimeZone) && !"GMT".equals(userTimeZone)) {
-			_log.error(
-				"Default JVM timezone configuration [" + userTimeZone + "] " +
-				"is not UTC or GMT, please review JVM user.timezone " +
-				"configuration");
+			String userTimeZone = System.getProperty("user.timezone");
+
+			if (!Objects.equals("UTC", userTimeZone) &&
+				!Objects.equals("GMT", userTimeZone)) {
+
+				StringBundler sb = new StringBundler(4);
+
+				sb.append("Default JVM timezone \"");
+				sb.append(userTimeZone);
+				sb.append("\" is not UTC or GMT, please review JVM ");
+				sb.append("user.timezone property");
+
+				_log.warn(sb.toString());
+			}
 		}
 
 		if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portlet/PortletContextFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletContextFactoryImpl.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portlet;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletApp;
 import com.liferay.portal.kernel.portlet.PortletContextFactory;
@@ -80,9 +78,6 @@ public class PortletContextFactoryImpl implements PortletContextFactory {
 	public void destroy(Portlet portlet) {
 		_pool.remove(portlet.getRootPortletId());
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		PortletContextFactoryImpl.class);
 
 	private final Map<String, Map<String, PortletContext>> _pool =
 		new ConcurrentHashMap<>();

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -38,18 +38,21 @@ import java.util.Map;
  * Provides the local service for accessing, adding, checking, deleting,
  * subscription handling of, trash handling of, and updating blog entries.
  *
- * @author Brian Wing Shun Chan
- * @author Wilson S. Man
- * @author Raymond Augé
- * @author Thiago Moreira
- * @author Juan Fernández
- * @author Zsolt Berentey
+ * @author     Brian Wing Shun Chan
+ * @author     Wilson S. Man
+ * @author     Raymond Augé
+ * @author     Thiago Moreira
+ * @author     Juan Fernández
+ * @author     Zsolt Berentey
  * @deprecated As of 7.0.0, replaced by {@link
  *             com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl}
  */
 @Deprecated
 public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public Folder addAttachmentsFolder(long userId, long groupId)
 		throws PortalException {
@@ -59,6 +62,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void addCoverImage(long entryId, ImageSelector imageSelector)
 		throws PortalException {
@@ -68,6 +74,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry addEntry(
 			long userId, String title, String content, Date displayDate,
@@ -79,6 +88,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry addEntry(
 			long userId, String title, String content,
@@ -91,6 +103,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	}
 
 	/**
+	 * @throws     PortalException
 	 * @deprecated As of 7.0.0, replaced by {@link #addEntry(long, String,
 	 *             String, String, String, int, int, int, int, int, boolean,
 	 *             boolean, String[], String, ImageSelector, ImageSelector,
@@ -112,6 +125,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry addEntry(
@@ -128,6 +144,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry addEntry(
 			long userId, String title, String subtitle, String description,
@@ -145,6 +164,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void addEntryResources(
 			BlogsEntry entry, boolean addGroupPermissions,
@@ -156,6 +178,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void addEntryResources(
 			BlogsEntry entry, ModelPermissions modelPermissions)
@@ -166,6 +191,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void addEntryResources(
 			long entryId, boolean addGroupPermissions,
@@ -177,6 +205,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void addEntryResources(
 			long entryId, ModelPermissions modelPermissions)
@@ -187,6 +218,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public long addOriginalImageFileEntry(
 			long userId, long groupId, long entryId,
@@ -198,6 +232,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void addSmallImage(long entryId, ImageSelector imageSelector)
 		throws PortalException {
@@ -207,6 +244,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void checkEntries() throws PortalException {
 		throw new UnsupportedOperationException(
@@ -214,6 +254,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void deleteEntries(long groupId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -221,6 +264,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
@@ -230,6 +276,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void deleteEntry(long entryId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -264,6 +313,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry[] getEntriesPrevAndNext(long entryId)
 		throws PortalException {
@@ -273,6 +325,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry getEntry(long entryId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -280,6 +335,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry getEntry(long groupId, String urlTitle)
 		throws PortalException {
@@ -384,6 +442,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void moveEntriesToTrash(long groupId, long userId)
 		throws PortalException {
@@ -400,6 +461,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	 * @param  userId the primary key of the user moving the blogs entry
 	 * @param  entry the blogs entry to be moved
 	 * @return the moved blogs entry
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
@@ -417,6 +479,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	 * @param  userId the primary key of the user moving the blogs entry
 	 * @param  entryId the primary key of the blogs entry to be moved
 	 * @return the moved blogs entry
+	 * @throws PortalException
 	 */
 	@Override
 	public BlogsEntry moveEntryToTrash(long userId, long entryId)
@@ -434,6 +497,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	 * @param  userId the primary key of the user restoring the blogs entry
 	 * @param  entryId the primary key of the blogs entry to be restored
 	 * @return the restored blogs entry from the recycle bin
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
@@ -445,6 +509,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void subscribe(long userId, long groupId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -452,6 +519,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void unsubscribe(long userId, long groupId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -459,6 +529,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void updateAsset(
 			long userId, BlogsEntry entry, long[] assetCategoryIds,
@@ -470,6 +543,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry updateEntry(
 			long userId, long entryId, String title, String content,
@@ -482,6 +558,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	}
 
 	/**
+	 * @throws     PortalException
 	 * @deprecated As of 7.0.0, replaced by {@link #updateEntry(long, long,
 	 *             String, String, String, String, int, int, int, int, int,
 	 *             boolean, boolean, String[], String, ImageSelector,
@@ -504,6 +581,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry updateEntry(
@@ -521,6 +601,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry updateEntry(
 			long userId, long entryId, String title, String subtitle,
@@ -538,6 +621,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void updateEntryResources(
 			BlogsEntry entry, ModelPermissions modelPermissions)
@@ -548,6 +634,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void updateEntryResources(
 			BlogsEntry entry, String[] groupPermissions,
@@ -560,6 +649,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	}
 
 	/**
+	 * @throws     PortalException
 	 * @deprecated As of 7.0.0, replaced by {@link #updateStatus(long, long,
 	 *             int, ServiceContext, Map)}
 	 */
@@ -575,6 +665,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry updateStatus(

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -32,8 +32,8 @@ import java.util.List;
  * handling of, trash handling of, and updating blog entries. Its methods
  * include permission checks.
  *
- * @author Brian Wing Shun Chan
- * @author Mate Thurzo
+ * @author     Brian Wing Shun Chan
+ * @author     Mate Thurzo
  * @deprecated As of 7.0.0, replaced by {@link
  *             com.liferay.blogs.service.impl.BlogsEntryServiceImpl}
  */
@@ -41,6 +41,7 @@ import java.util.List;
 public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 
 	/**
+	 * @throws     PortalException
 	 * @deprecated As of 7.0.0, replaced by {@link #addEntry(String, String,
 	 *             String, String, int, int, int, int, int, boolean, boolean,
 	 *             String[], String, ImageSelector, ImageSelector,
@@ -62,6 +63,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry addEntry(
 			String title, String subtitle, String description, String content,
@@ -78,6 +82,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void deleteEntry(long entryId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -85,6 +92,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public List<BlogsEntry> getCompanyEntries(
 			long companyId, Date displayDate, int status, int max)
@@ -95,6 +105,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public String getCompanyEntriesRSS(
 			long companyId, Date displayDate, int status, int max, String type,
@@ -107,6 +120,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry getEntry(long entryId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -114,6 +130,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry getEntry(long groupId, String urlTitle)
 		throws PortalException {
@@ -183,6 +202,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public String getGroupEntriesRSS(
 			long groupId, Date displayDate, int status, int max, String type,
@@ -195,6 +217,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public List<BlogsEntry> getGroupsEntries(
 			long companyId, long groupId, Date displayDate, int status, int max)
@@ -241,6 +266,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public List<BlogsEntry> getOrganizationEntries(
 			long organizationId, Date displayDate, int status, int max)
@@ -251,6 +279,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public String getOrganizationEntriesRSS(
 			long organizationId, Date displayDate, int status, int max,
@@ -263,6 +294,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry moveEntryToTrash(long entryId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -270,6 +304,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void restoreEntryFromTrash(long entryId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -277,6 +314,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void subscribe(long groupId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -284,6 +324,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void unsubscribe(long groupId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -292,6 +335,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	/**
+	 * @throws     PortalException
 	 * @deprecated As of 7.0.0, replaced by {@link #updateEntry(long, String,
 	 *             String, String, String, int, int, int, int, int, boolean,
 	 *             boolean, String[], String, ImageSelector, ImageSelector,
@@ -313,6 +357,9 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 				"com.liferay.blogs.service.impl.BlogsEntryServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsEntry updateEntry(
 			long entryId, String title, String subtitle, String description,

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
@@ -23,8 +23,8 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * @author Brian Wing Shun Chan
- * @author Mate Thurzo
+ * @author     Brian Wing Shun Chan
+ * @author     Mate Thurzo
  * @deprecated As of 7.0.0, replaced by {@link
  *             com.liferay.blogs.service.impl.BlogsStatsUserLocalServiceImpl}
  */
@@ -40,6 +40,9 @@ public class BlogsStatsUserLocalServiceImpl
 					"BlogsStatsUserLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void deleteStatsUser(long statsUserId) throws PortalException {
 		throw new UnsupportedOperationException(
@@ -161,6 +164,9 @@ public class BlogsStatsUserLocalServiceImpl
 					"BlogsStatsUserLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public BlogsStatsUser getStatsUser(long groupId, long userId)
 		throws PortalException {
@@ -171,6 +177,9 @@ public class BlogsStatsUserLocalServiceImpl
 					"BlogsStatsUserLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void updateStatsUser(long groupId, long userId)
 		throws PortalException {
@@ -181,6 +190,9 @@ public class BlogsStatsUserLocalServiceImpl
 					"BlogsStatsUserLocalServiceImpl");
 	}
 
+	/**
+	 * @throws PortalException
+	 */
 	@Override
 	public void updateStatsUser(long groupId, long userId, Date displayDate)
 		throws PortalException {

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -427,17 +427,6 @@
 				(Users_Groups.userId = ?)
 		]]>
 	</sql>
-	<sql id="com.liferay.portal.kernel.service.persistence.GroupFinder.joinByUsersUserGroups">
-		<![CDATA[
-			INNER JOIN Groups_UserGroups
-				ON (Groups_UserGroups.groupId = Group_.groupId)
-			INNER JOIN Users_UserGroups
-				ON (Users_UserGroups.userGroupId = Groups_UserGroups.userGroupId)
-			WHERE
-				(Group_.liveGroupId = 0) AND
-				(Users_UserGroups.userId = ?)
-		]]>
-	</sql>
 	<sql id="com.liferay.portal.kernel.service.persistence.LayoutFinder.findByNoPermissions">
 		<![CDATA[
 			SELECT

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -427,6 +427,17 @@
 				(Users_Groups.userId = ?)
 		]]>
 	</sql>
+	<sql id="com.liferay.portal.kernel.service.persistence.GroupFinder.joinByUsersUserGroups">
+		<![CDATA[
+			INNER JOIN Groups_UserGroups
+				ON (Groups_UserGroups.groupId = Group_.groupId)
+			INNER JOIN Users_UserGroups
+				ON (Users_UserGroups.userGroupId = Groups_UserGroups.userGroupId)
+			WHERE
+				(Group_.liveGroupId = 0) AND
+				(Users_UserGroups.userId = ?)
+		]]>
+	</sql>
 	<sql id="com.liferay.portal.kernel.service.persistence.LayoutFinder.findByNoPermissions">
 		<![CDATA[
 			SELECT

--- a/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
@@ -296,7 +296,7 @@ public class GroupServiceTest {
 			initialTagsCount + 1,
 			AssetTagLocalServiceUtil.getGroupTagsCount(group.getGroupId()));
 
-		User user = UserTestUtil.addUser(group.getGroupId());
+		UserTestUtil.addUser(group.getGroupId());
 
 		GroupLocalServiceUtil.deleteGroup(group.getGroupId());
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
@@ -150,7 +150,11 @@ public class AssetEntryQuery {
 
 		if (Validator.isNotNull(tagName)) {
 			_allTagIds = AssetTagLocalServiceUtil.getTagIds(
-				themeDisplay.getSiteGroupId(), new String[] {tagName});
+				themeDisplay.getScopeGroupId(), new String[] {tagName});
+
+			if (_allTagIds.length == 0) {
+				_allTagIds = new long[] {0};
+			}
 
 			_allTagIdsArray = new long[][] {_allTagIds};
 		}

--- a/portal-kernel/src/com/liferay/asset/kernel/util/BaseAssetEntryQueryProcessor.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/util/BaseAssetEntryQueryProcessor.java
@@ -46,14 +46,17 @@ public abstract class BaseAssetEntryQueryProcessor
 	 * @deprecated As of 7.0.0
 	 */
 	@Deprecated
+	@Override
 	public String getTitle(Locale locale) {
 		return StringPool.BLANK;
 	}
 
 	/**
 	 * @deprecated As of 7.0.0
+	 * @throws IOException
 	 */
 	@Deprecated
+	@Override
 	public void include(
 			HttpServletRequest request, HttpServletResponse response)
 		throws IOException {

--- a/portal-kernel/src/com/liferay/portal/kernel/executor/PortalExecutorManagerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/executor/PortalExecutorManagerUtil.java
@@ -104,9 +104,6 @@ public class PortalExecutorManagerUtil {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalExecutorManagerUtil.class);
 
-	private static final PortalExecutorManagerUtil _instance =
-		new PortalExecutorManagerUtil();
-
 	private static volatile PortalExecutorManager _portalExecutorManager =
 		ProxyFactory.newServiceTrackedInstanceWithoutDummyService(
 			PortalExecutorManager.class, PortalExecutorManagerUtil.class,

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageBusUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageBusUtil.java
@@ -222,8 +222,6 @@ public class MessageBusUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(MessageBusUtil.class);
 
-	private static final MessageBusUtil _instance = new MessageBusUtil();
-
 	private static volatile MessageBus _messageBus =
 		ProxyFactory.newServiceTrackedInstanceWithoutDummyService(
 			MessageBus.class, MessageBusUtil.class, "_messageBus");

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auto/login/AutoLogin.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auto/login/AutoLogin.java
@@ -37,8 +37,7 @@ public interface AutoLogin {
 		"AUTO_LOGIN_REDIRECT_AND_CONTINUE";
 
 	/**
-	 * @deprecated As of 7.0.0, with no replacement. This method is no longer
-	 *             used.
+	 * @deprecated As of 7.0.0, with no direct replacement
 	 */
 	@Deprecated
 	public String[] handleException(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auto/login/BaseAutoLogin.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auto/login/BaseAutoLogin.java
@@ -28,6 +28,10 @@ import javax.servlet.http.HttpServletResponse;
  */
 public abstract class BaseAutoLogin implements AutoLogin {
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public String[] handleException(
 			HttpServletRequest request, HttpServletResponse response,

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
@@ -505,7 +505,7 @@ public class StringUtilTest {
 
 	@Test
 	public void testShortenStringWith4ByteChars() {
-		int space = (int)CharPool.SPACE;
+		int space = CharPool.SPACE;
 
 		int[] codePoints = new int[] {
 			128515, 128516, space, 128517, 128518, 128519, 128520, 128521

--- a/portal-kernel/test/unit/com/liferay/portal/modules/ModulesStructureTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/modules/ModulesStructureTest.java
@@ -473,8 +473,6 @@ public class ModulesStructureTest {
 
 		// LPS-67772
 
-		Path dirNamePath = dirPath.getFileName();
-
 		Path gitAttributesPath = dirPath.resolve(".gitattributes");
 
 		Assert.assertTrue(

--- a/portal-web/docroot/html/taglib/ui/asset_tags_navigation/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_tags_navigation/page.jsp
@@ -65,7 +65,7 @@ private String _buildTagsNavigation(long scopeGroupId, long siteGroupId, String 
 		tags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 	}
 	else {
-		tags = AssetTagServiceUtil.getGroupTags(siteGroupId, 0, maxAssetTags, new AssetTagCountComparator());
+		tags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
 	}
 
 	if (tags.isEmpty()) {

--- a/util-taglib/src/com/liferay/taglib/util/DummyVelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/DummyVelocityTaglib.java
@@ -25,8 +25,6 @@ import com.liferay.taglib.ui.BreadcrumbTag;
 import com.liferay.taglib.ui.DiscussionTag;
 import com.liferay.taglib.ui.IconTag;
 import com.liferay.taglib.ui.JournalArticleTag;
-import com.liferay.taglib.ui.MySitesTag;
-import com.liferay.taglib.ui.PngImageTag;
 import com.liferay.taglib.ui.RatingsTag;
 
 import javax.portlet.PortletURL;
@@ -160,8 +158,12 @@ public class DummyVelocityTaglib implements VelocityTaglib {
 		return null;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
-	public MySitesTag getMySitesTag() {
+	public com.liferay.taglib.ui.MySitesTag getMySitesTag() {
 		return null;
 	}
 
@@ -170,8 +172,12 @@ public class DummyVelocityTaglib implements VelocityTaglib {
 		return null;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
-	public PngImageTag getPngImageTag() {
+	public com.liferay.taglib.ui.PngImageTag getPngImageTag() {
 		return null;
 	}
 

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
@@ -26,8 +26,6 @@ import com.liferay.taglib.ui.BreadcrumbTag;
 import com.liferay.taglib.ui.DiscussionTag;
 import com.liferay.taglib.ui.IconTag;
 import com.liferay.taglib.ui.JournalArticleTag;
-import com.liferay.taglib.ui.MySitesTag;
-import com.liferay.taglib.ui.PngImageTag;
 import com.liferay.taglib.ui.RatingsTag;
 
 import javax.portlet.PortletURL;
@@ -121,11 +119,19 @@ public interface VelocityTaglib {
 
 	public JournalArticleTag getJournalArticleTag() throws Exception;
 
-	public MySitesTag getMySitesTag() throws Exception;
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
+	public com.liferay.taglib.ui.MySitesTag getMySitesTag() throws Exception;
 
 	public PageContext getPageContext();
 
-	public PngImageTag getPngImageTag() throws Exception;
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
+	public com.liferay.taglib.ui.PngImageTag getPngImageTag() throws Exception;
 
 	public RatingsTag getRatingsTag() throws Exception;
 

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
@@ -34,7 +34,6 @@ import com.liferay.taglib.portletext.RuntimeTag;
 import com.liferay.taglib.security.DoAsURLTag;
 import com.liferay.taglib.security.PermissionsURLTag;
 import com.liferay.taglib.servlet.PipingPageContext;
-import com.liferay.taglib.theme.LayoutIconTag;
 import com.liferay.taglib.theme.MetaTagsTag;
 import com.liferay.taglib.theme.WrapPortletTag;
 import com.liferay.taglib.ui.AssetCategoriesSummaryTag;
@@ -44,12 +43,8 @@ import com.liferay.taglib.ui.BreadcrumbTag;
 import com.liferay.taglib.ui.DiscussionTag;
 import com.liferay.taglib.ui.IconTag;
 import com.liferay.taglib.ui.JournalArticleTag;
-import com.liferay.taglib.ui.JournalContentSearchTag;
 import com.liferay.taglib.ui.LanguageTag;
-import com.liferay.taglib.ui.MySitesTag;
-import com.liferay.taglib.ui.PngImageTag;
 import com.liferay.taglib.ui.RatingsTag;
-import com.liferay.taglib.ui.SearchTag;
 import com.liferay.taglib.ui.SitesDirectoryTag;
 import com.liferay.taglib.ui.SocialBookmarksTag;
 import com.liferay.taglib.ui.ToggleTag;
@@ -367,9 +362,14 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		return journalArticleTag;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
-	public MySitesTag getMySitesTag() throws Exception {
-		MySitesTag mySitesTag = new MySitesTag();
+	public com.liferay.taglib.ui.MySitesTag getMySitesTag() throws Exception {
+		com.liferay.taglib.ui.MySitesTag mySitesTag =
+			new com.liferay.taglib.ui.MySitesTag();
 
 		setUp(mySitesTag);
 
@@ -381,9 +381,14 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		return _pageContext;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
-	public PngImageTag getPngImageTag() throws Exception {
-		PngImageTag pngImageTag = new PngImageTag();
+	public com.liferay.taglib.ui.PngImageTag getPngImageTag() throws Exception {
+		com.liferay.taglib.ui.PngImageTag pngImageTag =
+			new com.liferay.taglib.ui.PngImageTag();
 
 		setUp(pngImageTag);
 
@@ -481,12 +486,16 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		journalContentSearch(true, null);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void journalContentSearch(boolean showListed, String targetPortletId)
 		throws Exception {
 
-		JournalContentSearchTag journalContentSearchTag =
-			new JournalContentSearchTag();
+		com.liferay.taglib.ui.JournalContentSearchTag journalContentSearchTag =
+			new com.liferay.taglib.ui.JournalContentSearchTag();
 
 		setUp(journalContentSearchTag);
 
@@ -542,9 +551,14 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		languageTag.runTag();
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void layoutIcon(Layout layout) throws Exception {
-		LayoutIconTag.doTag(layout, _servletContext, _request, _response);
+		com.liferay.taglib.theme.LayoutIconTag.doTag(
+			layout, _servletContext, _request, _response);
 	}
 
 	@Override
@@ -552,18 +566,28 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		MetaTagsTag.doTag(_servletContext, _request, _response);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void mySites() throws Exception {
-		MySitesTag mySitesTag = new MySitesTag();
+		com.liferay.taglib.ui.MySitesTag mySitesTag =
+			new com.liferay.taglib.ui.MySitesTag();
 
 		setUp(mySitesTag);
 
 		mySitesTag.runTag();
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void mySites(int max) throws Exception {
-		MySitesTag mySitesTag = new MySitesTag();
+		com.liferay.taglib.ui.MySitesTag mySitesTag =
+			new com.liferay.taglib.ui.MySitesTag();
 
 		setUp(mySitesTag);
 
@@ -806,9 +830,14 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 			_pageContext, _request, _response);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void search() throws Exception {
-		SearchTag searchTag = new SearchTag();
+		com.liferay.taglib.ui.SearchTag searchTag =
+			new com.liferay.taglib.ui.SearchTag();
 
 		setUp(searchTag);
 


### PR DESCRIPTION
Tag navigation now shows global tags; Asset searches using tags in portlets now respects portlet's scope

Assumptions:
1. Tags only show up if they're part of the specific scope. Ex: Global tags don't show up in site scope, and vice versa.
2. When doing an asset search with tag, NO assets will show up unless they have that specific tag.