### PR TITLE
LPS-73055 Added X-Robots-Tag: noindex, nofollow to Search Portlet

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/SearchPortlet.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/SearchPortlet.java
@@ -84,6 +84,8 @@ public class SearchPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			SearchDisplayContext.class.getName(), searchDisplayContext);
 
+		renderResponse.addProperty("X-Robots-Tag", "noindex, nofollow");
+
 		super.render(renderRequest, renderResponse);
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73055
https://issues.liferay.com/browse/LPP-25701

This adds the "X-Robots-Tag: noindex, nofollow" header to the Search Portlet to prevent Google (and other search engine) bots from using the Search Portlet which can cause performance issues as well as crash the Elasticsearch Cluster.