### PR TITLE
J cords lps 74454

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalService.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalService.java
@@ -147,22 +147,26 @@ public interface CalendarBookingLocalService extends BaseLocalService,
 	public CalendarBooking deleteCalendarBooking(long calendarBookingId,
 		boolean allRecurringInstances) throws PortalException;
 
-	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
-		int instanceIndex, boolean allFollowing) throws PortalException;
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, int instanceIndex, boolean allFollowing)
+		throws PortalException;
 
-	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
-		int instanceIndex, boolean allFollowing,
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, int instanceIndex,
+		boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, long startTime, boolean allFollowing)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, long startTime, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings) throws PortalException;
 
-	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
-		long startTime, boolean allFollowing) throws PortalException;
-
-	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
-		long startTime, boolean allFollowing,
-		boolean deleteRecurringCalendarBookings) throws PortalException;
-
-	public void deleteCalendarBookingInstance(long calendarBookingId,
-		long startTime, boolean allFollowing) throws PortalException;
+	public void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws PortalException;
 
 	public void deleteCalendarBookings(long calendarId)
 		throws PortalException;

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceUtil.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceUtil.java
@@ -155,50 +155,50 @@ public class CalendarBookingLocalServiceUtil {
 			allRecurringInstances);
 	}
 
-	public static void deleteCalendarBookingInstance(
+	public static void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
-			.deleteCalendarBookingInstance(calendarBooking, instanceIndex,
-			allFollowing);
+			.deleteCalendarBookingInstance(userId, calendarBooking,
+			instanceIndex, allFollowing);
 	}
 
-	public static void deleteCalendarBookingInstance(
+	public static void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
-			.deleteCalendarBookingInstance(calendarBooking, instanceIndex,
-			allFollowing, deleteRecurringCalendarBookings);
+			.deleteCalendarBookingInstance(userId, calendarBooking,
+			instanceIndex, allFollowing, deleteRecurringCalendarBookings);
 	}
 
-	public static void deleteCalendarBookingInstance(
+	public static void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
-			.deleteCalendarBookingInstance(calendarBooking, startTime,
+			.deleteCalendarBookingInstance(userId, calendarBooking, startTime,
 			allFollowing);
 	}
 
-	public static void deleteCalendarBookingInstance(
+	public static void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
-			.deleteCalendarBookingInstance(calendarBooking, startTime,
+			.deleteCalendarBookingInstance(userId, calendarBooking, startTime,
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
-	public static void deleteCalendarBookingInstance(long calendarBookingId,
-		long startTime, boolean allFollowing)
+	public static void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
-			.deleteCalendarBookingInstance(calendarBookingId, startTime,
-			allFollowing);
+			.deleteCalendarBookingInstance(userId, calendarBookingId,
+			startTime, allFollowing);
 	}
 
 	public static void deleteCalendarBookings(long calendarId)

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceWrapper.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceWrapper.java
@@ -155,49 +155,51 @@ public class CalendarBookingLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteCalendarBookingInstance(
+	public void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBooking,
-			instanceIndex, allFollowing);
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, instanceIndex, allFollowing);
 	}
 
 	@Override
-	public void deleteCalendarBookingInstance(
+	public void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBooking,
-			instanceIndex, allFollowing, deleteRecurringCalendarBookings);
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, instanceIndex, allFollowing,
+			deleteRecurringCalendarBookings);
 	}
 
 	@Override
-	public void deleteCalendarBookingInstance(
+	public void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBooking,
-			startTime, allFollowing);
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, startTime, allFollowing);
 	}
 
 	@Override
-	public void deleteCalendarBookingInstance(
+	public void deleteCalendarBookingInstance(long userId,
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBooking,
-			startTime, allFollowing, deleteRecurringCalendarBookings);
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, startTime, allFollowing,
+			deleteRecurringCalendarBookings);
 	}
 
 	@Override
-	public void deleteCalendarBookingInstance(long calendarBookingId,
-		long startTime, boolean allFollowing)
+	public void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBookingId,
-			startTime, allFollowing);
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBookingId, startTime, allFollowing);
 	}
 
 	@Override

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -450,7 +450,7 @@ public class CalendarBookingLocalServiceImpl
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, int instanceIndex,
+			long userId, CalendarBooking calendarBooking, int instanceIndex,
 			boolean allFollowing)
 		throws PortalException {
 
@@ -459,13 +459,13 @@ public class CalendarBookingLocalServiceImpl
 				calendarBooking, instanceIndex);
 
 		deleteCalendarBookingInstance(
-			calendarBooking, calendarBookingInstance.getStartTime(),
+			userId, calendarBooking, calendarBookingInstance.getStartTime(),
 			allFollowing);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, int instanceIndex,
+			long userId, CalendarBooking calendarBooking, int instanceIndex,
 			boolean allFollowing, boolean deleteRecurringCalendarBookings)
 		throws PortalException {
 
@@ -474,23 +474,23 @@ public class CalendarBookingLocalServiceImpl
 				calendarBooking, instanceIndex);
 
 		deleteCalendarBookingInstance(
-			calendarBooking, calendarBookingInstance.getStartTime(),
+			userId, calendarBooking, calendarBookingInstance.getStartTime(),
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			boolean allFollowing)
 		throws PortalException {
 
 		deleteCalendarBookingInstance(
-			calendarBooking, startTime, allFollowing, false);
+			userId, calendarBooking, startTime, allFollowing, false);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			boolean allFollowing, boolean deleteRecurringCalendarBookings)
 		throws PortalException {
 
@@ -504,7 +504,7 @@ public class CalendarBookingLocalServiceImpl
 		if (allFollowing) {
 			if (deleteRecurringCalendarBookings) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(calendarBooking, startTime);
+					splitCalendarBookingInstances(userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -549,13 +549,13 @@ public class CalendarBookingLocalServiceImpl
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			long calendarBookingId, long startTime, boolean allFollowing)
+			long userId, long calendarBookingId, long startTime, boolean allFollowing)
 		throws PortalException {
 
 		CalendarBooking calendarBooking =
 			calendarBookingPersistence.findByPrimaryKey(calendarBookingId);
 
-		deleteCalendarBookingInstance(calendarBooking, startTime, allFollowing);
+		deleteCalendarBookingInstance(userId, calendarBooking, startTime, allFollowing);
 	}
 
 	@Override
@@ -832,7 +832,7 @@ public class CalendarBookingLocalServiceImpl
 
 			if (allFollowing) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(calendarBooking, startTime);
+					splitCalendarBookingInstances(userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -860,7 +860,7 @@ public class CalendarBookingLocalServiceImpl
 			}
 
 			deleteCalendarBookingInstance(
-				calendarBooking, startTime, allFollowing);
+				userId, calendarBooking, startTime, allFollowing);
 
 			calendarBooking = addCalendarBooking(
 				userId, calendarId, childCalendarIds, 0,
@@ -1330,7 +1330,7 @@ public class CalendarBookingLocalServiceImpl
 		String oldRecurrence = calendarBooking.getRecurrence();
 
 		deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing, false);
+			userId, calendarBooking, instanceIndex, allFollowing, false);
 
 		Map<Locale, String> updatedTitleMap = calendarBooking.getTitleMap();
 
@@ -1345,7 +1345,7 @@ public class CalendarBookingLocalServiceImpl
 			Calendar calendar = calendarLocalService.getCalendar(calendarId);
 
 			List<CalendarBooking> recurringCalendarBookings =
-				splitCalendarBookingInstances(calendarBooking, startTime);
+				splitCalendarBookingInstances(userId, calendarBooking, startTime);
 
 			List<String> unmodifiedAttributesNames =
 				getUnmodifiedAttributesNames(
@@ -2018,7 +2018,7 @@ public class CalendarBookingLocalServiceImpl
 	}
 
 	protected CalendarBooking splitCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			Recurrence recurrence)
 		throws PortalException {
 
@@ -2046,13 +2046,13 @@ public class CalendarBookingLocalServiceImpl
 			calendarBooking.getSecondReminderType(),
 			ServiceContextThreadLocal.getServiceContext());
 
-		deleteCalendarBookingInstance(calendarBooking, startTime, true, false);
+		deleteCalendarBookingInstance(userId, calendarBooking, startTime, true, false);
 
 		return calendarBookingInstance;
 	}
 
 	protected List<CalendarBooking> splitCalendarBookingInstances(
-			CalendarBooking calendarBooking, long startTime)
+			long userId, CalendarBooking calendarBooking, long startTime)
 		throws PortalException {
 
 		List<CalendarBooking> recurringCalendarBookings =
@@ -2105,7 +2105,7 @@ public class CalendarBookingLocalServiceImpl
 
 						CalendarBooking newCalendarBooking =
 							splitCalendarBookingInstance(
-								recurringCalendarBooking,
+								userId, recurringCalendarBooking,
 								newStartTimeJCalendar.getTimeInMillis(),
 								recurrenceSplit.getSecondRecurrence());
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -495,6 +495,9 @@ public class CalendarBookingLocalServiceImpl
 		throws PortalException {
 
 		Date now = new Date();
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUserId(userId);
 
 		java.util.Calendar startTimeJCalendar = JCalendarUtil.getJCalendar(
 			startTime, calendarBooking.getTimeZone());
@@ -504,7 +507,8 @@ public class CalendarBookingLocalServiceImpl
 		if (allFollowing) {
 			if (deleteRecurringCalendarBookings) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(userId, calendarBooking, startTime);
+					splitCalendarBookingInstances(
+						userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -514,6 +518,10 @@ public class CalendarBookingLocalServiceImpl
 			}
 
 			if (startTime == calendarBooking.getStartTime()) {
+				_sendChildrenNotifications(
+					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+					serviceContext);
+
 				calendarBookingLocalService.deleteCalendarBooking(
 					calendarBooking, false);
 
@@ -533,6 +541,10 @@ public class CalendarBookingLocalServiceImpl
 				RecurrenceUtil.getCalendarBookingInstance(calendarBooking, 1);
 
 			if (calendarBookingInstance == null) {
+				_sendChildrenNotifications(
+					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+					serviceContext);
+
 				calendarBookingLocalService.deleteCalendarBooking(
 					calendarBooking, false);
 
@@ -545,17 +557,23 @@ public class CalendarBookingLocalServiceImpl
 		String recurrence = RecurrenceSerializer.serialize(recurrenceObj);
 
 		updateChildCalendarBookings(calendarBooking, now, recurrence);
+
+		_sendChildrenNotifications(
+			calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+			serviceContext);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			long userId, long calendarBookingId, long startTime, boolean allFollowing)
+			long userId, long calendarBookingId, long startTime,
+			boolean allFollowing)
 		throws PortalException {
 
 		CalendarBooking calendarBooking =
 			calendarBookingPersistence.findByPrimaryKey(calendarBookingId);
 
-		deleteCalendarBookingInstance(userId, calendarBooking, startTime, allFollowing);
+		deleteCalendarBookingInstance(
+			userId, calendarBooking, startTime, allFollowing);
 	}
 
 	@Override
@@ -832,7 +850,8 @@ public class CalendarBookingLocalServiceImpl
 
 			if (allFollowing) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(userId, calendarBooking, startTime);
+					splitCalendarBookingInstances(
+						userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -1345,7 +1364,8 @@ public class CalendarBookingLocalServiceImpl
 			Calendar calendar = calendarLocalService.getCalendar(calendarId);
 
 			List<CalendarBooking> recurringCalendarBookings =
-				splitCalendarBookingInstances(userId, calendarBooking, startTime);
+				splitCalendarBookingInstances(
+					userId, calendarBooking, startTime);
 
 			List<String> unmodifiedAttributesNames =
 				getUnmodifiedAttributesNames(
@@ -2046,7 +2066,8 @@ public class CalendarBookingLocalServiceImpl
 			calendarBooking.getSecondReminderType(),
 			ServiceContextThreadLocal.getServiceContext());
 
-		deleteCalendarBookingInstance(userId, calendarBooking, startTime, true, false);
+		deleteCalendarBookingInstance(
+			userId, calendarBooking, startTime, true, false);
 
 		return calendarBookingInstance;
 	}
@@ -2249,6 +2270,27 @@ public class CalendarBookingLocalServiceImpl
 
 	@ServiceReference(type = TrashEntryLocalService.class)
 	protected TrashEntryLocalService trashEntryLocalService;
+
+	private void _sendChildrenNotifications(
+		CalendarBooking calendarBooking,
+		NotificationTemplateType notificationType,
+		ServiceContext serviceContext) {
+
+		List<CalendarBooking> childCalendarBookings =
+			calendarBooking.getChildCalendarBookings();
+
+		for (CalendarBooking childCalendarBooking : childCalendarBookings) {
+			if (childCalendarBooking.equals(calendarBooking)) {
+				continue;
+			}
+
+			sendNotification(
+				childCalendarBooking, notificationType, serviceContext);
+
+			_sendChildrenNotifications(
+				childCalendarBooking, notificationType, serviceContext);
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarBookingLocalServiceImpl.class);

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
@@ -203,7 +203,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing);
+			getUserId(), calendarBooking, instanceIndex, allFollowing);
 	}
 
 	@Override
@@ -220,7 +220,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing,
+			getUserId(), calendarBooking, instanceIndex, allFollowing,
 			deleteRecurringCalendarBookings);
 	}
 
@@ -237,7 +237,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBookingId, startTime, allFollowing);
+			getUserId(), calendarBookingId, startTime, allFollowing);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74454
https://issues.liferay.com/browse/LPP-26631

Deleting an instance or multiple instances (with Following option) of a recurring calendar booking will now notify participants.
The children of the calendar event were found through different logic than what deletes the events because changing the deleteCalendarBooking method [here](https://github.com/liferay/liferay-portal/blob/3244e1d8430abffb737ad6aeeac50749cbce8faf/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L516) and elsewhere would create cascade of changes to the portlet.
Originally I found that the best pattern to follow would be: 
-Users aren't notified if the deleted event is in the past.
-User is notified with Deleted template if 1 occurrence is deleted
-User is notified with Updated template if multiple occurrences are deleted
However, our framework doesn't have the supporting methods necessary to easily implement this. In particular calendarBooking.getStartTime() is not updated when the first event in a recurring series is deleted. As such, I just to the Delete Notification Template when a user deletes 1 or more instances of a Calendar Booking. This breaks with the implementation a little, but it doesn't seem worth the effort to follow it perfectly in this case.