### PR TITLE
LPS-71794 Submitting poll without selecting a choice

### DIFF
--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/action/EditQuestionMVCActionCommand.java
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/action/EditQuestionMVCActionCommand.java
@@ -179,8 +179,10 @@ public class EditQuestionMVCActionCommand extends BaseMVCActionCommand {
 
 				hideDefaultErrorMessage(actionRequest);
 
-				actionResponse.setRenderParameter(
-					"mvcPath", "/polls/edit_question.jsp");
+				if (!(e instanceof NoSuchChoiceException)) {
+					actionResponse.setRenderParameter(
+						"mvcPath", "/polls/edit_question.jsp");
+				}
 			}
 			else if (e instanceof QuestionExpiredException) {
 			}

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
@@ -30,6 +30,9 @@ portletURL.setParameter("mvcRenderCommandName", "/polls/view");
 
 <div class="container-fluid-1280 main-content-body">
 	<aui:form method="post" name="fm">
+		<liferay-ui:error exception="<%= DuplicateVoteException.class %>" message="you-may-only-vote-once" />
+		<liferay-ui:error exception="<%= NoSuchChoiceException.class %>" message="please-select-an-option" />
+
 		<liferay-ui:search-container
 			emptyResultsMessage="no-entries-were-found"
 			iteratorURL="<%= portletURL %>"


### PR DESCRIPTION
LPS : https://issues.liferay.com/browse/LPS-71794
LPP : https://issues.liferay.com/browse/LPP-25050

The first commit handles the LPS / LPP by avoiding the configuration redirection (added from (https://github.com/liferay/liferay-portal/commit/a7db06c55d61a67b9658db513f236bda7a624105)) on poll submission.

The second commit addresses the issue of submitting polls that should throw errors via the Control Panel > Content > Polls.