### PR TITLE
LPS-72547

### DIFF
--- a/portal-impl/src/com/liferay/portal/workflow/permission/WorkflowPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/workflow/permission/WorkflowPermissionImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.model.WorkflowInstanceLink;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
@@ -61,12 +60,6 @@ public class WorkflowPermissionImpl implements WorkflowPermission {
 			permissionChecker.isGroupAdmin(groupId)) {
 
 			return Boolean.TRUE;
-		}
-
-		if (!WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(
-				companyId, groupId, className)) {
-
-			return null;
 		}
 
 		if (WorkflowInstanceLinkLocalServiceUtil.hasWorkflowInstanceLink(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
@@ -106,14 +106,13 @@ public class DLFileEntryPermission implements BaseModelPermissionChecker {
 			return hasPermission.booleanValue();
 		}
 
-		DLFileVersion latestDLFileVersion = dlFileEntry.getLatestFileVersion(
-			true);
+		DLFileVersion currentDLFileVersion = dlFileEntry.getFileVersion();
 
-		if (latestDLFileVersion.isPending()) {
+		if (currentDLFileVersion.isPending()) {
 			hasPermission = WorkflowPermissionUtil.hasPermission(
 				permissionChecker, dlFileEntry.getGroupId(),
-				DLFileEntry.class.getName(), dlFileEntry.getFileEntryId(),
-				actionId);
+				DLFileEntry.class.getName(),
+				currentDLFileVersion.getFileVersionId(), actionId);
 
 			if (hasPermission != null) {
 				return hasPermission.booleanValue();

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLFileEntryPermission.java
@@ -89,6 +89,14 @@ public class DLFileEntryPermission implements BaseModelPermissionChecker {
 		String portletId = PortletProviderUtil.getPortletId(
 			FileEntry.class.getName(), PortletProvider.Action.EDIT);
 
+		if (permissionChecker.hasOwnerPermission(
+				dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
+				dlFileEntry.getFileEntryId(), dlFileEntry.getUserId(),
+				actionId)) {
+
+			return true;
+		}
+
 		Boolean hasPermission = StagingPermissionUtil.hasPermission(
 			permissionChecker, dlFileEntry.getGroupId(),
 			DLFileEntry.class.getName(), dlFileEntry.getFileEntryId(),
@@ -109,6 +117,9 @@ public class DLFileEntryPermission implements BaseModelPermissionChecker {
 
 			if (hasPermission != null) {
 				return hasPermission.booleanValue();
+			}
+			else if (actionId.equals(ActionKeys.VIEW)) {
+				return false;
 			}
 		}
 
@@ -144,14 +155,6 @@ public class DLFileEntryPermission implements BaseModelPermissionChecker {
 					}
 				}
 			}
-		}
-
-		if (permissionChecker.hasOwnerPermission(
-				dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
-				dlFileEntry.getFileEntryId(), dlFileEntry.getUserId(),
-				actionId)) {
-
-			return true;
 		}
 
 		return permissionChecker.hasPermission(


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-25228
https://issues.liferay.com/browse/LPS-72547
Also, for relevant discussion: [LPP-25371](https://issues.liferay.com/browse/LPP-25371) & [PTR-71](https://issues.liferay.com/browse/PTR-71)

When workflow is enabled for documents (the workflow is defined by folder), a normal user can view the document before it's approved. This is a problem for security reasons. The problem can actually be broken into three distinct issues all applying to this use case:

**1 - WorkflowPermissionImpl returns null for VIEW permissions, but this is interpreted as Workflow being undefined.** In this case, as suggested on PTR, this can be handled on the DL side, making the interpretation of "null" more strict for VIEW permissions. See 0ea8c2b for the change addressing this issue.

**2 - A check in `WorkflowPermissionImpl.doHasPermission()` in the WorkflowDefinitionLink table does not support Workflow defined by folder (applies to Documents and Web Content).** There are a few issues with this. This call makes many assumptions that are not true for these types of Workflow definitions -- including that there would only be one classPK to check, or that the classNameId would match the entry in WorkflowInstanceLink (please see the description for [PTR-71](https://issues.liferay.com/browse/PTR-71) for more details on this). This check doesn't seem necessary if a check in WorkflowInstanceLink would be done anyway, so removing the call should resolve these issues without needing to refactor or add a lot more logic. See 3bc7c54 for the change addressing this issue.

**3 - `DLFileEntryPermission` is using the wrong classNameId and classPK to check for Workflow for a DLFileEntry.** For DLFileEntries, the WorkflowInstanceLink entry uses a classNameId matching `DLFolder`, and it uses a classPK matching the DLFileEntryVersionID. See 372d71e for the change addressing this issue.

Please let me know if there are any questions or concerns about this. Thank you.