### PR TITLE
LPS-71265 Add Author and Modified Date fields when exporting DDL entries

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exporter/impl/DDLCSVExporter.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exporter/impl/DDLCSVExporter.java
@@ -118,7 +118,7 @@ public class DDLCSVExporter extends BaseDDLExporter {
 
 			sb.append(CharPool.COMMA);
 
-			sb.append(recordVersion.getUserName());
+			sb.append(CSVUtil.encode(recordVersion.getUserName()));
 
 			if (iterator.hasNext()) {
 				sb.append(StringPool.NEW_LINE);

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exporter/impl/DDLCSVExporter.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exporter/impl/DDLCSVExporter.java
@@ -77,6 +77,10 @@ public class DDLCSVExporter extends BaseDDLExporter {
 		}
 
 		sb.append(LanguageUtil.get(getLocale(), "status"));
+		sb.append(CharPool.COMMA);
+		sb.append(LanguageUtil.get(getLocale(), "modified-date"));
+		sb.append(CharPool.COMMA);
+		sb.append(LanguageUtil.get(getLocale(), "author"));
 		sb.append(StringPool.NEW_LINE);
 
 		List<DDLRecord> records = _ddlRecordLocalService.getRecords(
@@ -107,6 +111,14 @@ public class DDLCSVExporter extends BaseDDLExporter {
 			sb.append(CharPool.COMMA);
 
 			sb.append(getStatusMessage(recordVersion.getStatus()));
+
+			sb.append(CharPool.COMMA);
+
+			sb.append(recordVersion.getStatusDate());
+
+			sb.append(CharPool.COMMA);
+
+			sb.append(recordVersion.getUserName());
 
 			if (iterator.hasNext()) {
 				sb.append(StringPool.NEW_LINE);

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exporter/impl/DDLXMLExporter.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/exporter/impl/DDLXMLExporter.java
@@ -112,6 +112,14 @@ public class DDLXMLExporter extends BaseDDLExporter {
 			addFieldElement(
 				fieldsElement, LanguageUtil.get(getLocale(), "status"),
 				getStatusMessage(recordVersion.getStatus()));
+
+			addFieldElement(
+				fieldsElement, LanguageUtil.get(getLocale(), "modified-date"),
+				recordVersion.getStatusDate());
+
+			addFieldElement(
+				fieldsElement, LanguageUtil.get(getLocale(), "author"),
+				recordVersion.getUserName());
 		}
 
 		String xml = document.asXML();


### PR DESCRIPTION
LPS : https://issues.liferay.com/browse/LPS-71265
LPP : https://issues.liferay.com/browse/LPP-24713

Changed to use recordVersion for Modified Date and use CSVUtil.encode() on Author.

This change adds the Author and Modified Date fields and populates from the DDL recordVersion.