### PR TITLE
LPS-70814

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/LayoutAdminWebUpgrade.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/LayoutAdminWebUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.admin.web.internal.upgrade;
 
 import com.liferay.layout.admin.web.internal.upgrade.v_1_0_0.UpgradeLayout;
+import com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -37,6 +38,10 @@ public class LayoutAdminWebUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"com.liferay.layout.admin.web", "0.0.1", "1.0.0",
 			new UpgradeLayout());
+
+		registry.register(
+			"com.liferay.layout.admin.web", "1.0.0", "1.0.1",
+			new UpgradeLayoutType());
 	}
 
 }

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.admin.web.internal.upgrade.v_1_0_1;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.PortletConstants;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Alec Shay
+ */
+public class UpgradeLayoutType extends UpgradeProcess {
+
+	protected void addPortletPreference(
+		StringBundler portletPreferences, String name, long value) {
+
+		addPortletPreference(portletPreferences, name, "" + value);
+	}
+
+	protected void addPortletPreference(
+		StringBundler portletPreferences, String name, String value) {
+
+		portletPreferences.append("<preference><name>");
+
+		portletPreferences.append(name);
+
+		portletPreferences.append("</name><value>");
+
+		portletPreferences.append(value);
+
+		portletPreferences.append("</value></preference>");
+	}
+
+	protected String createPortletPreferences(
+			long companyId, long groupId, long plid, long articleId)
+		throws Exception {
+
+		String portletId =
+			"com_liferay_journal_content_web_portlet_JournalContentPortlet";
+
+		String portletPreferencesId =
+			portletId + "_INSTANCE_" + PortletConstants.generateInstanceId();
+
+		Portlet webContentPortlet = PortletLocalServiceUtil.getPortletById(
+			portletId);
+
+		String defaultPreferences = getDefaultPortletPreferences(
+			groupId, articleId);
+
+		PortletPreferencesLocalServiceUtil.addPortletPreferences(
+			companyId, 0, PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid,
+			portletPreferencesId, webContentPortlet, defaultPreferences);
+
+		return portletPreferencesId;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		updateLayouts();
+	}
+
+	protected long getArticleIdFromTypeSettings(String typeSettings)
+		throws Exception {
+
+		UnicodeProperties typeSettingsProperties = new UnicodeProperties();
+
+		typeSettingsProperties.fastLoad(typeSettings);
+
+		String articleId = typeSettingsProperties.getProperty("article-id");
+
+		if (articleId == null) {
+			return 0;
+		}
+
+		return Long.parseLong(articleId);
+	}
+
+	protected long getAssetEntryIdForResource(long resourcePrimKey)
+		throws Exception {
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+			"com.liferay.portlet.journal.model.JournalArticle",
+			resourcePrimKey);
+
+		if (assetEntry == null) {
+			assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+				"com.liferay.journal.model.JournalArticle", resourcePrimKey);
+		}
+
+		if (assetEntry == null) {
+			throw new UpgradeException(
+				"No asset entry for a journal article with classPK: " +
+					resourcePrimKey);
+		}
+
+		return assetEntry.getEntryId();
+	}
+
+	protected String getDefaultPortletPreferences(long groupId, long articleId)
+		throws Exception {
+
+		if (articleId == 0) {
+			return null;
+		}
+
+		long resourcePrimKey = 0;
+
+		PreparedStatement ps = connection.prepareStatement(
+			"select resourcePrimKey from JournalArticle where articleId = ?");
+
+		ps.setString(1, "" + articleId);
+
+		try (ResultSet rs = ps.executeQuery()) {
+			while (rs.next()) {
+				resourcePrimKey = rs.getLong("resourcePrimKey");
+			}
+		}
+
+		if (resourcePrimKey == 0) {
+			throw new UpgradeException("Missing article with ID: " + articleId);
+		}
+
+		long assetEntryId = getAssetEntryIdForResource(resourcePrimKey);
+		StringBundler portletPreferences = new StringBundler(37);
+
+		portletPreferences.append("<portlet-preferences>");
+
+		addPortletPreference(portletPreferences, "articleId", articleId);
+		addPortletPreference(portletPreferences, "assetEntryId", assetEntryId);
+		addPortletPreference(
+			portletPreferences, "contentMetadataAssetAddonEntryKeys", "");
+		addPortletPreference(
+			portletPreferences, "enableViewCountIncrement", "true");
+		addPortletPreference(portletPreferences, "groupId", groupId);
+		addPortletPreference(
+			portletPreferences, "userToolAssetAddonEntryKeys", "");
+
+		portletPreferences.append("</portlet-preferences>");
+
+		return portletPreferences.toString();
+	}
+
+	protected void updateLayouts() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+				"select companyId, groupId, plid, typeSettings from Layout " +
+					"where type_ = ?")) {
+
+			ps.setString(1, "article");
+
+			try (ResultSet rs = ps.executeQuery()) {
+				while (rs.next()) {
+					long companyId = rs.getLong("companyId");
+					long groupId = rs.getLong("groupId");
+					long plid = rs.getLong("plid");
+					String typeSettings = rs.getString("typeSettings");
+
+					long articleId = getArticleIdFromTypeSettings(typeSettings);
+
+					String portletId = createPortletPreferences(
+						companyId, groupId, plid, articleId);
+
+					String updatedTypeSettings = updateTypeSettings(portletId);
+
+					updateTypeForLayout(plid, updatedTypeSettings);
+				}
+			}
+		}
+	}
+
+	protected void updateTypeForLayout(long plid, String typeSettings)
+		throws Exception {
+
+		try (PreparedStatement ps = connection.prepareStatement(
+				"update Layout set typeSettings = ?, type_ = ? where plid = ?"))
+		{
+
+			ps.setString(1, typeSettings);
+			ps.setString(2, "portlet");
+			ps.setLong(3, plid);
+
+			ps.executeUpdate();
+		}
+	}
+
+	protected String updateTypeSettings(String portletId) {
+		UnicodeProperties newTypeSettings = new UnicodeProperties();
+
+		newTypeSettings.put("column-1", portletId);
+
+		newTypeSettings.put(
+			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_column");
+
+		return newTypeSettings.toString();
+	}
+
+}


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-24318
https://issues.liferay.com/browse/LPS-70814

The "Web Content" layout type was removed in DXP (apparently with [this technical task](https://issues.liferay.com/browse/LPS-54976)), and has been deprecated since 6.1. According to [our documentation on removed features here](https://grow.liferay.com/people/Removed+Feature+Support), the fact that it was deprecated in previous versions means that this counts as clear documentation for the purposes of its removal -- however, there should still be a way to handle previously existing layouts.

As it is now, after an upgrade to DXP with "Web Content" pages, the layout stays as an "article" type in the database (which is no longer a valid type), and so it ends up just being a blank page without customizations. From a user's perspective, the content appears to have gone "missing" (although it still exists in the site).

The change in this pull is to create an UpgradeProcess to convert the layout to a 1-column, "portlet" type with a Web Content display -- which looks very different, but at least keeps the content intact, so it does not appear to have gone missing (and the page can still serve its previous purpose, although it looks different). We have opted for this route since the message in 6.2 indicating its deprecation (shown in the [attached image](https://issues.liferay.com/secure/attachment/204650/deprecated.png) on the ticket) seems to indicate that this is the form that should be used to replace this old page type moving forward.

We are aware that this is probably the extent of the assistance we can offer to customers from support, but want to at least make sure that doing this minimizes the perceived user experience for upgrades where this feature may still have been used previously, despite its deprecation. Please let me know if there are any disagreements, suggestions, or improvements that should be made to this approach though. Thank you.

Also, please note that there appears to be an issue upgrading to master that complicated testing -- to work around this, I was forced to manually update the build number for portal in the "release_" table from 7010 to 7003 before starting up Liferay post-upgrade. I'm not sure what's causing this but it was necessary for testing this in master (testing in ee-7.0.x seemed to work fine).

Thanks!