### PR TITLE
LPP-26493

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8245,12 +8245,11 @@ public class PortalImpl implements Portal {
 		String canonicalURLPrefix = canonicalURL.substring(0, pos);
 		String canonicalURLSuffix = canonicalURL.substring(pos);
 
-		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			String defaultLocalePath = _buildI18NPath(
-				siteDefaultLocale.getLanguage(), siteDefaultLocale);
+		String i18nPath = buildI18NPath(themeDisplay.getLocale());
 
-			canonicalURLSuffix = canonicalURL.substring(
-				pos + defaultLocalePath.length());
+		if (themeDisplay.isI18n() && canonicalURLSuffix.startsWith(i18nPath)) {
+			canonicalURLSuffix = canonicalURLSuffix.substring(
+				i18nPath.length());
 		}
 
 		for (Locale locale : availableLocales) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1377,19 +1377,6 @@ public class PortalImpl implements Portal {
 			layout.getLayoutSet(), themeDisplay, true,
 			layout.isTypeControlPanel());
 
-		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			StringBundler sb = new StringBundler();
-
-			sb.append(groupFriendlyURL);
-			sb.append(
-				_buildI18NPath(
-					siteDefaultLocale.getLanguage(), siteDefaultLocale));
-			sb.append(canonicalLayoutFriendlyURL);
-			sb.append(parametersURL);
-
-			return sb.toString();
-		}
-
 		return groupFriendlyURL.concat(canonicalLayoutFriendlyURL).concat(
 			parametersURL);
 	}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8183,9 +8183,20 @@ public class PortalImpl implements Portal {
 		}
 
 		if ((pos <= 0) || (pos >= canonicalURL.length())) {
+			Locale siteDefaultLocale = getSiteDefaultLocale(
+				layout.getGroupId());
+
 			for (Locale locale : availableLocales) {
-				alternateURLs.put(
-					locale, canonicalURL.concat(buildI18NPath(locale)));
+				if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) ||
+					!siteDefaultLocale.equals(locale)) {
+
+					alternateURLs.put(
+						locale, canonicalURL.concat(buildI18NPath(locale)));
+
+					continue;
+				}
+
+				alternateURLs.put(locale, canonicalURL);
 			}
 
 			return alternateURLs;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8353,6 +8353,18 @@ public class PortalImpl implements Portal {
 							path = PropsValues.WIDGET_SERVLET_MAPPING;
 						}
 
+						Locale siteDefaultLocale = getSiteDefaultLocale(
+							group.getGroupId());
+
+						if (themeDisplay.isI18n() &&
+							((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE ==
+								2) ||
+							 !siteDefaultLocale.equals(
+								 themeDisplay.getLocale()))) {
+
+							path = buildI18NPath(themeDisplay.getLocale());
+						}
+
 						if (!StringUtil.equalsIgnoreCase(
 								virtualHostname, _LOCALHOST) &&
 							!_isSameHostName(virtualHostname, portalDomain)) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8462,8 +8462,20 @@ public class PortalImpl implements Portal {
 		sb.append(portalURL);
 		sb.append(_pathContext);
 
-		if (themeDisplay.isI18n() && !canonicalURL) {
-			sb.append(themeDisplay.getI18nPath());
+		if (themeDisplay.isI18n()) {
+			if (canonicalURL) {
+				Locale siteDefaultLocale = getSiteDefaultLocale(
+					group.getGroupId());
+
+				if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) ||
+					!siteDefaultLocale.equals(themeDisplay.getLocale())) {
+
+					sb.append(buildI18NPath(themeDisplay.getLocale()));
+				}
+			}
+			else {
+				sb.append(themeDisplay.getI18nPath());
+			}
 		}
 
 		if (themeDisplay.isWidget()) {

--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -48,7 +48,7 @@ if (!themeDisplay.isSignedIn() && layout.isPublicLayout()) {
 	%>
 
 			<c:if test="<%= availableLocale.equals(defaultLocale) %>">
-				<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(canonicalURL) %>" hreflang="x-default" rel="alternate" />
+				<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(alternateURL) %>" hreflang="x-default" rel="alternate" />
 			</c:if>
 
 			<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(alternateURL) %>" hreflang="<%= LocaleUtil.toW3cLanguageId(availableLocale) %>" rel="alternate" />


### PR DESCRIPTION
Hi @SamZiemer,

Original Tickets:
[LPP-26493](https://issues.liferay.com/browse/LPP-26493)
[LPS-74031](https://issues.liferay.com/browse/LPS-74031)

I actually will not be here next week, which is why this pr has commits with detailed commit messages. 

Hopefully the commit messages and the description on [LPS-74031](https://issues.liferay.com/browse/LPS-74031) are clear enough to help review the fix. 

Code Changes
----
The code changes made in **_getGroupFriendlyURL** should only have affected the logic related to **canonical urls** and **alternate urls**

Additional Details
----
**Main Issue**
The main issue is that **canonical URL link element** is not being generated properly.
This can cause many issues for SEO rankings.

**Side Issue**
Another issue that I found was that the **alternate urls** were also not generating properly.
This pr also resolves that as well.

**Account for Portal Property**
One thing to account for is the portal property: **locale.prepend.friendly.url.style**
This portal property affects the friendly urls being generated.

For the most noticeable is: locale.prepend.friendly.url.style=2
When this is set, all URLs are localized.
This means that navigating to 
`http://localhost:8080 `
would redirect to
`http://localhost:8080/en_US/web/guest/home`

**Testing**
If you do decide to test this, it would be best to also test for **additionally created sites**.

For example, if we create a new site called **testSite**
The url would usually be: `http://localhost:8080/web/testSite`
instead of the default: `http://localhost:8080`

Also, creating an additional page, such as **testPage** would help as well
The url would usually be: `http://localhost:8080/web/testSite/testPage`.

With the above scenario, you can test different localizations by appending it in the URL:
e.g. `http://localhost:8080/fr/web/testSite/testPage`

----
Please let me know if you have any questions.
Thanks!