### PR TITLE
LPS-69514

### DIFF
--- a/modules/apps/web-experience/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
@@ -64,6 +64,12 @@ groupSearch.setResults(groups);
 long[] groupIds = ListUtil.toLongArray(groups, Group.GROUP_ID_ACCESSOR);
 
 Map<Long, Integer> groupUsersCounts = UserLocalServiceUtil.searchCounts(company.getCompanyId(), WorkflowConstants.STATUS_APPROVED, groupIds);
+
+if (Validator.isNotNull(searchTerms.getKeywords())) {
+	String redirect = ParamUtil.getString(request, "redirect");
+	portletDisplay.setShowBackIcon(true);
+	portletDisplay.setURLBack(redirect);
+}
 %>
 
 <liferay-ui:success key="membershipRequestSent" message="your-request-was-sent-you-will-receive-a-reply-by-email" />


### PR DESCRIPTION
Continuation of #138 

Commit msg: Back Button now Available for My Sites Portlet

After talking with Sam, we came to the conclusion that implementing the back button through `portletDisplay` would be the best option. This behaviour mimics most portlets, with this solution taking code from the blog portlet specifically. There also didn't seem to be a straightforward way of telling whether a search had been initiated, so I checked to see if there was a search term in use to show the back button.