### PR TITLE
LPS-72654 Updating DXP KB build number to 20 putting it ahead of 6.2

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/service.properties
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/service.properties
@@ -13,6 +13,6 @@
 ##
 
     build.namespace=KB
-    build.number=15
-    build.date=1423136031621
+    build.number=20
+    build.date=1495211376000
     build.auto.upgrade=true


### PR DESCRIPTION
As per a recommendation from Minhchau Dang, I will be increasing KB's build number to 20. This brings master ahead of the plugins-ee build number (it was incremented incorrectly in LPS-67188). This also brings master's build number forward as it should have been after LPS-57585 and adds a bit of a buffer between plugins-ee and master. 