### PR TITLE
LPS-69514

### DIFF
--- a/modules/apps/web-experience/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
@@ -86,6 +86,16 @@ Map<Long, Integer> groupUsersCounts = UserLocalServiceUtil.searchCounts(company.
 		%>
 
 		<aui:nav-item href="<%= availableSitesURL.toString() %>" id="availableSites" label="available-sites" selected='<%= tabs1.equals("available-sites") %>' />
+
+		<c:choose>
+			<c:when test="<%= tabs1.equals("my-sites") && Validator.isNotNull(searchTerms.getKeywords())%>">
+				<aui:nav-item href="<%= mySitesURL.toString() %>" id="back" label="back" />
+			</c:when>
+			<c:when test="<%= tabs1.equals("available-sites") && Validator.isNotNull(searchTerms.getKeywords())%>">
+				<aui:nav-item href="<%= availableSitesURL.toString() %>" id="back" label="back" />
+			</c:when>
+		</c:choose>
+
 	</aui:nav>
 
 	<aui:nav-bar-search>


### PR DESCRIPTION
Commit: Back Button now Available for My Sites Portlet

[Unfortunately, many portlets](https://issues.liferay.com/browse/LEXI-72) have different implementations of the back button:

- Blogs and Web Content Search use the Liferay Display Portlet class to instantiate a back button
- My Sites Directory uses Liferay-UI tabs
- My Sites currently is implementing the Nav Bar. 

As such, I'll be continuing Eric Chi's back button implementation which plays cohesively with the Nav Bar, and I'll be hiding the back button when no search is occurring.

Referencing the issue found in #132 , it seems that the Web Content Search portlet and My Sites portlet don't play well nicely at the get go. Simply searching in the My Sites portlets causes the WCS portlet to show it's last searched item (as shown in the gif below):

![search](https://cloud.githubusercontent.com/assets/1487616/20948747/7a7f54ac-bbca-11e6-8307-1a639ebbf0a6.gif)


Finally, UX will be modifying and streamlining all the back button implementations ([LEXI-72](https://issues.liferay.com/browse/LEXI-72)), so this fix will probably be rewritten by UX in the near future. 

