### PR TITLE
LPS-69384 Account for portal.proxy.path when comparing with portal contextPath

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
+++ b/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
@@ -410,7 +410,8 @@ public class IncludeTag extends AttributesTagSupport {
 		sb.append(page);
 		sb.append(" in the context ");
 
-		String contextPath = servletContext.getContextPath();
+		String contextPath = PortalUtil.getPathContext(
+			servletContext.getContextPath());
 
 		if (contextPath.equals(StringPool.BLANK)) {
 			contextPath = StringPool.SLASH;


### PR DESCRIPTION
Hey @SamZiemer,

**Issue** 
Currently, it looks like warning messages are being displayed unintentionally.
This is currently happening when we set a custom value for the property: **portal.proxy.path**

**Background Information**
The method, **logUnavailablePage(String page)**, was mainly created to help developers when working with OSGI and our taglibs.
Reference: https://github.com/liferay/liferay-portal/commit/209594bbfc73e3a84c8c48e266239430fafb4ce5

**Similar Issue**
There was a similar issue in the past, which occurred when we use a different context name, other than the default ROOT.  Basically, the changes refined the comparisons between the **servlet contextPath** and the **portal contextPath**.
Reference: https://github.com/liferay/liferay-portal/commit/3ab8a13b4315a864d79060540a7f55dcfa7df9c4

**Changes**
The changes in this commit are to make sure that the **portal.proxy.path** is accounted for when comparing the **servlet contextPath** with the **portal contextPath**.

The portal contextPath, by default, prepends the **portal.proxy.path**

----
Please let me know if you have any questions.
Thanks!
