### PR TITLE
LPS-70758 Show display for impersonated user

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/navigation.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/navigation.ftl
@@ -1,7 +1,7 @@
 <#assign VOID = freeMarkerPortletPreferences.setValue("portletSetupPortletDecoratorId", "barebone") />
 
 <div aria-expanded="false" class="collapse navbar-collapse" id="navigationCollapse">
-	<#if has_navigation && is_setup_complete>
+	<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 		<nav class="${nav_css_class} site-navigation" id="navigation" role="navigation">
 			<#if show_header_search>
 				<div class="navbar-form navbar-right" role="search">

--- a/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -34,7 +34,7 @@
 					</span>
 				</#if>
 
-				<#if is_setup_complete>
+				<#if is_setup_complete || themeDisplay.isImpersonated()>
 					<button aria-controls="navigation" aria-expanded="false" class="collapsed navbar-toggle" data-target="#navigationCollapse" data-toggle="collapse" type="button">
 						<span class="icon-bar"></span>
 

--- a/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
@@ -40,7 +40,7 @@
 			<a data-redirect="${is_login_redirect_required?string}" href="${sign_in_url}" id="sign-in" rel="nofollow">${sign_in_text}</a>
 		</#if>
 
-		<#if has_navigation && is_setup_complete>
+		<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 			<#include "${full_templates_path}/navigation.ftl" />
 		</#if>
 	</header>

--- a/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.vm
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.vm
@@ -38,7 +38,7 @@ $theme.include($body_top_include)
 			<a data-redirect="$is_login_redirect_required" href="$sign_in_url" id="sign-in" rel="nofollow">$sign_in_text</a>
 		#end
 
-		#if ($has_navigation && $is_setup_complete)
+		#if ($has_navigation && ($is_setup_complete || themeDisplay.isImpersonated()))
 			#parse ("$full_templates_path/navigation.vm")
 		#end
 	</header>

--- a/modules/apps/foundation/frontend-theme/frontend-theme-user-dashboard/src/templates/navigation.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-user-dashboard/src/templates/navigation.ftl
@@ -1,4 +1,4 @@
-<#if has_navigation && is_setup_complete>
+<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 	<nav class="${nav_css_class} site-navigation" id="navigation" role="navigation">
 		<#assign VOID = freeMarkerPortletPreferences.setValue("portletSetupPortletDecoratorId", "barebone") />
 

--- a/modules/apps/foundation/frontend-theme/frontend-theme-user-profile/src/templates/navigation.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-user-profile/src/templates/navigation.ftl
@@ -1,5 +1,5 @@
 <div aria-expanded="false" class="collapse navbar-collapse" id="navigationCollapse">
-	<#if has_navigation && is_setup_complete>
+	<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 		<nav class="${nav_css_class} site-navigation" id="navigation" role="navigation">
 			<#assign VOID = freeMarkerPortletPreferences.setValue("portletSetupPortletDecoratorId", "barebone") />
 

--- a/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
+++ b/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
@@ -118,7 +118,7 @@ ${languageUtil.format(locale, key, arguments)}</#macro>
 <#macro search
 	default_preferences = ""
 >
-	<#if is_setup_complete>
+	<#if themeDisplay.isImpersonated() || is_setup_complete>
 		<@liferay_portlet["runtime"]
 			defaultPreferences=default_preferences
 			portletProviderAction=portletProviderAction.VIEW

--- a/modules/apps/foundation/portal-template/portal-template-velocity/src/main/resources/VM_liferay.vm
+++ b/modules/apps/foundation/portal-template/portal-template-velocity/src/main/resources/VM_liferay.vm
@@ -62,7 +62,7 @@ $languageUtil.format($locale, $lang_key, $arguments.toArray())#end
 #end
 
 #macro (search $default_preferences)
-	#if ($is_setup_complete)
+	#if ($themeDisplay.isImpersonated() || $is_setup_complete)
 		$theme.runtime("com.liferay.portlet.admin.util.PortalSearchApplicationType$Search", $portletProviderAction.VIEW, "", $!default_preferences)
 	#end
 #end

--- a/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/src/templates/navigation.ftl
+++ b/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/src/templates/navigation.ftl
@@ -1,7 +1,7 @@
 <#assign VOID = freeMarkerPortletPreferences.setValue("portletSetupPortletDecoratorId", "barebone") />
 
 <div aria-expanded="false" class="${nav_collapse} collapse" id="navigationCollapse">
-	<#if has_navigation && is_setup_complete>
+	<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 		<div class="${nav_css_class} ${nav_css_right} site-navigation" id="navigation" role="navigation">
 			<@liferay.navigation_menu default_preferences="${freeMarkerPortletPreferences}" />
 		</div>

--- a/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/src/templates/portal_normal.ftl
@@ -39,7 +39,7 @@
 							</button>
 						</div>
 
-						<#if has_navigation && is_setup_complete>
+						<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 							<#include full_templates_path + "/navigation.ftl">
 						</#if>
 					</nav>

--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/templates/navigation.ftl
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/templates/navigation.ftl
@@ -1,7 +1,7 @@
 <#assign VOID = freeMarkerPortletPreferences.setValue("portletSetupPortletDecoratorId", "barebone") />
 
 <div aria-expanded="false" class="${nav_collapse} collapse" id="navigationCollapse">
-	<#if has_navigation && is_setup_complete>
+	<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 		<div class="${nav_css_class} ${nav_css_right} site-navigation" id="navigation" role="navigation">
 			<@liferay.navigation_menu default_preferences="${freeMarkerPortletPreferences}" />
 		</div>

--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/templates/portal_normal.ftl
@@ -39,7 +39,7 @@
 							</button>
 						</div>
 
-						<#if has_navigation && is_setup_complete>
+						<#if has_navigation && (is_setup_complete || themeDisplay.isImpersonated())>
 							<#include full_templates_path + "/navigation.ftl">
 						</#if>
 					</nav>


### PR DESCRIPTION
LPS : https://issues.liferay.com/browse/LPS-70758
LPP : https://issues.liferay.com/browse/LPP-24273

When impersonating a user, the display for a user who has logged in before and a newly created user should be the same.

I wasn't able to observe the UI changes from frontend-theme-unstyled.