### PR TITLE
LPS-70366 using fetchUser due to stale user in request

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/LoginPostAction.java
+++ b/portal-impl/src/com/liferay/portal/events/LoginPostAction.java
@@ -105,7 +105,9 @@ public class LoginPostAction extends Action {
 				UserLocalServiceUtil.addDefaultUserGroups(userId);
 			}
 
-			User user = PortalUtil.getUser(request);
+			userId = PortalUtil.getUserId(request);
+
+			User user = UserLocalServiceUtil.fetchUser(userId);
 
 			if (UserLocalServiceUtil.isPasswordExpiringSoon(user)) {
 				SessionMessages.add(request, "passwordExpiringSoon");


### PR DESCRIPTION
LPS-70366 has been committed, but we experienced an error that occurs only with Test User. I'm submitting a fix that fixes this edge case.

`isPasswordExpiringSoon` makes an update to the user's `PasswordModifiedDate` field if it is null. When this was done, Liferay threw an `ORMException` complaining about a stale user in the request. We've changed the logic to instead use `fetchUser` which gets the user from the DB.