### PR TITLE
LPS-70935 Dates are now listed under document versions

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -49,6 +49,10 @@
 						<%= fileVersion.getChangeLog() %>
 					</c:otherwise>
 				</c:choose>
+
+				<div class="h6">
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(fileVersion.getUserName()), dateFormatDateTime.format(fileVersion.getCreateDate())} %>" key="by-x-on-x" translateArguments="<%= false %>" />
+				</div>
 			</div>
 
 			<div class="list-group-item-field">


### PR DESCRIPTION
I've uploaded two screenshots on LPS-70935 about how the Version History looks in 62x, and how the proposed Master change will look. This code change adds the author and date fields underneath the change log field in the Versions sidebar info