### PR TITLE
[TECHNICAL SUPPORT] LPS-73279 Log original IP when Liferay behind load balancer

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/MainServlet.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.InactiveRequestHandler;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -1061,8 +1062,14 @@ public class MainServlet extends ActionServlet {
 			if (PropsValues.USERS_UPDATE_LAST_LOGIN ||
 				(user.getLastLoginDate() == null)) {
 
-				user = UserLocalServiceUtil.updateLastLogin(
-					userId, request.getRemoteAddr());
+				String remoteAddr = request.getHeader(
+					HttpHeaders.X_FORWARDED_FOR);
+
+				if (remoteAddr == null) {
+					remoteAddr = request.getRemoteAddr();
+				}
+
+				user = UserLocalServiceUtil.updateLastLogin(userId, remoteAddr);
 			}
 		}
 


### PR DESCRIPTION
**Ticket**
[LPS-73279](https://issues.liferay.com/browse/LPS-73279)
If Liferay is configured behind Apache with load balancers, when a user logs into liferay, their IP address is always registered as the IP address of web server. 
In order to solve this, we can first try to get the original IP address from the "X-Forwarded-For" HTTP header. After this fix, subsequent tests from other computers querying the server all logged those computers' IP addresses instead of the web server's IP address. 
