### PR TITLE
LPS-71490

### DIFF
--- a/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/set/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/set/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -286,6 +286,10 @@ public class StagedLayoutSetStagedModelDataHandler
 
 		updateLastMergeTime(portletDataContext, modifiedLayouts);
 
+		// Validate links between layouts
+
+		validateLinks(portletDataContext);
+
 		// Page priorities
 
 		updateLayoutPriorities(
@@ -634,6 +638,39 @@ public class StagedLayoutSetStagedModelDataHandler
 			}
 
 			_layoutLocalService.updateLayout(layout);
+		}
+	}
+
+	protected void validateLinks(PortletDataContext portletDataContext) {
+		Map<Long, Layout> layouts =
+			(Map<Long, Layout>)portletDataContext.getNewPrimaryKeysMap(
+				Layout.class + ".layout");
+
+		for (Map.Entry<Long, Layout> entry : layouts.entrySet()) {
+			Layout layout = entry.getValue();
+
+			UnicodeProperties typeSettingsProperties =
+				layout.getTypeSettingsProperties();
+
+			long linkToLayoutId = GetterUtil.getLong(
+				typeSettingsProperties.getProperty("linkToLayoutId"));
+
+			if (linkToLayoutId > 0) {
+				Layout linkedLayout = layouts.get(linkToLayoutId);
+
+				long newLinkToLayoutId = linkedLayout.getLayoutId();
+
+				if (newLinkToLayoutId != linkToLayoutId) {
+					layout = _layoutLocalService.fetchLayout(layout.getPlid());
+
+					typeSettingsProperties.setProperty(
+						"linkToLayoutId", "" + newLinkToLayoutId);
+
+					layout.setTypeSettingsProperties(typeSettingsProperties);
+
+					_layoutLocalService.updateLayout(layout);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-24812
https://issues.liferay.com/browse/LPS-71490

When using Staging for pages of type "Link to a Page of this Site," there is no guarantee for the live site's layoutId's to match the Staging site's layoutId's, so there is a strong possibility of them being mixed up during publication. This causes the links to sometimes point to the wrong pages, or possibly not work at all.

This fix adds another step to the Site publication process to validate these links, updating layoutId's wherever necessary.