### PR TITLE
LPS-74023

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
@@ -17,6 +17,7 @@ package com.liferay.users.admin.internal.exportimport.data.handler;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -481,7 +482,16 @@ public class OrganizationStagedModelDataHandler
 
 	@Override
 	protected void importReferenceStagedModels(
-		PortletDataContext portletDataContext, Organization organization) {
+			PortletDataContext portletDataContext, Organization organization)
+		throws PortletDataException {
+
+		if (organization.getParentOrganizationId() !=
+				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {
+
+			StagedModelDataHandlerUtil.importReferenceStagedModel(
+				portletDataContext, organization, Organization.class,
+				organization.getParentOrganizationId());
+		}
 	}
 
 	protected void importWebsites(


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-26614
https://issues.liferay.com/browse/LPS-74023

[LPS-49805](https://issues.liferay.com/browse/LPS-49805) added the implementation in master and ee-7.0.x for automatic importing of references for content, allowing content organized in hierarchies to enforce an order using these references (e.g., Organizations with parents that must be imported first). Organizations already had [their own custom implementation for importing references in `OrganizationStagedModelDatahandler`](https://github.com/matethurzo/liferay-portal/blob/4dad1dac670c069d248468852f7e5f659b792910/portal-impl/src/com/liferay/portlet/usersadmin/lar/OrganizationStagedModelDataHandler.java#L144), so one of the commits for LPS-49805 also added [an overriding method](https://github.com/danielkocsis/liferay-portal/pull/411/commits/4dad1dac670c069d248468852f7e5f659b792910#diff-847dbeae2d1b7c3552d1a4bfb80f60d3R477) to skip the new, generic implementation in favor of Organizations' custom one.

However, [LPS-50145](https://issues.liferay.com/browse/LPS-50145) then removed this code (see https://github.com/brianchandotcom/liferay-portal/pull/21040/commits/779ac21fc60ff2ab66be6aed2e926766bb1cbcd1), in favor of the generic implementation, even though [the overriding method added in LPS-49805](https://github.com/danielkocsis/liferay-portal/pull/411/commits/4dad1dac670c069d248468852f7e5f659b792910#diff-847dbeae2d1b7c3552d1a4bfb80f60d3R477) would still cause that to be skipped. Thus, there is now no way for Organizations to enforce references being imported correctly.

This can cause a number of strange behaviors, including Organizations that should have a parent becoming root Organizations depending on the order imported.

The `BaseStagedModelDataHandler` implementation of importing references would not entirely work for Organizations, because the "references" for Organizations actually reference the Organization, and so must be imported afterward (see https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java#L201).

But, since the parent Organization must be imported first, this reference alone can and should be imported first, so it can be done when the `BaseStagedModelDataHandler` triggers it. So this fix simply re-adds [the code removed with LPS-50145](https://github.com/brianchandotcom/liferay-portal/pull/21040/commits/779ac21fc60ff2ab66be6aed2e926766bb1cbcd1) (but into the overriding method, so it can at least somewhat match the pattern that seemed to be the intention of the change).

Please let me know if there are any problems with this. Thanks!