### PR TITLE
LPS-69226

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/user_thread_columns.jspf
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/user_thread_columns.jspf
@@ -63,6 +63,7 @@
 	<liferay-ui:search-container-column-status
 		href="<%= rowURL %>"
 		name="status"
+		status="<%= thread.getStatus() %>"
 	/>
 </c:if>
 


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPP-23229
https://issues.liferay.com/browse/LPS-69226


When using the Tags Navigation portlet on a page together with a Message Boards portlet, while the Message Boards portlet has "My Posts" selected, clicking one of the tags will cause any results returned to throw an error because of a missing "status" field in the search container. This comes from user_thread_columns.jspf, where the values for all of the search container columns are explicitly set, except for the status column.

Explicitly setting the value of this column resolves this issue (using the same pattern as some other `search-container-column-status` columns in Liferay, such as https://github.com/liferay/liferay-portal/blob/master/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp#L409).

Let me know if there are any problems with this. Thanks!