### PR TITLE
LPS-72509

### DIFF
--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5376,9 +5376,6 @@ public class JournalArticleLocalServiceImpl
 				throw new ArticleVersionException(sb.toString());
 			}
 
-			serviceContext.validateModifiedDate(
-				latestArticle, ArticleVersionException.class);
-
 			if (latestArticle.isApproved() || latestArticle.isExpired() ||
 				latestArticle.isScheduled()) {
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-25469
https://issues.liferay.com/browse/LPS-72509

If the Permissions for a Web Content article are edited in the edit form (using the menu shown in the attached screenshot), the user cannot publish changes to the article itself unless the form is refreshed.

This is due to an old validation check for concurrent updates added with [LPS-15308](https://issues.liferay.com/browse/LPS-15308). It compares the date the edit form was loaded with the lastModifiedDate for the content -- and since updating Permissions can be done after the form was loaded without refreshing it, it will treat it as though another user had updated the content, and throw an error.

After looking into this, I noted that there is already another validation check in place that compares version numbers, which seems to make much more sense; trying to change any of the values for the actual content in the form (not including the permissions) increments the version, so it seems like that should be the preferred method of validating to prevent concurrent updates. I removed the check from LPS-15308 and tested it, and [this code in JournalArticleLocalServiceImpl](https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L5368) still seems to correctly show an error if two users try to concurrently edit the content. So I believe only this one should be necessary, and removing the lastModifiedDate check is necessary to allow the same user to modify both Permissions and the content without running into an error.

Also note that (as a separate but relevant issue), whichever of these two strategies is used to detect concurrent updates, the current user's changes are kept rather than the up-to-date content's, but clicking the button again will make the publish successful. On one hand this gives the user a chance to recover their local changes before they are lost, but it also seems a bit counter-intuitive to me. I wasn't totally sure though, so I just opened [LPS-72510](https://issues.liferay.com/browse/LPS-72510) for this in the meantime.