### PR TITLE
[TECHNICAL-SUPPORT] LPS-72271 Change obc toString to not return null

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/OrderByComparator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/OrderByComparator.java
@@ -94,7 +94,14 @@ public abstract class OrderByComparator<T>
 
 	@Override
 	public String toString() {
-		return getOrderBy();
+		String orderBy = getOrderBy();
+
+		if (orderBy == null) {
+			return super.toString();
+		}
+		else {
+			return orderBy;
+		}
 	}
 
 	private static final String _ORDER_BY_DESC = " DESC";


### PR DESCRIPTION
Quote from customer:
> Basically the change done 4 months ago in https://github.com/liferay/liferay-portal-ee/commit/70a99f787c6508e7ecaacf435e4e81b68e360275 changed how the arguments were being encoded to act as the cache key for the finder cache.
Now, the com.liferay.portal.kernel.dao.orm.FinderPath calls StringUtil.toString() on each argument and the StringUtil.toString() method basically invokes the toString() method on objects to get the String representation.
The core problem is that the OrderByComparator, when used as an anonymous inner class, the toString() method returns null and this ends up causing an NPE when Liferay is trying to process the args to build the cache key.

The fix is ensuring that toString does not return null. By returning super.toString(), the empty string is returned which is able to be encoded later on by FinderPath.encodeArguments(). 

Relevant tickets:
[LPS-72271](https://issues.liferay.com/browse/LPS-72271)
[LPS-69922](https://issues.liferay.com/browse/LPS-69922)