### PR TITLE
LPS-72648

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/util/DDLImpl.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/util/DDLImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -111,55 +112,105 @@ public class DDLImpl implements DDL {
 			String fieldType = field.getType();
 			Object fieldValue = field.getValue(locale);
 
-			if (fieldValue instanceof Date) {
-				jsonObject.put(fieldName, ((Date)fieldValue).getTime());
+			if (Validator.isNull(fieldValue)) {
+				continue;
 			}
-			else if (fieldType.equals(DDMFormFieldType.DOCUMENT_LIBRARY) &&
-					 Validator.isNotNull(fieldValue)) {
 
-				JSONObject fieldValueJSONObject =
-					JSONFactoryUtil.createJSONObject(
-						String.valueOf(fieldValue));
+			Object[] fieldValues;
 
-				String uuid = fieldValueJSONObject.getString("uuid");
-				long groupId = fieldValueJSONObject.getLong("groupId");
-
-				fieldValueJSONObject.put(
-					"title", getFileEntryTitle(uuid, groupId));
-
-				jsonObject.put(fieldName, fieldValueJSONObject.toString());
+			if (fieldValue instanceof Object[]) {
+				fieldValues = (Object[])fieldValue;
 			}
-			else if (fieldType.equals(DDMFormFieldType.LINK_TO_PAGE) &&
-					 Validator.isNotNull(fieldValue)) {
+			else {
+				fieldValues = new Object[1];
 
-				JSONObject fieldValueJSONObject =
-					JSONFactoryUtil.createJSONObject(
-						String.valueOf(fieldValue));
-
-				long groupId = fieldValueJSONObject.getLong("groupId");
-				boolean privateLayout = fieldValueJSONObject.getBoolean(
-					"privateLayout");
-				long layoutId = fieldValueJSONObject.getLong("layoutId");
-
-				String layoutName = getLayoutName(
-					groupId, privateLayout, layoutId,
-					LanguageUtil.getLanguageId(locale));
-
-				fieldValueJSONObject.put("name", layoutName);
-
-				jsonObject.put(fieldName, fieldValueJSONObject.toString());
+				fieldValues[0] = fieldValue;
 			}
-			else if ((fieldType.equals(DDMFormFieldType.RADIO) ||
-					  fieldType.equals(DDMFormFieldType.SELECT)) &&
-					 Validator.isNotNull(fieldValue)) {
 
-				fieldValue = JSONFactoryUtil.createJSONArray(
-					String.valueOf(fieldValue));
+			JSONArray fieldJSONArray = null;
+			StringBundler sb = new StringBundler();
+			String jsonObjectValueName = null;
 
-				jsonObject.put(fieldName, (JSONArray)fieldValue);
+			for (int i = 0; i < fieldValues.length; i++) {
+				fieldValue = fieldValues[i];
+
+				if (Validator.isNull(fieldValue)) {
+					continue;
+				}
+
+				if (sb.length() != 0) {
+					sb.append(StringPool.COMMA_AND_SPACE);
+				}
+
+				if (fieldValue instanceof Date) {
+					sb.append(((Date)fieldValue).getTime());
+				}
+				else if (fieldType.equals(DDMFormFieldType.DOCUMENT_LIBRARY)) {
+					JSONObject fieldValueJSONObject =
+						JSONFactoryUtil.createJSONObject(
+							String.valueOf(fieldValue));
+
+					String uuid = fieldValueJSONObject.getString("uuid");
+					long groupId = fieldValueJSONObject.getLong("groupId");
+
+					jsonObjectValueName = "title";
+
+					sb.append(getFileEntryTitle(uuid, groupId));
+				}
+				else if (fieldType.equals(DDMFormFieldType.LINK_TO_PAGE)) {
+					JSONObject fieldValueJSONObject =
+						JSONFactoryUtil.createJSONObject(
+							String.valueOf(fieldValue));
+
+					long groupId = fieldValueJSONObject.getLong("groupId");
+					boolean privateLayout = fieldValueJSONObject.getBoolean(
+						"privateLayout");
+					long layoutId = fieldValueJSONObject.getLong("layoutId");
+
+					jsonObjectValueName = "name";
+
+					String layoutName = getLayoutName(
+						groupId, privateLayout, layoutId,
+						LanguageUtil.getLanguageId(locale));
+
+					sb.append(layoutName);
+				}
+				else if (fieldType.equals(DDMFormFieldType.RADIO) ||
+						 fieldType.equals(DDMFormFieldType.SELECT)) {
+
+					if (fieldJSONArray == null) {
+						fieldJSONArray = JSONFactoryUtil.createJSONArray(
+							String.valueOf(fieldValue));
+					}
+					else {
+						JSONArray tempJSONArray =
+							JSONFactoryUtil.createJSONArray(
+								String.valueOf(fieldValue));
+
+						fieldJSONArray.put(tempJSONArray.get(0));
+					}
+				}
+				else {
+					sb.append(String.valueOf(fieldValue));
+				}
 			}
-			else if (Validator.isNotNull(fieldValue)) {
-				jsonObject.put(fieldName, String.valueOf(fieldValue));
+
+			if (fieldType.equals(DDMFormFieldType.DOCUMENT_LIBRARY) ||
+				fieldType.equals(DDMFormFieldType.LINK_TO_PAGE)) {
+
+				JSONObject fieldJSONObject = JSONFactoryUtil.createJSONObject();
+
+				fieldJSONObject.put(jsonObjectValueName, sb.toString());
+
+				jsonObject.put(fieldName, fieldJSONObject.toString());
+			}
+			else if (fieldType.equals(DDMFormFieldType.RADIO) ||
+					 fieldType.equals(DDMFormFieldType.SELECT)) {
+
+				jsonObject.put(fieldName, fieldJSONArray);
+			}
+			else {
+				jsonObject.put(fieldName, sb.toString());
 			}
 		}
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-25555
https://issues.liferay.com/browse/LPS-72648

When viewing a Dynamic Data List in "spreadsheet view," fields that are repeatable will either not display correctly, or cause the page to fail to load with a stack trace in the console.

This is because DDLImpl's [getRecordJSONObject() method](https://github.com/liferay/liferay-portal/blob/master/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/util/DDLImpl.java#L80) does not take repeatable fields into account; repeatable fields' values are retrieved as an array of field values, but treated as though they are a single Object (typically a String). A single JSONObject is expected to hold the value for the JSONObject using the field name as an identifier.

I thought of a few ways this could be solved for the "spreadsheet view" case in particular (like using something other than DDLImpl to retrieve the DDLRecord values), but as of now I think this is the correct way to do it, since the code in this method appears to be incorrect regardless; I essentially just fit all the values into a list of values where appropriate, so they could still be used within a single JSONObject like this method presupposes. This did mean a lot of the code had to be rewritten to allow for it to be done in a loop, however.

Please let me know of any questions, concerns, or improvements that can be made. Thanks!