### PR TITLE
LPS 69104

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
@@ -288,9 +288,7 @@ public class ServletContextHelperRegistrationImpl
 			return contextPath;
 		}
 
-		String symbolicName = _bundle.getSymbolicName();
-
-		return '/' + symbolicName.replaceAll("[^a-zA-Z0-9]", "");
+		return '/' + _bundle.getSymbolicName();
 	}
 
 	protected String getServletContextName(String contextPath) {
@@ -302,9 +300,7 @@ public class ServletContextHelperRegistrationImpl
 			return header;
 		}
 
-		contextPath = contextPath.substring(1);
-
-		return contextPath.replaceAll("[^a-zA-Z0-9\\-]", "");
+		return contextPath.substring(1);
 	}
 
 	protected void registerServletContext() {

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
@@ -53,7 +53,6 @@ public class ServletContextHelperRegistrationImpl
 		Map<String, Object> properties) {
 
 		_bundle = bundle;
-		_logger = logger;
 		_properties = properties;
 
 		String contextPath = getContextPath();
@@ -66,7 +65,7 @@ public class ServletContextHelperRegistrationImpl
 			_wabShapedBundle = true;
 
 			WebXMLDefinitionLoader webXMLDefinitionLoader =
-				new WebXMLDefinitionLoader(_bundle, saxParserFactory, _logger);
+				new WebXMLDefinitionLoader(_bundle, saxParserFactory, logger);
 
 			WebXMLDefinition webXMLDefinition = null;
 
@@ -330,7 +329,6 @@ public class ServletContextHelperRegistrationImpl
 	private final CustomServletContextHelper _customServletContextHelper;
 	private final ServiceRegistration<?> _defaultServletServiceRegistration;
 	private final ServiceRegistration<Servlet> _jspServletServiceRegistration;
-	private final Logger _logger;
 	private final ServiceRegistration<Servlet>
 		_portletServletServiceRegistration;
 	private final Map<String, Object> _properties;

--- a/portal-kernel/src/com/liferay/portal/kernel/bean/PortletBeanLocatorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/bean/PortletBeanLocatorUtil.java
@@ -17,7 +17,6 @@ package com.liferay.portal.kernel.bean;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,18 +39,13 @@ public class PortletBeanLocatorUtil {
 		BeanLocator beanLocator = getBeanLocator(servletContextName);
 
 		if (beanLocator == null) {
-			beanLocator = getBeanLocator(
-				StringUtil.strip(servletContextName, '.'));
+			_log.error(
+				"BeanLocator is null for servlet context " +
+					servletContextName);
 
-			if (beanLocator == null) {
-				_log.error(
-					"BeanLocator is null for servlet context " +
-						servletContextName);
-
-				throw new BeanLocatorException(
-					"BeanLocator is not set for servlet context " +
-						servletContextName);
-			}
+			throw new BeanLocatorException(
+				"BeanLocator is not set for servlet context " +
+					servletContextName);
 		}
 
 		return beanLocator.locate(name);


### PR DESCRIPTION
This fix replaces the previous fix connected to [LPS-69104](https://github.com/brianchandotcom/liferay-portal/pull/44871): 

After extensive testing, searching, and help from @Preston-Crary, I discovered that Liferay's filtering of OSGI custom portlet context [names](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java#L308) & [paths](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java#L294) are unnecessary due to our implementation of [Equinox OSGI already filtering out improper characters in the context name](https://git.eclipse.org/c/equinox/rt.equinox.bundles.git/commit/?id=34c2425bdadb56dad5e6453415ecf58de0d158a8). Therefore, we can get rid of the unnecessary character stripping which is causing our customers' problems.