### PR TITLE
LPS-70761 Allow the Group Owner and Group Members to view the Group's private LayoutSet logo

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -66,7 +66,6 @@ import com.liferay.portal.kernel.service.ImageServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
@@ -494,9 +493,8 @@ public class WebServerServlet extends HttpServlet {
 					PermissionChecker permissionChecker =
 						PermissionCheckerFactoryUtil.create(user);
 
-					if (!GroupPermissionUtil.contains(
-							permissionChecker, layoutSet.getGroupId(),
-							ActionKeys.VIEW)) {
+					if (!permissionChecker.isGroupMember(
+							layoutSet.getGroupId())) {
 
 						throw new PrincipalException.MustHavePermission(
 							permissionChecker, LayoutSet.class.getName(),

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -494,6 +494,8 @@ public class WebServerServlet extends HttpServlet {
 						PermissionCheckerFactoryUtil.create(user);
 
 					if (!permissionChecker.isGroupMember(
+							layoutSet.getGroupId()) &&
+						!permissionChecker.isGroupOwner(
 							layoutSet.getGroupId())) {
 
 						throw new PrincipalException.MustHavePermission(


### PR DESCRIPTION
Hi @SamZiemer,

Main Ticket: [LPP-24406](https://issues.liferay.com/browse/LPP-24406)

For this issue, we will be modifying the permission check to allow only Group Owners and Group Members to view the private LayoutSet logo.  

The original permission check is to give VIEW permission to the actual Group itself.  As we've seen in a previous issue, being a site member does not mean the user has VIEW permissions to the group itself.

I interpreted the intent of the original permission check as to allow users who are able to view a site's private pages to view the related logo. 

**Fix**
The fix will consist of two parts:

1. Allow Site Members to view the logo from the Site's private pages
    - Currently, site members cannot view the logo when visiting the private pages of the site.  
    - It looks like the original fix: [LPS-69171](https://issues.liferay.com/browse/LPS-69171) prevented non-site members from viewing the logo, but also made it so actual site members can no longer view the logo.
2. Allow users to view logos that originated from a site template for their "My Dashboard"
    - This is for resolving the main ticket.  
    - I found that when a user visits their "My Dashboard" page, doing a permission check for the user with the related Group returns false when checking if the user is a Group Member.
        - Instead we can check if the user is the Group Owner.
        - **Note: The reason might be because the Group is actually not categorized as a Site**
            - The database shows the group with a type: 0 and site: 0
                - Group types can be found in [GroupConstants.java#L55](https://github.com/liferay/liferay-portal-ee/blob/fix-pack-de-11-7010/portal-kernel/src/com/liferay/portal/kernel/model/GroupConstants.java#L55)
                - Other groups that are actual sites, such as /guest, have site: 1

----
Please let me know if you have any questions.
Thanks!