### PR TITLE
LPS-73251 Do not add the delta parameter in the redirect URL if delta is not provided as a parameter in the request

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherHelper.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/util/AssetPublisherHelper.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
+import java.util.Map;
 import java.util.Objects;
 
 import javax.portlet.PortletURL;
@@ -73,13 +74,20 @@ public class AssetPublisherHelper {
 
 		PortletURL redirectURL = liferayPortletResponse.createRenderURL();
 
+		Map<String, String[]> parameterMap =
+			liferayPortletRequest.getParameterMap();
+
+		if (parameterMap.containsKey("delta")) {
+			int delta = ParamUtil.getInteger(liferayPortletRequest, "delta");
+
+			redirectURL.setParameter("delta", String.valueOf(delta));
+		}
+
 		int cur = ParamUtil.getInteger(liferayPortletRequest, "cur");
-		int delta = ParamUtil.getInteger(liferayPortletRequest, "delta");
 		boolean resetCur = ParamUtil.getBoolean(
 			liferayPortletRequest, "resetCur");
 
 		redirectURL.setParameter("cur", String.valueOf(cur));
-		redirectURL.setParameter("delta", String.valueOf(delta));
 		redirectURL.setParameter("resetCur", String.valueOf(resetCur));
 		redirectURL.setParameter(
 			"assetEntryId", String.valueOf(assetEntry.getEntryId()));


### PR DESCRIPTION
Original Ticket:
* [LPP-26021](https://issues.liferay.com/browse/LPP-26021)
* [LPS-73251](https://issues.liferay.com/browse/LPS-73251)

Hi @SamZiemer,

For this issue, the main cause is the **delta** parameter being introduced into the **redirectURL**.  
In our steps to reproduce, the **delta** parameter is actually null, but it is being included in the **redirectURL** with a default value of 0.

This behavior was introduced by [LPS-70373](https://issues.liferay.com/browse/LPS-70373), specifically this commit: 
https://github.com/ealonso/liferay-portal/pull/818/commits/a520f60505f90f83a669b8be90c72723dbb59bff
* **Note:** This commit is labeled with **SF**, but it looks as if it adds additional parameters to the **redirectURL**, compared to the original code, such as the **delta** parameter.

**Approach**
With the above observation, I found it to be quite confusing on how I should approach creating this fix (whether the parameters were intended to be included).

And so, for this fix, I assumed that the engineer who worked on the fix had reasons to include those parameters.  The method involved is called in several places, such as **jsp** files and **ftl** files. 

The approach I eventually took for this fix was to make it so the **delta** parameter would not be added if the parameter was never set in the request.

**Additional Thoughts**
The other parameters that also appear to be introduced into the **redirectURL** are **cur** and **resetCur**.

I also considered creating the same fix for those two parameters as well, but the **delta** parameter was the only parameter I needed to fix to resolve this particular issue.

----
Please let me know if you have any questions.
Thanks!