### PR TITLE
LPS-70313 Increase visiblity of Document Preview navigation arrows

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_preview.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_preview.scss
@@ -43,6 +43,12 @@
 	right: 0;
 }
 
+.lfr-preview-file-arrow {
+	color: #000;
+	font-size: 30px;
+	font-weight: bold;
+}
+
 .lfr-preview-file-toolbar {
 	display: block;
 }


### PR DESCRIPTION
Ticket : https://issues.liferay.com/browse/LPS-70313

We're changing / creating the styling for the CSS class "lfr-preview-file-arrow", which is uniquely used for Document Preview's arrows.

Screenshots to contrast the UI changes are in the ticket.