### PR TITLE
LPS-73629

### DIFF
--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -160,7 +160,7 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 			function(key) {
 				var field = A.one('[name="<portlet:namespace />' + key + '"]');
 
-				if ((field.attr('type') === 'checkbox') || (field.attr('type') === 'radio')) {
+				if (field && ((field.attr('type') === 'checkbox') || (field.attr('type') === 'radio'))) {
 					field = A.one('[name="<portlet:namespace />' + key + '"]:checked');
 
 					fieldsMap[key] = '';
@@ -199,7 +199,9 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				optionalFieldError.replace(optionalFieldError);
 			}
 
-			field.attr('aria-invalid', true);
+			if (field) {
+				field.attr('aria-invalid', true);
+			}
 		}
 		else if (!fieldValidationFunctions[key](currentFieldValue, fieldsMap)) {
 			A.all('.alert-success').hide();
@@ -213,7 +215,9 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				validationError.replace(validationError);
 			}
 
-			field.attr('aria-invalid', true);
+			if (field) {
+				field.attr('aria-invalid', true);
+			}
 		}
 		else {
 			if (optionalFieldError) {
@@ -224,7 +228,9 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				validationError.hide();
 			}
 
-			field.attr('aria-invalid', false);
+			if (field) {
+				field.attr('aria-invalid', false);
+			}
 
 			return true;
 		}

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -182,6 +182,18 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 
 		var field = A.one('[name="<portlet:namespace />' + key + '"]');
 
+		if (field && (field.attr('type') === 'radio')) {
+			var uncheckedOptions = A.all('[name="<portlet:namespace />' + key + '"]:not(:checked)');
+
+			uncheckedOptions.each(
+				function(option) {
+					option.removeAttribute('aria-invalid');
+				}
+			);
+
+			field = A.one('[name="<portlet:namespace />' + key + '"]:checked');
+		}
+
 		var currentFieldValue = fieldsMap[key];
 
 		var optionalFieldError = A.one('#<portlet:namespace />fieldOptionalError' + key);

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -275,17 +275,23 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 
 	keys.forEach(
 		function(key) {
-			var field = A.one('[name="<portlet:namespace />' + key + '"]');
+			var fields = A.all('[name="<portlet:namespace />' + key + '"]');
 
-			field.on(
-				'blur',
-				function(event) {
-					if (!validateField(key)) {
-						event.halt();
-						event.stopImmediatePropagation();
+			var addOnBlurFieldValidation = function(field) {
+				field.on(
+					'blur',
+					function(event) {
+						if (!validateField(key)) {
+							event.halt();
+							event.stopImmediatePropagation();
+						}
 					}
-				});
-		});
+				);
+			};
+
+			fields.each(addOnBlurFieldValidation);
+		}
+	);
 
 	var form = A.one('#<portlet:namespace />fm');
 


### PR DESCRIPTION
Hi @SamZiemer,
This pr mainly focuses on handling nulls when retrieving a field.

**Note: Additional Change when adding onblur validation listener(s)**
While working on adding null checks for the method that adds onblur validation listeners, I noticed that it only retrieved one field per key:
``` var field = A.one('[name="<portlet:namespace />' + key + '"]');```

This meant that if a **radio type** field was used with multiple options, only **one radio option** would have a registered listener.

So, I added an additional change to retrieve all the fields associated with the key, to account for the radio type:
```var fields = A.all('[name="<portlet:namespace />' + key + '"]');```

This allows us to handle the null check by utilizing the returned [NodeList:](http://alloyui.com/api/classes/NodeList.html#method_each)
```fields.each(addOnBlurFieldValidation);```

**Original Tickets:**
[LPS-73629](https://issues.liferay.com/browse/LPS-73629)
[LPP-25030](https://issues.liferay.com/browse/LPP-25030)

----
Also, I did not assign you to the the original [LPP-25030](https://issues.liferay.com/browse/LPP-25030), as it is currently assigned to Michael for reviewing a backport, which is also needed to resolve the ticket.

Please let me know if you have any questions.
Thanks!