### PR TITLE
LPP-26493

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1380,17 +1380,66 @@ public class PortalImpl implements Portal {
 			layout.getLayoutSet(), themeDisplay, true,
 			layout.isTypeControlPanel());
 
-		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			StringBundler sb = new StringBundler(4);
+		String groupFriendlyURLDomain = HttpUtil.getDomain(groupFriendlyURL);
 
-			sb.append(groupFriendlyURL);
-			sb.append(
-				_buildI18NPath(
-					siteDefaultLocale.getLanguage(), siteDefaultLocale));
-			sb.append(canonicalLayoutFriendlyURL);
-			sb.append(parametersURL);
+		int pos = groupFriendlyURL.indexOf(groupFriendlyURLDomain);
 
-			return sb.toString();
+		if (pos > 0) {
+			pos = groupFriendlyURL.indexOf(
+				CharPool.SLASH, pos + groupFriendlyURLDomain.length());
+
+			if (Validator.isNotNull(_pathContext)) {
+				pos = groupFriendlyURL.indexOf(
+					CharPool.SLASH, pos + _pathContext.length());
+			}
+		}
+
+		boolean rootURL = false;
+
+		if ((pos <= 0) || (pos >= groupFriendlyURL.length())) {
+			rootURL = true;
+		}
+
+		if (themeDisplay.isI18n() ||
+			(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
+
+			Locale locale = null;
+
+			if (themeDisplay.isI18n() &&
+				!siteDefaultLocale.equals(themeDisplay.getLocale())) {
+
+				locale = themeDisplay.getLocale();
+			}
+			else if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
+				locale = siteDefaultLocale;
+			}
+
+			if (locale != null) {
+				if (rootURL) {
+					groupFriendlyURL += buildI18NPath(locale);
+
+					if (!canonicalLayoutFriendlyURL.startsWith(
+							StringPool.SLASH)) {
+
+						groupFriendlyURL += StringPool.SLASH;
+					}
+				}
+				else {
+					String groupFriendlyURLPrefix = groupFriendlyURL.substring(
+						0, pos);
+
+					String groupFriendlyURLSuffix = groupFriendlyURL.substring(
+						pos);
+
+					StringBundler sb = new StringBundler(3);
+
+					sb.append(groupFriendlyURLPrefix);
+					sb.append(buildI18NPath(locale));
+					sb.append(groupFriendlyURLSuffix);
+
+					groupFriendlyURL = sb.toString();
+				}
+			}
 		}
 
 		return groupFriendlyURL.concat(canonicalLayoutFriendlyURL).concat(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8264,10 +8264,25 @@ public class PortalImpl implements Portal {
 			}
 		}
 
+		Locale siteDefaultLocale = getSiteDefaultLocale(layout.getGroupId());
+
 		if ((pos <= 0) || (pos >= canonicalURL.length())) {
 			for (Locale locale : availableLocales) {
-				alternateURLs.put(
-					locale, canonicalURL.concat(buildI18NPath(locale)));
+				if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) ||
+					!siteDefaultLocale.equals(locale)) {
+
+					StringBundler sb = new StringBundler(3);
+
+					sb.append(canonicalURL);
+					sb.append(buildI18NPath(locale));
+					sb.append(StringPool.SLASH);
+
+					alternateURLs.put(locale, sb.toString());
+
+					continue;
+				}
+
+				alternateURLs.put(locale, canonicalURL);
 			}
 
 			return alternateURLs;
@@ -8288,8 +8303,6 @@ public class PortalImpl implements Portal {
 				replaceFriendlyURL = false;
 			}
 		}
-
-		Locale siteDefaultLocale = getSiteDefaultLocale(layout.getGroupId());
 
 		List<LayoutFriendlyURL> layoutFriendlyURLs = null;
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8329,18 +8329,25 @@ public class PortalImpl implements Portal {
 		String canonicalURLPrefix = canonicalURL.substring(0, pos);
 		String canonicalURLSuffix = canonicalURL.substring(pos);
 
-		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			String defaultLocalePath = _buildI18NPath(
-				siteDefaultLocale.getLanguage(), siteDefaultLocale);
+		if (themeDisplay.isI18n() ||
+			(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
 
-			int canonicalURLSuffixPos = defaultLocalePath.length() + pos;
+			Locale locale = null;
 
-			if (canonicalURLSuffixPos >= canonicalURL.length()) {
-				canonicalURLSuffix = StringPool.BLANK;
+			if (themeDisplay.isI18n() &&
+				!siteDefaultLocale.equals(themeDisplay.getLocale())) {
+
+				locale = themeDisplay.getLocale();
 			}
-			else {
-				canonicalURLSuffix = canonicalURL.substring(
-					canonicalURLSuffixPos + 1);
+			else if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
+				locale = siteDefaultLocale;
+			}
+
+			String i18nPath = buildI18NPath(locale);
+
+			if (canonicalURLSuffix.startsWith(i18nPath)) {
+				canonicalURLSuffix =
+					canonicalURLSuffix.substring(i18nPath.length());
 			}
 		}
 

--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -48,7 +48,7 @@ if (!themeDisplay.isSignedIn() && layout.isPublicLayout()) {
 	%>
 
 			<c:if test="<%= availableLocale.equals(defaultLocale) %>">
-				<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(canonicalURL) %>" hreflang="x-default" rel="alternate" />
+				<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(alternateURL) %>" hreflang="x-default" rel="alternate" />
 			</c:if>
 
 			<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(alternateURL) %>" hreflang="<%= LocaleUtil.toW3cLanguageId(availableLocale) %>" rel="alternate" />


### PR DESCRIPTION
Hi @SamZiemer,

Original Tickets:
[LPP-26493](https://issues.liferay.com/browse/LPP-26493)
[LPS-74031](https://issues.liferay.com/browse/LPS-74031)

## Main Issue
Currently, canonical URLs do not account for localization. This means that every page, regardless of which locale you are viewing it from, currently uses the same canonical URL.

For example, for the URL: http://localhost:8080
The canonical URL is http://localhost:8080

For a localized example, for the URL: http://localhost:8080/fr/
The canonical URL is currently also http://localhost:8080

This is an issue, since http://localhost:8080 and http://localhost:8080/fr/ should each have it's own canonical url. 

The expected canonical URL for this case should be: http://localhost:8080/fr/

**Note:** Below will be a section with some example scenarios to further describe expected results related to this issue

## Second Issue
Currently, alternate URLs are not being generated properly in several cases.
There was an attempt to resolve this for certain cases in [LPS-72431](https://issues.liferay.com/browse/LPS-72431).

Even then, the changes introduced did not work properly at times.
This can be seen in a recent ticket: [LPS-74272](https://issues.liferay.com/browse/LPS-74272)

The changes introduced in this pr should address generating the proper alternate URLs for the two tickets mentioned above as well.

In addition, this pr will also handle providing the proper url for the x-default hreflang tag.

**Note:** Below will be a section with some example scenarios to further describe expected results related to this issue

---
The fixes for this pr also accounts for other factors, such as:
* The portal property **locale.prepend.friendly.url.style=2**
  * The examples provided mainly focus on the overall changes.
* portal.proxy.path

Please let me know if you have any questions.
Thanks!

---

## A Few Example Scenarios - Main Issue
To better describe the goals of the fix regarding canonical URLs, here are expected results from some scenarios.

### Default Site (using default locale - en_US)
URL: http://localhost:8080
Expected Canonical URL: http://localhost:8080

URL: http://localhost:8080/en_US/
Expected Canonical URL: http://localhost:8080

URL: http://localhost:8080/web/guest/home
Expected Canonical URL: http://localhost:8080

### Default Site (using non-default locale - fr)
URL: http://localhost:8080/fr/
Expected Canonical URL: http://localhost:8080/fr/

URL: http://localhost:8080/fr/web/guest/home
Expected Canonical URL: http://localhost:8080/fr/

### Created site called testsite with second created public page testpage2 (using default locale - en_US)
URL: http://localhost:8080/web/testsite/testpage2
Expected Canonical URL: http://localhost:8080/web/testsite/testpage2

URL: http://localhost:8080/en_US/web/testsite/testpage2
Expected Canonical URL: http://localhost:8080/web/testsite/testpage2

### Created site called testsite with second created public page testpage2 (using non-default locale - fr)
URL: http://localhost:8080/fr/web/testsite/testpage2
Expected Canonical URL: http://localhost:8080/fr/web/testsite/testpage2

## A Few Example Scenarios - Second Issue
To better describe the goals of the fix regarding alternate URLs, here are expected results from some scenarios. For these examples, we will only include a snippet of the hreflang tags to reduce the amount of space used.

### Default Site (using default locale - en_US)
URL: http://localhost:8080/web/guest/home
```
<link data-senna-track="temporary" href="https://localhost:8080/fr/" hreflang="fr-CA" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080" hreflang="x-default" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080" hreflang="en-US" rel="alternate">
```

### Default Site (using non-default locale - fr)
URL: http://localhost:8080/fr/web/guest/home
```
<link data-senna-track="temporary" href="https://localhost:8080/fr/" hreflang="fr-CA" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080" hreflang="x-default" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080" hreflang="en-US" rel="alternate">
```

### Created site called testsite with second created public page testpage2 (using default locale - en_US)
URL: http://localhost:8080/web/testsite/testpage2
```
<link data-senna-track="temporary" href="https://localhost:8080/fr/web/testsite/testpage2" hreflang="fr-CA" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080/web/testsite/testpage2" hreflang="x-default" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080/web/testsite/testpage2" hreflang="en-US" rel="alternate">
```

URL: http://localhost:8080/en_US/web/testsite/testpage2
```
<link data-senna-track="temporary" href="https://localhost:8080/fr/web/testsite/testpage2" hreflang="fr-CA" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080/web/testsite/testpage2" hreflang="x-default" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080/web/testsite/testpage2" hreflang="en-US" rel="alternate">
```

### Created site called testsite with second created public page testpage2 (using non-default locale - fr)
URL: http://localhost:8080/fr/web/testsite/testpage2
```
<link data-senna-track="temporary" href="https://localhost:8080/fr/web/testsite/testpage2" hreflang="fr-CA" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080/web/testsite/testpage2" hreflang="x-default" rel="alternate">
<link data-senna-track="temporary" href="https://localhost:8080/web/testsite/testpage2" hreflang="en-US" rel="alternate">
```