### PR TITLE
LPS-72290 Validate poll empty selection before submission

### DIFF
--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view_question.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view_question.jsp
@@ -65,6 +65,9 @@ portletDisplay.setURLBack(redirect);
 
 			<c:choose>
 				<c:when test="<%= !viewResults && !question.isExpired() && !hasVoted && PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.ADD_VOTE) %>">
+					<div class="hide" id="<portlet:namespace />noChoiceSelectedError">
+						<span class="alert alert-danger"><liferay-ui:message key="please-select-an-option" /></span>
+					</div>
 
 					<%
 					for (PollsChoice choice : choices) {
@@ -132,4 +135,23 @@ portletDisplay.setURLBack(redirect);
 			</c:choose>
 		</aui:fieldset>
 	</aui:fieldset-group>
+
+	<aui:script use="aui-base,selector-css3">
+		var form = A.one('#<portlet:namespace />fm');
+
+		if (form) {
+			form.on(
+				'submit',
+				function(event) {
+					var hasChecked = A.one('input[name=<portlet:namespace />choiceId]:checked');
+
+					if (!hasChecked) {
+						A.one('#<portlet:namespace />noChoiceSelectedError').show();
+						event.halt();
+						event.stopImmediatePropagation();
+					}
+				}
+			);
+		}
+	</aui:script>
 </aui:form>

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
@@ -83,6 +83,9 @@ catch (NoSuchQuestionException nsqe) {
 
 					<c:choose>
 						<c:when test="<%= !question.isExpired() && !hasVoted && PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.ADD_VOTE) %>">
+							<div class="hide" id="<portlet:namespace />noChoiceSelectedError">
+								<span class="alert alert-danger"><liferay-ui:message key="please-select-an-option" /></span>
+							</div>
 
 							<%
 							for (PollsChoice choice : choices) {
@@ -114,5 +117,24 @@ catch (NoSuchQuestionException nsqe) {
 				</aui:fieldset>
 			</aui:fieldset-group>
 		</aui:form>
+
+		<aui:script use="aui-base,selector-css3">
+			var form = A.one('#<portlet:namespace />fm');
+
+			if (form) {
+				form.on(
+					'submit',
+					function(event) {
+						var hasChecked = A.one('input[name=<portlet:namespace />choiceId]:checked');
+
+						if (!hasChecked) {
+							A.one('#<portlet:namespace />noChoiceSelectedError').show();
+							event.halt();
+							event.stopImmediatePropagation();
+						}
+					}
+				);
+			}
+		</aui:script>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-72290

Implements frontend validation to reject empty polls before submission (based on Web Form Portlet) and should prevent Poll NoSuchChoiceExceptions.