### PR TITLE
LPS-70537

### DIFF
--- a/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/set/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/set/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -567,9 +567,7 @@ public class StagedLayoutSetStagedModelDataHandler
 		String mergeFailFriendlyURLLayouts = settingsProperties.getProperty(
 			Sites.MERGE_FAIL_FRIENDLY_URL_LAYOUTS);
 
-		if (Validator.isNull(mergeFailFriendlyURLLayouts) &&
-			modifiedLayouts.isEmpty()) {
-
+		if (Validator.isNull(mergeFailFriendlyURLLayouts)) {
 			settingsProperties.setProperty(
 				Sites.LAST_MERGE_TIME, String.valueOf(lastMergeTime));
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-24016
https://issues.liferay.com/browse/LPS-70537

If a site template and a site based on it are both modified (and a merge can still be performed), then the merge will be performed on every page load rather than just once. This ultimately makes the site itself very slow, as the merge can be quite expensive.

This appears to be caused by one of the changes added for [LPS-45858](https://issues.liferay.com/browse/LPS-45858) -- specifically, part of [the if-statement on this line.](https://github.com/brianchandotcom/liferay-portal/pull/18136/commits/3a5db6bce41875d8e23b9da5832068eb975af474#diff-3e52cc1457f0e25acb401ede2700beb1R747) I think it makes sense not to update if the merge failed, but I don't see why there should be no modified layouts to update the last merge time if the merge was already done anyway.

The comment added together with this change says that the "last merge time is updated only if there aren't any modified layouts"; however, it is unclear to me why this would be the case, as this means the last merge time will no longer be updated from that point unless changes are reset, and the merge will have to be repeated. Additionally, the commit message mentions that "the last merge time of the layout set is not updated unless all layouts have been merged" -- which seems to reference the update affected by this change, but that is not the actual effect of the if-statement, nor am I sure why that is an important distinction.

I am not sure of the reasoning for why this was originally added, so I could be missing something; I would appreciate any explanation of this.

Also, note that the performance of the merge itself could probably also be addressed, as it seems to be doing some things that are unnecessary (like merging in admin portlets), but that may be subject to further discussion, and is a separate issue.

Thank you!