### PR TITLE
LPS-73064 Ignore dragging inside source editor

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -2968,7 +2968,10 @@ AUI.add(
 							repeatableInstance.add(field.get('container'));
 						}
 
-						A.DD.DDM.getDrag(field.get('container')).addInvalid('.alloy-editor');
+						var drag = A.DD.DDM.getDrag(field.get('container'));
+
+						drag.addInvalid('.alloy-editor');
+						drag.addInvalid('.lfr-source-editor');
 					},
 
 					toJSON: function() {


### PR DESCRIPTION
Relevant ticket: [LPS-73064](https://issues.liferay.com/browse/LPS-73064)

Prior to this fix, the user could not highlight text in the source editor in a sortable list, because it would start dragging the content box to reorder it. This fix adds an ignore for the source editor, so the user is now able to highlight without accidentally dragging.

Let me know if you have any questions!