### PR TITLE
LPS-69881 Recurse on organization parents to properly determine circular organization references.

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -2173,8 +2173,8 @@ public class OrganizationLocalServiceImpl
 			long parentOrganizationId, long organizationId)
 		throws PortalException {
 
-		// Return true if parentOrganizationId is among the parent organizatons
-		// of organizationId
+		// Return true if parentOrganizationId is among the parent/ancestor
+		// organizatons of organizationId
 
 		if (organizationId ==
 				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {
@@ -2193,7 +2193,16 @@ public class OrganizationLocalServiceImpl
 			return true;
 		}
 		else {
-			return false;
+			long ancestorOrganizationId =
+				organization.getParentOrganizationId();
+
+			if (Validator.isNotNull(ancestorOrganizationId)) {
+				return isParentOrganization(
+					parentOrganizationId, ancestorOrganizationId);
+			}
+			else {
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
Ticket : https://issues.liferay.com/browse/LPS-69881

Recursively call isParentOrganization on the organization's parent and only return false after we have searched the entire depth of the ancestor tree.