### PR TITLE
LPS-66047

### DIFF
--- a/modules/apps/collaboration/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/AnnouncementsWebUpgrade.java
+++ b/modules/apps/collaboration/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/AnnouncementsWebUpgrade.java
@@ -90,7 +90,7 @@ public class AnnouncementsWebUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"com.liferay.announcements.web", "1.0.1", "1.0.2",
-			new UpgradePermission());
+			new UpgradePermission(true));
 
 		// See LPS-69656
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -168,7 +168,7 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=" + CalendarPortletKeys.CALENDAR,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=administrator,guest,power-user,user",
+		"javax.portlet.security-role-ref=administrator,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
 	service = Portlet.class

--- a/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
+++ b/modules/apps/foundation/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
@@ -139,7 +139,7 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=" + ContactsPortletKeys.CONTACTS_CENTER,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=administrator,guest,power-user,user",
+		"javax.portlet.security-role-ref=administrator,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
 	service = Portlet.class

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/AssetPublisherPortlet.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/AssetPublisherPortlet.java
@@ -91,7 +91,7 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=" + AssetPublisherPortletKeys.ASSET_PUBLISHER,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=guest,power-user,user",
+		"javax.portlet.security-role-ref=power-user,user",
 		"javax.portlet.supported-public-render-parameter=categoryId",
 		"javax.portlet.supported-public-render-parameter=resetCur",
 		"javax.portlet.supported-public-render-parameter=tag",

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -586,17 +586,21 @@ public class ResourceActionsImpl implements ResourceActions {
 	public List<String> getResourceGuestUnsupportedActions(
 		String portletResource, String modelResource) {
 
-		List<String> actions = null;
-
 		if (Validator.isNull(modelResource)) {
-			actions = getPortletResourceGuestUnsupportedActions(
-				portletResource);
+			return getPortletResourceGuestUnsupportedActions(portletResource);
+		}
+		else if (Validator.isNull(portletResource)) {
+			return getModelResourceGuestUnsupportedActions(modelResource);
+		}
+		else if (_modelResourceActionsBags.containsKey(modelResource)) {
+			return getModelResourceGuestUnsupportedActions(modelResource);
+		}
+		else if (_portletResourceActionsBags.containsKey(portletResource)) {
+			return getPortletResourceGuestUnsupportedActions(portletResource);
 		}
 		else {
-			actions = getModelResourceGuestUnsupportedActions(modelResource);
+			return Collections.<String>emptyList();
 		}
-
-		return actions;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -1241,6 +1241,8 @@ public class ResourceActionsImpl implements ResourceActions {
 		Set<String> modelResourceActions =
 			modelResourceActionsBag.getResourceActions();
 
+		modelResourceActions.clear();
+
 		readSupportsActions(modelResourceElement, modelResourceActions);
 
 		checkModelActions(modelResourceActions);
@@ -1309,6 +1311,8 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		Set<String> portletResourceActions =
 			portletResourceActionsBag.getResourceActions();
+
+		portletResourceActions.clear();
 
 		readSupportsActions(portletResourceElement, portletResourceActions);
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -430,7 +430,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 
 		synchronized (this) {
-			actions = getPortletMimeTypeActions(name);
+			actions.addAll(getPortletMimeTypeActions(name));
 
 			if (!name.equals(PortletKeys.PORTAL)) {
 				checkPortletActions(name, actions);

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -1377,13 +1377,13 @@ public class ResourceActionsImpl implements ResourceActions {
 		Set<String> portletResourceActions =
 			portletResourceActionsBag.getResourceActions();
 
-		readSupportsActions(portletResourceElement, portletResourceActions);
-
-		portletResourceActions.addAll(getPortletMimeTypeActions(name));
-
 		if (!name.equals(PortletKeys.PORTAL)) {
 			checkPortletActions(name, portletResourceActions);
 		}
+
+		readSupportsActions(portletResourceElement, portletResourceActions);
+
+		portletResourceActions.addAll(getPortletMimeTypeActions(name));
 
 		if (portletResourceActions.size() > 64) {
 			throw new ResourceActionsException(

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -1057,9 +1057,32 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		Element rootElement = document.getRootElement();
 
+		Set<String> portletResourceElementNames = new HashSet<>();
+		Set<String> modelResourceElementNames = new HashSet<>();
+
 		if (PropsValues.RESOURCE_ACTIONS_READ_PORTLET_RESOURCES) {
 			for (Element portletResourceElement :
 					rootElement.elements("portlet-resource")) {
+
+				String name = portletResourceElement.elementTextTrim(
+					"portlet-name");
+
+				if (servletContextName != null) {
+					name = name.concat(PortletConstants.WAR_SEPARATOR).concat(
+						servletContextName);
+				}
+
+				name = JS.getSafeName(name);
+
+				if (portletResourceElementNames.add(name)) {
+					PortletResourceActionsBag portletResourceActionsBag =
+						getPortletResourceActionsBag(name);
+
+					Set<String> portletResourceActions =
+						portletResourceActionsBag.getResourceActions();
+
+					portletResourceActions.clear();
+				}
 
 				String portletName = readPortletResource(
 					servletContextName, portletResourceElement);
@@ -1072,6 +1095,23 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		for (Element modelResourceElement :
 				rootElement.elements("model-resource")) {
+
+			String name = modelResourceElement.elementTextTrim("model-name");
+
+			if (Validator.isNull(name)) {
+				name = getCompositeModelName(
+					modelResourceElement.element("composite-model-name"));
+			}
+
+			if (modelResourceElementNames.add(name)) {
+				ModelResourceActionsBag modelResourceActionsBag =
+					getModelResourceActionsBag(name);
+
+				Set<String> modelResourceActions =
+					modelResourceActionsBag.getResourceActions();
+
+				modelResourceActions.clear();
+			}
 
 			String modelName = readModelResource(
 				servletContextName, modelResourceElement);
@@ -1241,8 +1281,6 @@ public class ResourceActionsImpl implements ResourceActions {
 		Set<String> modelResourceActions =
 			modelResourceActionsBag.getResourceActions();
 
-		modelResourceActions.clear();
-
 		readSupportsActions(modelResourceElement, modelResourceActions);
 
 		checkModelActions(modelResourceActions);
@@ -1311,8 +1349,6 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		Set<String> portletResourceActions =
 			portletResourceActionsBag.getResourceActions();
-
-		portletResourceActions.clear();
 
 		readSupportsActions(portletResourceElement, portletResourceActions);
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -1082,6 +1082,18 @@ public class ResourceActionsImpl implements ResourceActions {
 						portletResourceActionsBag.getResourceActions();
 
 					portletResourceActions.clear();
+
+					Set<String> portletResourceGroupDefaultActions =
+						portletResourceActionsBag.
+							getResourceGroupDefaultActions();
+
+					portletResourceGroupDefaultActions.clear();
+
+					Set<String> portletResourceGuestDefaultActions =
+						portletResourceActionsBag.
+							getResourceGuestDefaultActions();
+
+					portletResourceGuestDefaultActions.clear();
 				}
 
 				String portletName = readPortletResource(
@@ -1111,6 +1123,21 @@ public class ResourceActionsImpl implements ResourceActions {
 					modelResourceActionsBag.getResourceActions();
 
 				modelResourceActions.clear();
+
+				Set<String> modelResourceGroupDefaultActions =
+					modelResourceActionsBag.getResourceGroupDefaultActions();
+
+				modelResourceGroupDefaultActions.clear();
+
+				Set<String> modelResourceGuestDefaultActions =
+					modelResourceActionsBag.getResourceGuestDefaultActions();
+
+				modelResourceGuestDefaultActions.clear();
+
+				Set<String> modelResourceOwnerDefaultActions =
+					modelResourceActionsBag.getResourceOwnerDefaultActions();
+
+				modelResourceOwnerDefaultActions.clear();
 			}
 
 			String modelName = readModelResource(

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
@@ -106,6 +106,14 @@ public class ResourceActionLocalServiceImpl
 				"There are too many actions for resource " + name);
 		}
 
+		List<ResourceAction> resourceActions = getResourceActions(name);
+
+		for (ResourceAction resourceAction : resourceActions) {
+			if (!actionIds.contains(resourceAction.getActionId())) {
+				deleteResourceAction(resourceAction);
+			}
+		}
+
 		long availableBits = -2;
 
 		for (ResourceAction resourceAction : getResourceActions(name)) {

--- a/portal-impl/test/integration/com/liferay/portal/kernel/upgrade/BaseUpgradePortletIdTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/upgrade/BaseUpgradePortletIdTest.java
@@ -167,7 +167,7 @@ public class BaseUpgradePortletIdTest extends BaseUpgradePortletId {
 		Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
 
 		Role role = RoleLocalServiceUtil.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.GUEST);
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
 
 		roleIdsToActionIds.put(
 			role.getRoleId(), new String[] {ActionKeys.CONFIGURATION});


### PR DESCRIPTION
Hey @SamZiemer,

This is an update to [LPS-66047](https://issues.liferay.com/browse/LPS-66047), because when the LPS was originally committed, I was not able to fully implement the behavior I wanted because it caused several of the tests to fail. However, now that I've put more effort into this, I've determined that these test failures are all the result of bugs that were exposed by the new behavior.

The first five commits make it so that when you deploy a new version of a portlet, any resource actions that existed in the previous version of the portlet but no longer exist in the new version are automatically removed from the database AND from the JVM's memory (in the ResourceActionsBag variables). This is the behavior I wanted to introduce the first time I committed LPS-66047.

All the subsequent commits fix bugs that were exposed by this new behavior. For instance, the new behavior exposed a bug that prevented the "guest unsupported actions" feature from working at all. Once we fixed this bug (in commit [46c1bc75bdbe397513685d5ef480a34f54d59539](https://github.com/mbowerman/liferay-portal/commit/46c1bc75bdbe397513685d5ef480a34f54d59539)), it exposed a number of other bugs where we tried to assign resource actions to guests that were guest unsupported resource actions. So, we had to fix those bugs as well.

Please let me know if you have any questions about this fix.