### PR TITLE
[TECHNICAL SUPPORT] LPS-72548 Avoid NPE when query index is empty

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchQuerySuggester.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchQuerySuggester.java
@@ -177,19 +177,21 @@ public class ElasticsearchQuerySuggester extends BaseQuerySuggester {
 		SuggesterResult suggesterResult = suggesterResults.getSuggesterResult(
 			phraseSuggester.getName());
 
-		List<SuggesterResult.Entry> suggesterResultEntries =
-			suggesterResult.getEntries();
+		if (suggesterResult != null) {
+			List<SuggesterResult.Entry> suggesterResultEntries =
+				suggesterResult.getEntries();
 
-		for (SuggesterResult.Entry suggesterResultEntry :
+			for (SuggesterResult.Entry suggesterResultEntry :
 				suggesterResultEntries) {
 
-			for (SuggesterResult.Entry.Option suggesterResultEntryOption :
+				for (SuggesterResult.Entry.Option suggesterResultEntryOption :
 					suggesterResultEntry.getOptions()) {
 
-				String optionText = String.valueOf(
-					suggesterResultEntryOption.getText());
+					String optionText = String.valueOf(
+						suggesterResultEntryOption.getText());
 
-				keywordQueries.add(optionText);
+					keywordQueries.add(optionText);
+				}
 			}
 		}
 


### PR DESCRIPTION
When using the search portlet, if you don't get over a certain threshold of results, you should receive "Related Queries" suggestions. However, when there are no queries that have been indexed yet, attempting to get the list of results returns an NPE. 
While the client did not specifically report this issue with search in [LPP-25506,](https://issues.liferay.com/browse/LPP-25506) they will most likely encounter it as they continue to use the search portlet so should they request a hotfix, this fix will be included. 
The other issue reported deals with the spell check suggestions with search which appear to be fixed by [LPS-72653](https://issues.liferay.com/browse/LPS-72653).