### PR TITLE
LPS-73566 Using adjustedDate in validation methods

### DIFF
--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -111,7 +111,7 @@ AUI.add(
 						};
 
 						if (instance._isChecked('rangeDateRangeNode')) {
-							dateRangeChecker.validRange = instance._rangeEndsLater() && instance._rangeEndsInPast(today) && instance._rangeStartsInPast(today);
+							dateRangeChecker.validRange = instance._rangeEndsLater() && instance._rangeEndsInPast(adjustedDate) && instance._rangeStartsInPast(adjustedDate);
 						}
 
 						return dateRangeChecker;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73566

My LPP has been resolved with https://issues.liferay.com/browse/LPS-73377, however, the LPS-73566 issue is now reproducible when completing the same workflow and I'd like to fix it.

To resolve LPS-73566 we use the "adjustedDate" instead of "today" in staging-process-web.  

This change of using "adjustedDate" was previously made in export-import-web GitID: https://github.com/liferay/liferay-portal/commit/4a12dbdd52312aafbcfa0798071fe70a33593466 in https://issues.liferay.com/browse/LPS-67866.
