### PR TITLE
LPS-71134

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -132,8 +132,21 @@ public class WikiNodeStagedModelDataHandler
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(
 			node.getUuid(), portletDataContext.getScopeGroupId());
 
+		String initialNodeName =
+			wikiGroupServiceConfiguration.initialNodeName();
+
 		if (portletDataContext.isDataStrategyMirror()) {
-			if (existingNode == null) {
+			WikiNode initialNode = _wikiNodeLocalService.fetchNode(
+				portletDataContext.getScopeGroupId(), initialNodeName);
+
+			if ((initialNode != null) &&
+				initialNodeName.equals(node.getName())) {
+
+				importedNode = _wikiNodeLocalService.updateNode(
+					initialNode.getNodeId(), node.getName(),
+					node.getDescription(), serviceContext);
+			}
+			else if (existingNode == null) {
 				serviceContext.setUuid(node.getUuid());
 
 				importedNode = _wikiNodeLocalService.addNode(
@@ -147,9 +160,6 @@ public class WikiNodeStagedModelDataHandler
 			}
 		}
 		else {
-			String initialNodeName =
-				wikiGroupServiceConfiguration.initialNodeName();
-
 			if ((existingNode != null) &&
 				initialNodeName.equals(existingNode.getName())) {
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-24513
https://issues.liferay.com/browse/LPS-71134

Our behavior for importing LAR files containing the default "Main" page into another site with the "Main" site has traditionally been to overwrite (or delete) the old "Main" page to make room for the new one.

However, [LPS-57516](https://issues.liferay.com/browse/LPS-57516) changed this so that only the "Copy as New" import strategy considers the "Main" page -- so the default "Mirror" strategy no longer would. This causes a change in the behavior that I think is unintentional, as it makes LAR imports with default data between sites impossible due to DuplicateNodeNameExceptions (two Wiki nodes with the same name cannot be in the same place). Please see the original commit here: https://github.com/brianchandotcom/liferay-portal/pull/29426/commits/5c7ac47a79d018f6036a663d0c106d31cfa9b898

This change is keeping the changes to the "Copy as New" strategy intact but allowing the "Mirror" strategy to still overwrite the "Main" node like it used to be able to.