### PR TITLE
LPS-69722

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
@@ -217,7 +217,12 @@ if (portletTitleBasedNavigation) {
 
 							<%
 							try {
-								wikiEngineRenderer.renderEditPageHTML(selectedFormat, pageContext, node, wikiPage);
+								if (wikiPage.isNew() && (templatePage != null)) {
+									wikiEngineRenderer.renderEditPageHTML(selectedFormat, pageContext, node, templatePage);
+								}
+								else {
+									wikiEngineRenderer.renderEditPageHTML(selectedFormat, pageContext, node, wikiPage);
+								}
 							}
 							catch (WikiFormatException wfe) {
 							%>

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
@@ -217,7 +217,7 @@ if (portletTitleBasedNavigation) {
 
 							<%
 							try {
-								if (wikiPage.isNew() && (templatePage != null)) {
+								if ((wikiPage != null) && wikiPage.isNew() && (templatePage != null)) {
 									wikiEngineRenderer.renderEditPageHTML(selectedFormat, pageContext, node, templatePage);
 								}
 								else {


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-23657
https://issues.liferay.com/browse/LPS-69722

Re-sending from https://github.com/sergiogonzalez/liferay-portal/pull/3644 with a simple change (as requested in https://github.com/sergiogonzalez/liferay-portal/pull/3644#pullrequestreview-13579503) to prevent NullPointerExceptions (although I couldn't find a use case where this would happen, theoretically it's possible).

Copied from previous pull:

> If copying a Wiki page with an embedded image using Creole, the image will show the "missing" thumbnail rather than the actual image, even though the edit page has the capability of displaying the image. This change will use the original page as a template for rendering the copied images (although they can still be changed while editing).
> 
> This fix is somewhat reliant on the fix for https://issues.liferay.com/browse/LPS-69663 (which was just recently merged into master), because without that fix, copying attachments does not work at all, and embedded images in Creole seem to rely on image attachments.