### PR TITLE
LPS-69041 IE11

### DIFF
--- a/portal-web/docroot/html/taglib/aui/select/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/select/end.jsp
@@ -38,3 +38,17 @@
 		</label>
 	</c:if>
 </div>
+
+<aui:script>
+	var ie11 = Liferay.Browser.isIe() && Liferay.Browser.getMajorVersion() == 11.0;
+
+	if (ie11) {
+		var select = AUI.$('#<%= namespace + id %>');
+
+		select.mousedown(
+			function() {
+				this.focus();
+			}
+		);
+	}
+</aui:script>


### PR DESCRIPTION
Previous PR [here](https://github.com/jonmak08/liferay-portal/pull/1627)

Select Bar no longer extends too far after switching focus

Implementing Byran Zaugg's [solution](https://issues.liferay.com/browse/LPP-22880?focusedCommentId=895359&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-895359) with a few small changes

