### PR TITLE
LPS-73381 obscure LDAP securityCredential

### DIFF
--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/build.gradle
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/build.gradle
@@ -16,7 +16,6 @@ copyTestLibs {
 
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.application.list.api", version: "2.0.0"
-	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.form.renderer", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.form.values.factory", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "2.0.0"
@@ -33,6 +32,7 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"
+	provided project(":apps:forms-and-workflow:dynamic-data-mapping:dynamic-data-mapping-api")
 	provided project(":apps:static:portal-configuration:portal-configuration-persistence")
 
 	testCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.test.util", version: "2.0.0"

--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
@@ -201,6 +201,9 @@ public class ConfigurationModelToDDMFormConverter {
 
 			return DDMFormFieldType.RADIO;
 		}
+		else if (type == AttributeDefinition.PASSWORD) {
+			return DDMFormFieldType.PASSWORD;
+		}
 
 		if (ArrayUtil.isNotEmpty(attributeDefinition.getOptionLabels()) ||
 			ArrayUtil.isNotEmpty(attributeDefinition.getOptionValues())) {

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/configuration/LDAPServerConfiguration.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/configuration/LDAPServerConfiguration.java
@@ -52,7 +52,7 @@ public interface LDAPServerConfiguration {
 	@Meta.AD(deflt = "", required = false)
 	public String securityPrincipal();
 
-	@Meta.AD(deflt = "secret", required = false)
+	@Meta.AD(deflt = "secret", required = false, type = Meta.Type.Password)
 	public String securityCredential();
 
 	@Meta.AD(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-26142
https://issues.liferay.com/browse/LPS-73381

requires dependency : https://github.com/SamZiemer/com-liferay-dynamic-data-mapping/pull/4

We set the type of securityCredential configuration to the newly added password type to hide the sensitive field.

Hope I did this right, if not please let me know how to push these dependent changes  https://github.com/SamZiemer/liferay-portal/pull/333#issuecomment-316564258.  I expect this test to fail because it is incomplete without the dependency.