### PR TITLE
LPS-71134

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -132,17 +132,36 @@ public class WikiNodeStagedModelDataHandler
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(
 			node.getUuid(), portletDataContext.getScopeGroupId());
 
+		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
+			portletDataContext.getGroupId(), node.getName());
+
+		String nodeName = node.getName();
+
 		if (portletDataContext.isDataStrategyMirror()) {
 			if (existingNode == null) {
+				if (nodeWithSameName != null) {
+					nodeName = getNodeName(
+						portletDataContext, node, node.getName(), 2);
+				}
+
 				serviceContext.setUuid(node.getUuid());
 
 				importedNode = _wikiNodeLocalService.addNode(
-					userId, node.getName(), node.getDescription(),
-					serviceContext);
+					userId, nodeName, node.getDescription(), serviceContext);
 			}
 			else {
+				String uuid = existingNode.getUuid();
+
+				if ((nodeWithSameName != null) &&
+					!uuid.equals(nodeWithSameName.getUuid()) &&
+					!nodeName.equals(existingNode.getName())) {
+
+					nodeName = getNodeName(
+						portletDataContext, node, nodeName, 2);
+				}
+
 				importedNode = _wikiNodeLocalService.updateNode(
-					existingNode.getNodeId(), node.getName(),
+					existingNode.getNodeId(), nodeName,
 					node.getDescription(), serviceContext);
 			}
 		}
@@ -154,12 +173,12 @@ public class WikiNodeStagedModelDataHandler
 				initialNodeName.equals(existingNode.getName())) {
 
 				importedNode = _wikiNodeLocalService.updateNode(
-					existingNode.getNodeId(), node.getName(),
+					existingNode.getNodeId(), nodeName,
 					node.getDescription(), serviceContext);
 			}
 			else {
-				String nodeName = getNodeName(
-					portletDataContext, node, node.getName(), 2);
+				nodeName = getNodeName(
+					portletDataContext, node, nodeName, 2);
 
 				importedNode = _wikiNodeLocalService.addNode(
 					userId, nodeName, node.getDescription(), serviceContext);


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-24513
https://issues.liferay.com/browse/LPS-71134

As a result of LPS-57516, a bug was exposed where importing Wiki nodes using the default "Mirror" import strategy would not work because it cannot handle name conflicts the same way other components can, despite code for it already being in place. This fix is leveraging the existing `getNodeName()` method to create a new name to avoid name conflicts when importing with the default "Mirror" strategy.