### PR TITLE
LPS-69669 Update org.apache.felix.scr to 2.0.6

### DIFF
--- a/modules/apps/static/required-dependencies/required-dependencies/build.gradle
+++ b/modules/apps/static/required-dependencies/required-dependencies/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	provided group: "org.apache.felix", name: "org.apache.felix.gogo.command", transitive: false, version: "0.12.0"
 	provided group: "org.apache.felix", name: "org.apache.felix.gogo.runtime", transitive: false, version: "0.10.0"
 	provided group: "org.apache.felix", name: "org.apache.felix.gogo.shell", transitive: false, version: "0.10.0"
-	provided group: "org.apache.felix", name: "org.apache.felix.scr", transitive: false, version: "2.0.2"
+	provided group: "org.apache.felix", name: "org.apache.felix.scr", transitive: false, version: "2.0.6"
 	provided group: "org.glassfish", name: "javax.el", transitive: false, version: "3.0.1-b05"
 	provided group: "org.osgi", name: "org.osgi.service.metatype", transitive: false, version: "1.3.0"
 


### PR DESCRIPTION
Hey @SamZiemer,

Original Ticket: [LPS-69669](https://issues.liferay.com/browse/LPS-69669)

This fix is basically to use a newer version of Apache Felix SCR as a dependency.

**Quick explanation on how we decided on this fix**
While investigating [LPP-23581](https://issues.liferay.com/browse/LPP-23581), I found a related ticket that had a similar description to this isuse: [FELIX-5270](https://issues.apache.org/jira/browse/FELIX-5270).  We think this is what fixed the bug in the newer version of Apache Felix SCR.

We tested using the newer Apache Felix SCR in Liferay, and our issue was resolved.

----
Please let me know if you have any questions.
Thanks!