### PR TITLE
LPS-73354 

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerUtil.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerUtil.java
@@ -290,7 +290,7 @@ public class AssetEntriesCheckerUtil {
 					user.getEmailAddress(), user.getFullName());
 			}
 
-			subscriptionSender.setBulk(true);
+			subscriptionSender.setBulk(false);
 
 			subscriptionSender.flushNotificationsAsync();
 		}


### PR DESCRIPTION
Relevant Ticket:
[LPS-73354](https://issues.liferay.com/browse/LPS-73354)

In this bug, the [$TO_ADDRESS$] and [$TO_NAME$] variables are incorrectly set to the value of [$FROM_ADDRESS$] when creating email notifications for Asset Publisher subscriptions. The emails are delivered to the correct recipients, but if we try to name those recipients in the email body using these variables, they are mishandled.

Bulk emails are meant to have the same email body, which means no personalized names.
Since we want to be able to utilize these variables within email templates for Asset Publisher subscriptions, it is best to not send them in bulk - since we are then able to individualize each email sent out with the respective names and addresses of the recipients.

Let me know if you have any questions!