### PR TITLE
[TECHNICAL SUPPORT] LPS-72368 Revert to default LayoutSet to avoid repeating errors

### DIFF
--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 58600441474679c3a3a2786a098234ad96035fe4
+	commit = e0643744a1bfa7bff6ab5e0e83c6bda3a6e3b5d5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3f39be0c1d9891443e87df1755a7083a819dad51
+	parent = 3f96aa53cc6bbd7ad175202727d31f980d651f74
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d7e280493092ddce083eeee800e0e0da21f9eb4c
+	commit = 25c56f71541b0873e03ced0b0f39a40ea4516ae1
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4c0d997b4a138b69ec5e25063372cd070ce77eb7
+	parent = dd6fb20510aa4c56d2edb4ccae847de0b5357b81
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 7b2f5d64bc77d5da56032461ae1279e4c944f0f0
+	commit = 8c247dac0f0eba8ad703f610b83a783a064bbcb8
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c7427702eb08c7915311986e332ca8391fb8b481
+	parent = 36a52cc94d0a20401c1774f26238fd3b985c1c7f
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.107
+Bundle-Version: 1.0.108

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -192,8 +192,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		long currentTimestamp = System.currentTimeMillis();
 		int totalRecentBatchSizes = 0;
 
-		List<Long> expiredTimestamps = new ArrayList<>(
-			_batchSizes.size());
+		List<Long> expiredTimestamps = new ArrayList<>(_batchSizes.size());
 
 		for (long expiryTimestamp : _batchSizes.keySet()) {
 			if (expiryTimestamp < currentTimestamp) {
@@ -213,9 +212,9 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	}
 
 	private boolean _available;
+	private final Map<Long, Integer> _batchSizes = new TreeMap<>();
 	private final String _masterName;
 	private final String _masterURL;
-	private final Map<Long, Integer> _batchSizes = new TreeMap<>();
 	private int _reportedSlavesAvailable;
 	private String _summary;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -34,7 +34,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		_recentBatchesMap = new TreeMap<>();
 	}
 
-	public void addRecentBatch(int batchSize) {
+	public synchronized void addRecentBatch(int batchSize) {
 		_recentBatchesMap.put(
 			System.currentTimeMillis() + maxRecentBatchAge, batchSize);
 
@@ -66,7 +66,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	}
 
 	public int getAvailableSlavesCount() {
-		int totalRecentBatchSizes = _getTotalRecentBatcheSizes();
+		int totalRecentBatchSizes = _getTotalRecentBatchSizes();
 
 		int availableSlavesCount =
 			_reportedSlavesAvailable - totalRecentBatchSizes;
@@ -189,9 +189,9 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 	protected static long maxRecentBatchAge = 120 * 1000;
 
-	private int _getTotalRecentBatcheSizes() {
+	private synchronized int _getTotalRecentBatchSizes() {
 		long currentTimestamp = System.currentTimeMillis();
-		int totalRecentBatchesSize = 0;
+		int totalRecentBatchSizes = 0;
 
 		List<Long> expiredTimestamps = new ArrayList<>(
 			_recentBatchesMap.size());
@@ -203,14 +203,14 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 				continue;
 			}
 
-			totalRecentBatchesSize += _recentBatchesMap.get(expiryTimestamp);
+			totalRecentBatchSizes += _recentBatchesMap.get(expiryTimestamp);
 		}
 
 		for (Long expiredTimestamp : expiredTimestamps) {
 			_recentBatchesMap.remove(expiredTimestamp);
 		}
 
-		return totalRecentBatchesSize;
+		return totalRecentBatchSizes;
 	}
 
 	private boolean _available;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -65,13 +65,15 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	public int getAvailableSlavesCount() {
 		int recentBatchSizesTotal = _getRecentBatchSizesTotal();
 
-		int availableSlavesCount =
-			_reportedAvailableSlavesCount - recentBatchSizesTotal;
-
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("{availableSlavesCount=");
+
+		int availableSlavesCount =
+			_reportedAvailableSlavesCount - recentBatchSizesTotal;
+
 		sb.append(availableSlavesCount);
+
 		sb.append(", recentBatchSizesTotal=");
 		sb.append(recentBatchSizesTotal);
 		sb.append(", reportedAvailableSlavesCount=");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -131,11 +131,11 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 		int idleCount = 0;
 
-		JSONArray computersJSONArray = computerJSONObject.getJSONArray(
+		JSONArray computerJSONArray = computerJSONObject.getJSONArray(
 			"computer");
 
-		for (int i = 0; i < computersJSONArray.length(); i++) {
-			JSONObject curComputerJSONObject = computersJSONArray.getJSONObject(
+		for (int i = 0; i < computerJSONArray.length(); i++) {
+			JSONObject curComputerJSONObject = computerJSONArray.getJSONObject(
 				i);
 
 			if (curComputerJSONObject.getBoolean("idle") &&

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -74,10 +74,10 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 		sb.append("{available=");
 		sb.append(availableSlavesCount);
-		sb.append(", reportedSlavesAvailable=");
-		sb.append(_reportedSlavesAvailable);
 		sb.append(", recentBatchSizesTotal=");
 		sb.append(recentBatchSizesTotal);
+		sb.append(", reportedSlavesAvailable=");
+		sb.append(_reportedSlavesAvailable);
 		sb.append(", url=");
 		sb.append(_masterURL);
 		sb.append("}");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author Peter Yoo
+ */
+public class JenkinsMaster implements Comparable<JenkinsMaster> {
+
+	public JenkinsMaster(String masterName) {
+		_masterName = masterName;
+		_masterURL = "http://" + masterName;
+		_recentBatchesMap = new TreeMap<>();
+	}
+
+	public void addRecentBatch(int batchSize) {
+		_recentBatchesMap.put(
+			System.currentTimeMillis() + _RECENT_BATCH_AGE, batchSize);
+
+		getAvailableSlavesCount();
+	}
+
+	@Override
+	public int compareTo(JenkinsMaster otherJenkinsMaster) {
+		Integer availableSlavesCount = getAvailableSlavesCount();
+		Integer otherAvailableSlavesCount =
+			otherJenkinsMaster.getAvailableSlavesCount();
+
+		int availableSlavesCountCompareToResult =
+			-1 * (availableSlavesCount.compareTo(otherAvailableSlavesCount));
+
+		if (availableSlavesCountCompareToResult != 0) {
+			return availableSlavesCountCompareToResult;
+		}
+
+		Random random = new Random();
+
+		while (true) {
+			int result = random.nextInt(3) - 1;
+
+			if (result != 0) {
+				return result;
+			}
+		}
+	}
+
+	public int getAvailableSlavesCount() {
+		int totalRecentBatchSizes = _getTotalRecentBatcheSizes();
+
+		int availableSlavesCount =
+			_reportedSlavesAvailable - totalRecentBatchSizes;
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{available=");
+		sb.append(availableSlavesCount);
+		sb.append(", reportedSlavesAvailable=");
+		sb.append(_reportedSlavesAvailable);
+		sb.append(", recentBatchSizesTotal=");
+		sb.append(totalRecentBatchSizes);
+		sb.append(", url=");
+		sb.append(_masterURL);
+		sb.append("}");
+
+		_summary = sb.toString();
+
+		return availableSlavesCount;
+	}
+
+	public String getMasterName() {
+		return _masterName;
+	}
+
+	public boolean isAvailable() {
+		return _available;
+	}
+
+	@Override
+	public String toString() {
+		getAvailableSlavesCount();
+
+		return _summary;
+	}
+
+	public void update() {
+		JSONObject computerJSONObject = null;
+		JSONObject queueJSONObject = null;
+
+		try {
+			computerJSONObject = JenkinsResultsParserUtil.toJSONObject(
+				JenkinsResultsParserUtil.getLocalURL(
+					JenkinsResultsParserUtil.combine(
+						_masterURL,
+						"/computer/api/json?tree=computer[displayName,",
+						"idle,offline]")),
+				false, 5000);
+			queueJSONObject = JenkinsResultsParserUtil.toJSONObject(
+				JenkinsResultsParserUtil.getLocalURL(
+					_masterURL + "/queue/api/json?tree=items[task[name],why]"),
+				false, 5000);
+		}
+		catch (Exception e) {
+			System.out.println("Unable to read " + _masterURL);
+
+			_available = false;
+
+			return;
+		}
+
+		_available = true;
+
+		int idleCount = 0;
+
+		JSONArray computersJSONArray = computerJSONObject.getJSONArray(
+			"computer");
+
+		for (int i = 0; i < computersJSONArray.length(); i++) {
+			JSONObject curComputerJSONObject = computersJSONArray.getJSONObject(
+				i);
+
+			if (curComputerJSONObject.getBoolean("idle") &&
+				!curComputerJSONObject.getBoolean("offline")) {
+
+				String displayName = curComputerJSONObject.getString(
+					"displayName");
+
+				if (!displayName.equals("master")) {
+					idleCount++;
+				}
+			}
+		}
+
+		int queueCount = 0;
+
+		if (queueJSONObject.has("items")) {
+			JSONArray itemsJSONArray = queueJSONObject.getJSONArray("items");
+
+			for (int i = 0; i < itemsJSONArray.length(); i++) {
+				JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
+
+				if (itemJSONObject.has("why")) {
+					String why = itemJSONObject.getString("why");
+
+					if (why.endsWith("is offline")) {
+						continue;
+					}
+				}
+
+				if (itemJSONObject.has("task")) {
+					JSONObject taskJSONObject = itemJSONObject.getJSONObject(
+						"task");
+
+					String taskName = taskJSONObject.getString("name");
+
+					if (taskName.equals("verification-node")) {
+						continue;
+					}
+				}
+
+				queueCount++;
+			}
+		}
+
+		_reportedSlavesAvailable = idleCount - queueCount;
+
+		getAvailableSlavesCount();
+	}
+
+	private int _getTotalRecentBatcheSizes() {
+		long currentTimestamp = System.currentTimeMillis();
+		int totalRecentBatchesSize = 0;
+
+		for (long expiryTimestamp : _recentBatchesMap.keySet()) {
+			if (expiryTimestamp < currentTimestamp) {
+				_recentBatchesMap.remove(expiryTimestamp);
+
+				continue;
+			}
+
+			totalRecentBatchesSize += _recentBatchesMap.get(expiryTimestamp);
+		}
+
+		return totalRecentBatchesSize;
+	}
+
+	private static final long _RECENT_BATCH_AGE = 120 * 1000;
+
+	private boolean _available;
+	private final String _masterName;
+	private final String _masterURL;
+	private final Map<Long, Integer> _recentBatchesMap;
+	private int _reportedSlavesAvailable;
+	private String _summary;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -14,6 +14,8 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -189,14 +191,21 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		long currentTimestamp = System.currentTimeMillis();
 		int totalRecentBatchesSize = 0;
 
+		List<Long> expiredTimestamps = new ArrayList<>(
+			_recentBatchesMap.size());
+
 		for (long expiryTimestamp : _recentBatchesMap.keySet()) {
 			if (expiryTimestamp < currentTimestamp) {
-				_recentBatchesMap.remove(expiryTimestamp);
+				expiredTimestamps.add(expiryTimestamp);
 
 				continue;
 			}
 
 			totalRecentBatchesSize += _recentBatchesMap.get(expiryTimestamp);
+		}
+
+		for (Long expiredTimestamp : expiredTimestamps) {
+			_recentBatchesMap.remove(expiredTimestamp);
 		}
 
 		return totalRecentBatchesSize;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -41,11 +41,11 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	}
 
 	@Override
-	public int compareTo(JenkinsMaster otherJenkinsMaster) {
+	public int compareTo(JenkinsMaster jenkinsMaster) {
 		Integer availableSlavesCount = getAvailableSlavesCount();
 
 		int value = availableSlavesCount.compareTo(
-			otherJenkinsMaster.getAvailableSlavesCount());
+			jenkinsMaster.getAvailableSlavesCount());
 
 		if (value != 0) {
 			return -value;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -194,14 +194,14 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 		List<Long> expiredTimestamps = new ArrayList<>(_batchSizes.size());
 
-		for (long expiryTimestamp : _batchSizes.keySet()) {
-			if (expiryTimestamp < currentTimestamp) {
-				expiredTimestamps.add(expiryTimestamp);
+		for (long expirationTimestamp : _batchSizes.keySet()) {
+			if (expirationTimestamp < currentTimestamp) {
+				expiredTimestamps.add(expirationTimestamp);
 
 				continue;
 			}
 
-			recentBatchSizesTotal += _batchSizes.get(expiryTimestamp);
+			recentBatchSizesTotal += _batchSizes.get(expirationTimestamp);
 		}
 
 		for (Long expiredTimestamp : expiredTimestamps) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -28,15 +28,15 @@ import org.json.JSONObject;
  */
 public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
-	public JenkinsMaster(String masterName) {
+	public JenkinsMaster(String masterName, String masterURL) {
 		_masterName = masterName;
-		_masterURL = "http://" + masterName;
+		_masterURL = masterURL;
 		_recentBatchesMap = new TreeMap<>();
 	}
 
 	public void addRecentBatch(int batchSize) {
 		_recentBatchesMap.put(
-			System.currentTimeMillis() + _RECENT_BATCH_AGE, batchSize);
+			System.currentTimeMillis() + maxRecentBatchAge, batchSize);
 
 		getAvailableSlavesCount();
 	}
@@ -187,6 +187,8 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		getAvailableSlavesCount();
 	}
 
+	protected static long maxRecentBatchAge = 120 * 1000;
+
 	private int _getTotalRecentBatcheSizes() {
 		long currentTimestamp = System.currentTimeMillis();
 		int totalRecentBatchesSize = 0;
@@ -210,8 +212,6 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 		return totalRecentBatchesSize;
 	}
-
-	private static final long _RECENT_BATCH_AGE = 120 * 1000;
 
 	private boolean _available;
 	private final String _masterName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -66,16 +66,16 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		int recentBatchSizesTotal = _getRecentBatchSizesTotal();
 
 		int availableSlavesCount =
-			_reportedSlavesAvailable - recentBatchSizesTotal;
+			_reportedAvailableSlavesCount - recentBatchSizesTotal;
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("{available=");
+		sb.append("{availableSlavesCount=");
 		sb.append(availableSlavesCount);
 		sb.append(", recentBatchSizesTotal=");
 		sb.append(recentBatchSizesTotal);
-		sb.append(", reportedSlavesAvailable=");
-		sb.append(_reportedSlavesAvailable);
+		sb.append(", reportedAvailableSlavesCount=");
+		sb.append(_reportedAvailableSlavesCount);
 		sb.append(", url=");
 		sb.append(_masterURL);
 		sb.append("}");
@@ -179,7 +179,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 			}
 		}
 
-		_reportedSlavesAvailable = idleCount - queueCount;
+		_reportedAvailableSlavesCount = idleCount - queueCount;
 
 		getAvailableSlavesCount();
 	}
@@ -213,7 +213,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	private final Map<Long, Integer> _batchSizes = new TreeMap<>();
 	private final String _masterName;
 	private final String _masterURL;
-	private int _reportedSlavesAvailable;
+	private int _reportedAvailableSlavesCount;
 	private String _summary;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -65,10 +65,10 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	}
 
 	public int getAvailableSlavesCount() {
-		int totalRecentBatchSizes = _getTotalRecentBatchSizes();
+		int recentBatchSizesTotal = _getRecentBatchSizesTotal();
 
 		int availableSlavesCount =
-			_reportedSlavesAvailable - totalRecentBatchSizes;
+			_reportedSlavesAvailable - recentBatchSizesTotal;
 
 		StringBuilder sb = new StringBuilder();
 
@@ -77,7 +77,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		sb.append(", reportedSlavesAvailable=");
 		sb.append(_reportedSlavesAvailable);
 		sb.append(", recentBatchSizesTotal=");
-		sb.append(totalRecentBatchSizes);
+		sb.append(recentBatchSizesTotal);
 		sb.append(", url=");
 		sb.append(_masterURL);
 		sb.append("}");
@@ -188,9 +188,9 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 	protected static long maxRecentBatchAge = 120 * 1000;
 
-	private synchronized int _getTotalRecentBatchSizes() {
+	private synchronized int _getRecentBatchSizesTotal() {
 		long currentTimestamp = System.currentTimeMillis();
-		int totalRecentBatchSizes = 0;
+		int recentBatchSizesTotal = 0;
 
 		List<Long> expiredTimestamps = new ArrayList<>(_batchSizes.size());
 
@@ -201,14 +201,14 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 				continue;
 			}
 
-			totalRecentBatchSizes += _batchSizes.get(expiryTimestamp);
+			recentBatchSizesTotal += _batchSizes.get(expiryTimestamp);
 		}
 
 		for (Long expiredTimestamp : expiredTimestamps) {
 			_batchSizes.remove(expiredTimestamp);
 		}
 
-		return totalRecentBatchSizes;
+		return recentBatchSizesTotal;
 	}
 
 	private boolean _available;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -158,14 +158,6 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 			for (int i = 0; i < itemsJSONArray.length(); i++) {
 				JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
 
-				if (itemJSONObject.has("why")) {
-					String why = itemJSONObject.getString("why");
-
-					if (why.endsWith("is offline")) {
-						continue;
-					}
-				}
-
 				if (itemJSONObject.has("task")) {
 					JSONObject taskJSONObject = itemJSONObject.getJSONObject(
 						"task");
@@ -173,6 +165,14 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 					String taskName = taskJSONObject.getString("name");
 
 					if (taskName.equals("verification-node")) {
+						continue;
+					}
+				}
+
+				if (itemJSONObject.has("why")) {
+					String why = itemJSONObject.getString("why");
+
+					if (why.endsWith("is offline")) {
 						continue;
 					}
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -31,7 +31,6 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	public JenkinsMaster(String masterName, String masterURL) {
 		_masterName = masterName;
 		_masterURL = masterURL;
-		_recentBatchesMap = new TreeMap<>();
 	}
 
 	public synchronized void addRecentBatch(int batchSize) {
@@ -216,7 +215,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	private boolean _available;
 	private final String _masterName;
 	private final String _masterURL;
-	private final Map<Long, Integer> _recentBatchesMap;
+	private final Map<Long, Integer> _recentBatchesMap = new TreeMap<>();
 	private int _reportedSlavesAvailable;
 	private String _summary;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -43,10 +43,9 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	@Override
 	public int compareTo(JenkinsMaster otherJenkinsMaster) {
 		Integer availableSlavesCount = getAvailableSlavesCount();
-		Integer otherAvailableSlavesCount =
-			otherJenkinsMaster.getAvailableSlavesCount();
 
-		int value = availableSlavesCount.compareTo(otherAvailableSlavesCount);
+		int value = availableSlavesCount.compareTo(
+			otherJenkinsMaster.getAvailableSlavesCount());
 
 		if (value != 0) {
 			return -value;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -46,11 +46,10 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		Integer otherAvailableSlavesCount =
 			otherJenkinsMaster.getAvailableSlavesCount();
 
-		int availableSlavesCountCompareToResult =
-			-1 * (availableSlavesCount.compareTo(otherAvailableSlavesCount));
+		int value = availableSlavesCount.compareTo(otherAvailableSlavesCount);
 
-		if (availableSlavesCountCompareToResult != 0) {
-			return availableSlavesCountCompareToResult;
+		if (value != 0) {
+			return -value;
 		}
 
 		Random random = new Random();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -34,7 +34,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	}
 
 	public synchronized void addRecentBatch(int batchSize) {
-		_recentBatchesMap.put(
+		_batchSizes.put(
 			System.currentTimeMillis() + maxRecentBatchAge, batchSize);
 
 		getAvailableSlavesCount();
@@ -193,20 +193,20 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		int totalRecentBatchSizes = 0;
 
 		List<Long> expiredTimestamps = new ArrayList<>(
-			_recentBatchesMap.size());
+			_batchSizes.size());
 
-		for (long expiryTimestamp : _recentBatchesMap.keySet()) {
+		for (long expiryTimestamp : _batchSizes.keySet()) {
 			if (expiryTimestamp < currentTimestamp) {
 				expiredTimestamps.add(expiryTimestamp);
 
 				continue;
 			}
 
-			totalRecentBatchSizes += _recentBatchesMap.get(expiryTimestamp);
+			totalRecentBatchSizes += _batchSizes.get(expiryTimestamp);
 		}
 
 		for (Long expiredTimestamp : expiredTimestamps) {
-			_recentBatchesMap.remove(expiredTimestamp);
+			_batchSizes.remove(expiredTimestamp);
 		}
 
 		return totalRecentBatchSizes;
@@ -215,7 +215,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	private boolean _available;
 	private final String _masterName;
 	private final String _masterURL;
-	private final Map<Long, Integer> _recentBatchesMap = new TreeMap<>();
+	private final Map<Long, Integer> _batchSizes = new TreeMap<>();
 	private int _reportedSlavesAvailable;
 	private String _summary;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -74,12 +74,12 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 		sb.append(availableSlavesCount);
 
+		sb.append(", masterURL=");
+		sb.append(_masterURL);
 		sb.append(", recentBatchSizesTotal=");
 		sb.append(recentBatchSizesTotal);
 		sb.append(", reportedAvailableSlavesCount=");
 		sb.append(_reportedAvailableSlavesCount);
-		sb.append(", masterURL=");
-		sb.append(_masterURL);
 		sb.append("}");
 
 		_summary = sb.toString();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -78,7 +78,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		sb.append(recentBatchSizesTotal);
 		sb.append(", reportedAvailableSlavesCount=");
 		sb.append(_reportedAvailableSlavesCount);
-		sb.append(", url=");
+		sb.append(", masterURL=");
 		sb.append(_masterURL);
 		sb.append("}");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -193,9 +193,9 @@ public class LoadBalancerUtil {
 	private static List<JenkinsMaster> _getJenkinsMasters(
 		String masterPrefix, Properties properties) {
 
-		List<JenkinsMaster> allJenkinsMasters;
+		List<JenkinsMaster> allJenkinsMasters = null;
 
-		if (!_jenkinsMastersMap.containsKey(masterPrefix)) {
+		if (!_jenkinsMasters.containsKey(masterPrefix)) {
 			allJenkinsMasters = new ArrayList<>();
 
 			for (String masterName :
@@ -210,19 +210,20 @@ public class LoadBalancerUtil {
 								"jenkins.local.url[", masterName, "]"))));
 			}
 
-			_jenkinsMastersMap.put(masterPrefix, allJenkinsMasters);
+			_jenkinsMasters.put(masterPrefix, allJenkinsMasters);
 		}
 		else {
-			allJenkinsMasters = _jenkinsMastersMap.get(masterPrefix);
+			allJenkinsMasters = _jenkinsMasters.get(masterPrefix);
 		}
 
 		List<String> blacklist = _getBlacklist(properties);
-		List<JenkinsMaster> filteredJenkinsMasters = new ArrayList<>(
-			allJenkinsMasters.size());
 
 		if (blacklist.isEmpty()) {
 			return allJenkinsMasters;
 		}
+
+		List<JenkinsMaster> filteredJenkinsMasters = new ArrayList<>(
+			allJenkinsMasters.size());
 
 		for (JenkinsMaster jenkinsMaster : allJenkinsMasters) {
 			if (blacklist.contains(jenkinsMaster.getMasterName())) {
@@ -305,7 +306,7 @@ public class LoadBalancerUtil {
 
 	private static final int _MAX_RETRIES = 3;
 
-	private static final Map<String, List<JenkinsMaster>> _jenkinsMastersMap =
+	private static final Map<String, List<JenkinsMaster>> _jenkinsMasters =
 		new HashMap<>();
 	private static final Map<String, Long> _nextUpdateTimestampMap =
 		new HashMap<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -54,11 +54,15 @@ public class LoadBalancerUtil {
 				List<JenkinsMaster> jenkinsMasters = _getJenkinsMasters(
 					masterPrefix, properties);
 
+				long nextUpdateTimestamp = _getNextUpdateTimestamp(
+					masterPrefix);
+
 				if (nextUpdateTimestamp < System.currentTimeMillis()) {
 					_updateJenkinsMasters(jenkinsMasters);
 
-					nextUpdateTimestamp =
-						System.currentTimeMillis() + _updateInterval;
+					_setNextUpdateTimestamp(
+						masterPrefix,
+						System.currentTimeMillis() + _updateInterval);
 				}
 
 				Collections.sort(jenkinsMasters);
@@ -241,6 +245,20 @@ public class LoadBalancerUtil {
 		return matcher.group("masterPrefix");
 	}
 
+	private static long _getNextUpdateTimestamp(String masterPrefix) {
+		if (!_nextUpdateTimestampMap.containsKey(masterPrefix)) {
+			return 0;
+		}
+
+		else return _nextUpdateTimestampMap.get(masterPrefix);
+	}
+
+	private static void _setNextUpdateTimestamp(
+		String masterPrefix, long nextUpdateTimestamp) {
+
+		_nextUpdateTimestampMap.put(masterPrefix, nextUpdateTimestamp);
+	}
+
 	private static void _updateJenkinsMasters(
 		List<JenkinsMaster> jenkinsMasters) {
 
@@ -289,9 +307,10 @@ public class LoadBalancerUtil {
 
 	private static final Map<String, List<JenkinsMaster>> _jenkinsMastersMap =
 		new HashMap<>();
+	private static final Map<String, Long> _nextUpdateTimestampMap =
+		new HashMap<>();
 	private static long _updateInterval = 1000 * 10;
 	private static final Pattern _urlPattern = Pattern.compile(
 		"http://(?<masterPrefix>.+-\\d?).liferay.com");
-	private static long nextUpdateTimestamp;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -182,16 +182,6 @@ public class LoadBalancerUtil {
 		return blacklist;
 	}
 
-	private static String _getMasterPrefix(String baseInvocationURL) {
-		Matcher matcher = _urlPattern.matcher(baseInvocationURL);
-
-		if (!matcher.find()) {
-			return baseInvocationURL;
-		}
-
-		return matcher.group("masterPrefix");
-	}
-
 	private static List<JenkinsMaster> _getJenkinsMasters(
 		String masterPrefix, Properties properties) {
 
@@ -235,6 +225,16 @@ public class LoadBalancerUtil {
 		}
 
 		return filteredJenkinsMasters;
+	}
+
+	private static String _getMasterPrefix(String baseInvocationURL) {
+		Matcher matcher = _urlPattern.matcher(baseInvocationURL);
+
+		if (!matcher.find()) {
+			return baseInvocationURL;
+		}
+
+		return matcher.group("masterPrefix");
 	}
 
 	private static void _updateJenkinsMasters(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -58,7 +58,7 @@ public class LoadBalancerUtil {
 					_updateJenkinsMasters(jenkinsMasters);
 
 					nextUpdateTimestamp =
-						System.currentTimeMillis() + _UPDATE_INTERVAL;
+						System.currentTimeMillis() + _updateInterval;
 				}
 
 				Collections.sort(jenkinsMasters);
@@ -161,6 +161,10 @@ public class LoadBalancerUtil {
 		}
 
 		return getMostAvailableMasterURL(properties);
+	}
+
+	public static void setUpdateInterval(long interval) {
+		_updateInterval = interval;
 	}
 
 	private static List<String> _getBlacklist(Properties properties) {
@@ -283,10 +287,9 @@ public class LoadBalancerUtil {
 
 	private static final int _MAX_RETRIES = 3;
 
-	private static final long _UPDATE_INTERVAL = 1000 * 10;
-
 	private static final Map<String, List<JenkinsMaster>> _jenkinsMastersMap =
 		new HashMap<>();
+	private static long _updateInterval = 1000 * 10;
 	private static final Pattern _urlPattern = Pattern.compile(
 		"http://(?<masterPrefix>.+-\\d?).liferay.com");
 	private static long nextUpdateTimestamp;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -202,12 +202,13 @@ public class LoadBalancerUtil {
 					JenkinsResultsParserUtil.getMasters(
 						properties, masterPrefix)) {
 
-				allJenkinsMasters.add(
-					new JenkinsMaster(
-						masterName,
-						properties.getProperty(
-							JenkinsResultsParserUtil.combine(
-								"jenkins.local.url[", masterName, "]"))));
+				JenkinsMaster jenkinsMaster = new JenkinsMaster(
+					masterName,
+					properties.getProperty(
+						JenkinsResultsParserUtil.combine(
+							"jenkins.local.url[", masterName, "]")));
+
+				allJenkinsMasters.add(jenkinsMaster);
 			}
 
 			_jenkinsMasters.put(masterPrefix, allJenkinsMasters);
@@ -300,7 +301,7 @@ public class LoadBalancerUtil {
 
 		if (jenkinsMasters.isEmpty()) {
 			throw new RuntimeException(
-				"Unable to communicate with any jenkins masters.");
+				"Unable to communicate with any Jenkins masters");
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -35,6 +35,8 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 	public void setUp() throws Exception {
 		downloadSample("test-1", null);
 		downloadSample("test-2", null);
+
+		LoadBalancerUtil.setUpdateInterval(0);
 	}
 
 	@After

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -46,7 +46,7 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 
 	@Test
 	public void testGetMostAvailableMasterURL() throws Exception {
-		LoadBalancerUtil.RECENT_BATCH_AGE = 0;
+		JenkinsMaster.maxRecentBatchAge = 0;
 
 		assertSamples();
 	}

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.model.cache.CacheField;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalServiceUtil;
 import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
@@ -210,7 +211,19 @@ public class LayoutSetImpl extends LayoutSetBaseImpl {
 
 	@Override
 	public Theme getTheme() {
-		return ThemeLocalServiceUtil.getTheme(getCompanyId(), getThemeId());
+		Theme theme = ThemeLocalServiceUtil.getTheme(
+			getCompanyId(), getThemeId());
+
+		if (!theme.getThemeId().equals(getThemeId())) {
+			try {
+				LayoutSetLocalServiceUtil.updateLookAndFeel(
+					getGroupId(), theme.getThemeId(), null, null);
+			}
+			catch (PortalException pe) {
+				_log.error(pe, pe);
+			}
+		}
+		return theme;
 	}
 
 	@Override


### PR DESCRIPTION
[LPS-72368](https://issues.liferay.com/browse/LPS-72368)
When themeLocalServiceImpl:getTheme is called, but the theme cannot be found (usually because it was undeployed while configured), the theme will revert to the default Liferay theme and [WARN messages will appear in the console notifying the developer](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java#L231). However, the reversion is never persisted so if you refresh the page, this message will continue to flood the log with every refresh. Even though the page has already reverted, it will keep trying to get the theme that is no longer there. The only way to stop this is to reconfigure the page from the control panel and set it to another theme. Even then, the control panel will show that the default Liferay theme is set, even though the error messages continue to appear. Ideally, we should persist the reversion right after the WARN messages but we need to call updateLookAndFeel for the LayoutSet and that requires a groupId which we don't have in ThemeLocalServiceImpl. Thus, the next best alternative is calling it in the caller function one level up the stack, in LayoutSetImpl. After this update, successive calls will query the default Liferay theme instead of the undeployed theme and no more WARN messages will appear. 