### PR TITLE
LPS-71902 Clear cache in transaction callback when removing virtual host

### DIFF
--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1611aae1600a3f8a1275fa5ac32943426cf03eba
+	commit = 62864ff274b143b009fb7ef0b57091faeff1b699
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 77a4af3c96c03d02761421fd7bb0e00c390e657a
+	parent = 9c9fc0387b731faa1a12d57081905808d26a0f80
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LayoutSetVirtualHostException;
 import com.liferay.portal.kernel.exception.NoSuchImageException;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.LayoutSetStagingHandler;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ColorSchemeFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -37,6 +39,8 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.ThemeFactoryUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.impl.LayoutSetImpl;
+import com.liferay.portal.model.impl.LayoutSetModelImpl;
 import com.liferay.portal.service.base.LayoutSetLocalServiceBaseImpl;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsValues;
@@ -47,6 +51,7 @@ import java.io.InputStream;
 
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * @author Brian Wing Shun Chan
@@ -486,6 +491,21 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			try {
 				virtualHostPersistence.removeByC_L(
 					layoutSet.getCompanyId(), layoutSet.getLayoutSetId());
+
+				TransactionCommitCallbackUtil.registerCallback(
+						new Callable<Void>() {
+
+							@Override
+							public Void call() {
+								EntityCacheUtil.removeResult(
+										LayoutSetModelImpl.ENTITY_CACHE_ENABLED,
+										LayoutSetImpl.class,
+										layoutSet.getLayoutSetId());
+
+								return null;
+							}
+
+						});
 			}
 			catch (NoSuchVirtualHostException nsvhe) {
 


### PR DESCRIPTION
Relevant tickets:
[LPS-71902](https://issues.liferay.com/browse/LPS-71902)
[LPS-51074](https://issues.liferay.com/browse/LPS-51074)
[LPS-63741](https://issues.liferay.com/browse/LPS-63741)

When removing a virtual host, it is successfully removed from the database, but it still remains visible in the input. The cache is cleared when a virtual host is added or modified, but not when it is removed.

The opposite problem where a virtual host was added and then not displayed was identified in LPS-51074 and fixed in LPS-63741. Following the same pattern, this change clears the cache in the same manner as LPS-63741 when a virtual host is removed.

Please let me know if there are any problems, thanks.