### PR TITLE
LPS-73053

### DIFF
--- a/modules/apps/web-experience/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@
 
 <c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) %>">
 	<div class="alert alert-info hide" id="<portlet:namespace />nested-portlets-msg">
-		<liferay-ui:message key="drag-portlets-below-to-nest-them" />
+		<liferay-ui:message key="drag-applications-below-to-nest-them" />
 	</div>
 
 	<aui:script sandbox="<%= true %>">

--- a/modules/apps/web-experience/nested-portlets/nested-portlets-web/src/main/resources/content/Language.properties
+++ b/modules/apps/web-experience/nested-portlets/nested-portlets-web/src/main/resources/content/Language.properties
@@ -1,4 +1,4 @@
-drag-portlets-below-to-nest-them=Drag portlets below to nest them.
-javax.portlet.title.com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet=Nested Portlets
-nested.portlets.configuration.name=Nested Portlets Options
-nested.portlets.portlet.instance.configuration.name=Nested Portlets
+drag-applications-below-to-nest-them=Drag applications below to nest them.
+javax.portlet.title.com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet=Nested Applications
+nested.portlets.configuration.name=Nested Applications Options
+nested.portlets.portlet.instance.configuration.name=Nested Applications


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-25921
https://issues.liferay.com/browse/LPS-73053
https://issues.liferay.com/browse/PTR-82

The use of the word "portlet" in "Nested Portlets" on the user end in the UI is incorrect; according to [PTR-82](https://issues.liferay.com/browse/PTR-82) (see for original discussion), the portlet presented to the user should be called "Nested Applications."

The word "portlet" should only be allowed in the UI in a technical context, when it refers to the portlet technology being used. Thus, for some cases (such as, according to PTR-82, the "Hello Soy Portlet"), the term is acceptable -- but in this case, it should be avoided.

Note that, in this case, I only opted to change the values for language keys, because they are the messages exposed to the end user. I also did not change the actual keys themselves for the most part -- I only changed "drag-nested-portlets-below-to-nest-them" to "drag-applications-below-to-nest-them" in order to match our convention of matching the keys to the messages. If more pertaining to this should also be changed though, or should be looked into, please let me know. Thanks.