### PR TITLE
LPS-69679 

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/definition/WebXMLDefinitionLoader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/definition/WebXMLDefinitionLoader.java
@@ -32,6 +32,8 @@ import com.liferay.portal.osgi.web.servlet.context.helper.order.Order.Path;
 
 import java.io.InputStream;
 
+import java.lang.annotation.Annotation;
+
 import java.net.URL;
 
 import java.util.ArrayList;
@@ -952,6 +954,12 @@ public class WebXMLDefinitionLoader extends DefaultHandler {
 
 		try {
 			clazz = bundle.loadClass(className);
+
+			Annotation[] annotations = clazz.getAnnotations();
+
+			if (annotations.length == 0) {
+				return;
+			}
 		}
 		catch (Throwable t) {
 			_logger.log(Logger.LOG_DEBUG, t.getMessage());


### PR DESCRIPTION
Commit msg: Liferay no longer throws exception when unused class annotation is not included in portlet

clazz.getAnnotation() causes an error to be thrown for portlets that don't include all relevant classes that have annotation references in their files. Customer portlets are breaking because of this issue, and so we included clazz.getAnnotation() in a try/catch to escape before the error could be thrown.