### PR TITLE
LPP-25843

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -1678,9 +1678,13 @@ public class ServiceBuilder {
 		String methodName = method.getName();
 
 		if (methodName.equals("afterPropertiesSet") ||
+			methodName.equals("clearService") ||
 			methodName.equals("destroy") || methodName.equals("equals") ||
-			methodName.equals("getClass") || methodName.equals("hashCode") ||
-			methodName.equals("notify") || methodName.equals("notifyAll") ||
+			methodName.equals("getClass") || methodName.equals("getService") ||
+			methodName.equals("getWrappedService") ||
+			methodName.equals("hashCode") || methodName.equals("notify") ||
+			methodName.equals("notifyAll") ||
+			methodName.equals("setWrappedService") ||
 			methodName.equals("toString") || methodName.equals("wait")) {
 
 			return false;

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -1698,27 +1698,33 @@ public class ServiceBuilder {
 
 			return false;
 		}
-		else if (methodName.endsWith("Finder") &&
-				 (methodName.startsWith("get") ||
-				  methodName.startsWith("set"))) {
 
-			return false;
-		}
-		else if (methodName.endsWith("Persistence") &&
-				 (methodName.startsWith("get") ||
-				  methodName.startsWith("set"))) {
+		JavaClass javaClass = method.getParentClass();
 
-			return false;
-		}
-		else if (methodName.endsWith("Service") &&
-				 (methodName.startsWith("get") ||
-				  methodName.startsWith("set"))) {
+		String packageName = javaClass.getPackageName();
 
-			return false;
+		if (packageName.endsWith(".service.base")) {
+			if (methodName.endsWith("Finder") &&
+				(methodName.startsWith("get") ||
+				 methodName.startsWith("set"))) {
+
+				return false;
+			}
+			else if (methodName.endsWith("Persistence") &&
+					 (methodName.startsWith("get") ||
+					  methodName.startsWith("set"))) {
+
+				return false;
+			}
+			else if (methodName.endsWith("Service") &&
+					 (methodName.startsWith("get") ||
+					  methodName.startsWith("set"))) {
+
+				return false;
+			}
 		}
-		else {
-			return true;
-		}
+
+		return true;
 	}
 
 	public boolean isHBMCamelCasePropertyAccessor(String propertyName) {

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -1704,21 +1704,45 @@ public class ServiceBuilder {
 		String packageName = javaClass.getPackageName();
 
 		if (packageName.endsWith(".service.base")) {
-			if (methodName.endsWith("Finder") &&
-				(methodName.startsWith("get") ||
-				 methodName.startsWith("set"))) {
+			if (!methodName.endsWith("Finder") &&
+				!methodName.endsWith("Persistence") &&
+				!methodName.endsWith("Service")) {
 
-				return false;
+				return true;
 			}
-			else if (methodName.endsWith("Persistence") &&
-					 (methodName.startsWith("get") ||
-					  methodName.startsWith("set"))) {
 
-				return false;
+			Type[] parameterTypes = method.getParameterTypes(true);
+			Type returnType = method.getReturnType(true);
+
+			Type checkType = null;
+
+			if (methodName.startsWith("get")) {
+				if (ArrayUtil.isEmpty(parameterTypes)) {
+					checkType = returnType;
+				}
 			}
-			else if (methodName.endsWith("Service") &&
-					 (methodName.startsWith("get") ||
-					  methodName.startsWith("set"))) {
+			else if (methodName.startsWith("set")) {
+				if ((parameterTypes != null) && (parameterTypes.length == 1)) {
+					checkType = parameterTypes[0];
+				}
+			}
+
+			if (checkType == null) {
+				return true;
+			}
+
+			String checkTypeName = checkType.getFullyQualifiedName();
+
+			int pos = checkTypeName.lastIndexOf(CharPool.PERIOD);
+
+			if (pos == -1) {
+				return true;
+			}
+
+			String checkPackageName = checkTypeName.substring(0, pos);
+
+			if (checkPackageName.endsWith(".persistence") ||
+				checkPackageName.endsWith(".service")) {
 
 				return false;
 			}


### PR DESCRIPTION
Hi @SamZiemer,
This pr involves resolving an issue in **ServiceBuilder**, where methods are not generated due to the entity name/method name that is being used.

I will try to provide a detailed explanation of the issue and the approach that we took to resolve this issue, as it can be quite confusing.

Also, MCD helped with creating the fix and I took the essential parts of it to create this pull request.

**Main Issue**
The main issue this pr is trying to resolve is that **ServiceBuilder** is not generating an expected method in the LocalService class if the entity name ends with: Finder, Service, or Persistence.

For example, let's say I am using **Service Builder** to generate an entity called **TestService** with a primary key called testId.

The generated class, TestServiceLocalService, will be missing the method:
```public TestService getTestService(long testId)```

**Reason for this behavior**
The main reason is due to how **ServiceBuilder** determines whether the method should be generated.

This is mainly decided by a method that determines whether a method should or should not be considered as a custom method: [ServiceBuilder.java#L1677-L1722](https://github.com/liferay/liferay-portal-ee/blob/fix-pack-de-22-7010/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java#L1677-L1722)

Our main focus are the checks that involve identifying method names that end with:
**Finder**, **Persistence**, and **Service**.

These checks are the reasons why using entity names, such as **TestService**, results in the expected method not being generated.

**Approach**
Looking at the checks that focused on method names ending with **Finder**, **Persistence**, and **Service**, the checks looked quite broad.

After looking through the source code and testing, it appeared that these specific checks were mainly for methods that are being introduced with Service BaseImpl classes.

We further narrowed down the checks by utilizing the method's **parameterTypes** and **returnType**.

**Other Considerations**
With the change, we also considered other methods that we may need to account for.  We found that we also needed to account for methods, such as:
* getWrappedService/setWrappedService
* getService/clearService

These methods are introduced by the ServiceUtil and ServiceWrapper and are not introduced from a Service BaseImpl class.

**Testing**
Here are a few things we tested with the changes:
* Using the ServiceBuilder to rebuild portal services.
  * **Result:** No changes
* Using ServiceBuilder to creating custom entities, such as:
testService, testPersistence, and testFinder.
  * **Result:** method is now being generated in the LocalService class
* Using ServiceBuilder to create custom entities that have methods, such as:
getWrappedService, getService, getTestService
  * **Result:** these methods are not generated

All of the above test results demonstrated expected behavior.

Also, I submitted a pr to myself beforehand to check if the CI tests pass.
The tests completed successfully: https://github.com/ericyanLr/liferay-portal/pull/27#issuecomment-313588869 

----
Please let me know if you have any questions.
Thanks!