### PR TITLE
LPS-69305 Google's minifier treats variable access as dead code, so a…

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/build.gradle
@@ -106,6 +106,12 @@ buildLexicon {
 
 	eachFile new StripPathSegmentsAction(7)
 
+	filter {
+		String line ->
+
+		line.replace ".offsetWidth // force reflow", ".offsetWidth.toFixed() // force reflow"
+	}
+
 	from {
 		zipTree(configurations.lexicon.singleFile)
 	}


### PR DESCRIPTION
…pply equivalent NOOP

Resending because of an error in the original PR.  Also smashed all commits into 1 by Minhchau's recommendation as the extra commits were largely superfluous.