### PR TITLE
LPS-68408 Use TimeZone to get JVM time zone

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
@@ -109,6 +109,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletContext;
@@ -241,15 +242,15 @@ public class MainServlet extends ActionServlet {
 				_log.warn(sb.toString());
 			}
 
-			String userTimeZone = System.getProperty("user.timezone");
+			String jvmTimeZone = TimeZone.getDefault().getID();
 
-			if (!Objects.equals("UTC", userTimeZone) &&
-				!Objects.equals("GMT", userTimeZone)) {
+			if (!Objects.equals("UTC", jvmTimeZone) &&
+				!Objects.equals("GMT", jvmTimeZone)) {
 
 				StringBundler sb = new StringBundler(4);
 
 				sb.append("The default JVM time zone \"");
-				sb.append(userTimeZone);
+				sb.append(jvmTimeZone);
 				sb.append("\" is not UTC or GMT. Please review the JVM ");
 				sb.append("property \"user.timezone\".");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-68408
https://issues.liferay.com/browse/LPP-25452

TimeZone.getDefault() grabs the jvmarg and is used for Time.java (via Date.java, TimeZone.java).

Assuming user.timezone used to be synced with the jvmarg, I haven't found the LPS which causes user.timezone to deviate from the JVM user.timezone.