### PR TITLE
LPS-71794 Submitting poll without selecting a choice

### DIFF
--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/action/EditQuestionMVCActionCommand.java
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/action/EditQuestionMVCActionCommand.java
@@ -179,8 +179,10 @@ public class EditQuestionMVCActionCommand extends BaseMVCActionCommand {
 
 				hideDefaultErrorMessage(actionRequest);
 
-				actionResponse.setRenderParameter(
-					"mvcPath", "/polls/edit_question.jsp");
+				if (!(e instanceof NoSuchChoiceException)) {
+					actionResponse.setRenderParameter(
+						"mvcPath", "/polls/edit_question.jsp");
+				}
 			}
 			else if (e instanceof QuestionExpiredException) {
 			}

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view.jsp
@@ -30,6 +30,9 @@ portletURL.setParameter("mvcRenderCommandName", "/polls/view");
 
 <div class="container-fluid-1280 main-content-body">
 	<aui:form method="post" name="fm">
+		<liferay-ui:error exception="<%= DuplicateVoteException.class %>" message="you-may-only-vote-once" />
+		<liferay-ui:error exception="<%= NoSuchChoiceException.class %>" message="please-select-an-option" />
+
 		<liferay-ui:search-container
 			emptyResultsMessage="no-entries-were-found"
 			iteratorURL="<%= portletURL %>"

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view_question.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view_question.jsp
@@ -65,6 +65,9 @@ portletDisplay.setURLBack(redirect);
 
 			<c:choose>
 				<c:when test="<%= !viewResults && !question.isExpired() && !hasVoted && PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.ADD_VOTE) %>">
+					<div class="hide" id="<portlet:namespace />fieldRequiredErrorPoll">
+						<span class="alert alert-danger"><liferay-ui:message key="this-field-is-required" /></span>
+					</div>
 
 					<%
 					for (PollsChoice choice : choices) {
@@ -132,4 +135,23 @@ portletDisplay.setURLBack(redirect);
 			</c:choose>
 		</aui:fieldset>
 	</aui:fieldset-group>
+
+	<aui:script use="aui-base,selector-css3">
+		var form = A.one('#<portlet:namespace />fm');
+
+		if (form) {
+			form.on(
+				'submit',
+				function(event) {
+					var hasChecked = A.one('input[name=<portlet:namespace />choiceId]:checked');
+
+					if (!hasChecked) {
+						A.one('#<portlet:namespace />fieldRequiredErrorPoll').show();
+						event.halt();
+						event.stopImmediatePropagation();
+					}
+				}
+			);
+		}
+	</aui:script>
 </aui:form>

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
@@ -83,6 +83,9 @@ catch (NoSuchQuestionException nsqe) {
 
 					<c:choose>
 						<c:when test="<%= !question.isExpired() && !hasVoted && PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.ADD_VOTE) %>">
+							<div class="hide" id="<portlet:namespace />fieldRequiredErrorPoll">
+								<span class="alert alert-danger"><liferay-ui:message key="this-field-is-required" /></span>
+							</div>
 
 							<%
 							for (PollsChoice choice : choices) {
@@ -114,5 +117,24 @@ catch (NoSuchQuestionException nsqe) {
 				</aui:fieldset>
 			</aui:fieldset-group>
 		</aui:form>
+
+		<aui:script use="aui-base,selector-css3">
+			var form = A.one('#<portlet:namespace />fm');
+
+			if (form) {
+				form.on(
+					'submit',
+					function(event) {
+						var hasChecked = A.one('input[name=<portlet:namespace />choiceId]:checked');
+
+						if (!hasChecked) {
+							A.one('#<portlet:namespace />fieldRequiredErrorPoll').show();
+							event.halt();
+							event.stopImmediatePropagation();
+						}
+					}
+				);
+			}
+		</aui:script>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
LPS : https://issues.liferay.com/browse/LPS-71794
LPP : https://issues.liferay.com/browse/LPP-25050

The first and second commit address the issue described in the LPP/LPS by avoiding the configuration redirection introduced by liferay@a7db06c.  We hide the default error and display to the user the NoSuchChoiceException.

The third commit implements frontend validation to reject empty polls before submission (based on Web Form Portlet).

EDIT : The frontend validation should prevent NoSuchChoiceExceptions, however I think the first two commits should remain.  https://gist.github.com/SpencerWoo/8dfaae600cfa792ae1b856a3f264439e#file-editquestionmvcactioncommand-java-L184 can also be done but I don't think it should be with QuestionExpiredException with nothing.