### PR TITLE
LPS-70065 Pass a currentURL value in the request when opening the control menu

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/control_menu/product_menu_control_menu_entry_icon.jsp
+++ b/modules/apps/web-experience/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/control_menu/product_menu_control_menu_entry_icon.jsp
@@ -46,7 +46,7 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 %>
 
 <li class="control-menu-nav-item <%= Objects.equals(productMenuState, "open") ? "active" : StringPool.BLANK %>">
-	<a class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-qa-id="productMenu" data-target="#<%= portletNamespace %>sidenavSliderId" data-title="<%= HtmlUtil.escape(LanguageUtil.get(request, "menu")) %>" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" <%= Objects.equals(productMenuState, "open") ? StringPool.BLANK : "data-url='" + portletURL.toString() + "'" %> href="javascript:;" id="<%= portletNamespace %>sidenavToggleId">
+	<a class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-qa-id="productMenu" data-target="#<%= portletNamespace %>sidenavSliderId" data-title="<%= HtmlUtil.escape(LanguageUtil.get(request, "menu")) %>" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed" <%= Objects.equals(productMenuState, "open") ? StringPool.BLANK : "data-url='" + portletURL.toString() + StringPool.AMPERSAND + "currentURL=" + PortalUtil.getCurrentURL(request) + "'" %> href="javascript:;" id="<%= portletNamespace %>sidenavToggleId">
 		<div class="toast-animation">
 			<div class="pm"></div>
 


### PR DESCRIPTION
Ticket : https://issues.liferay.com/browse/LPS-70065

When a currentURL is not passed a currentURL is generated to be used as backURL.  The generated currentURL redirects to the distorted CSS page.