### PR TITLE
LPS-72406 Better logging for fail scenario in Service Builder when pk is undefined with uuid set to true

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -5225,6 +5225,12 @@ public class ServiceBuilder {
 			}
 		}
 
+		if (uuid && pkList.isEmpty()) {
+			throw new ServiceBuilderException(
+				"Cannot create entity \"" + ejbName +
+					"\" with a uuid without a primary key.");
+		}
+
 		if (hasLocalizationTable) {
 			int index = columnList.indexOf(
 				new EntityColumn("defaultLanguageId"));


### PR DESCRIPTION
/cc @SGM3 

Notes from Shanon:

> This change is to cover better logging of the scenario when you try running "gradlew buildService" with a service.xml as follows:
> ```
> <?xml version="1.0"?>
> <!DOCTYPE service-builder PUBLIC "-//Liferay//DTD Service Builder 7.0.0//EN" "http://www.liferay.com/dtd/liferay-service-builder_7_0_0.dtd">
> 
> <service-builder package-path="com.nps.simple">
> 	<namespace>NPS_SIMPLE</namespace>
> 	<entity local-service="true" name="BasicEntry" remote-service="true" uuid="true"/>
> </service-builder>
> ```
> it fails with an obscure FTL error when the real issue is "uuid" is set to true for an entity without a primary key defined.
> 
> The current liferay-plugin gradle pulls the 1.55 version of service builder (line 14 in `gradle-plugins-service-builder/build.gradle`, which in turn is used by Line 12 in `gradle-plugins/build.gradle`).
> 
> This can be overridden in a service-builder module's build.gradle by have a dependency as follows:
> ```
> dependencies {
>         // other dependencies
>         serviceBuilder group: "com.liferay", name: "com.liferay.portal.tools.service.builder", version: "<MY-NEW-VERSION>"
> }
> 
> ```
> Now with a more appropriate message, using the entity name.
> 
> The approach I took was to capture the Entity right after it is parsed for its primary key columns. In this location, I check to see if the uuid flag was set for the entity and fail the buildSerivice if no PK's were defined.
> 
> PS. I recommend added a custom string to the artifact version (effectively the Bundle-Version in the bnd.dn file) before doing a `gw clean install` on the module so you wont affect the dirty the one in your m2 directory.
