### PR TITLE
LPS-74607

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -203,7 +203,27 @@
 
 				placeHolder.addClass('portlet-boundary');
 
-				portletPosition = column.all('.portlet-boundary').indexOf(placeHolder);
+				var columnPortlets = column.all('.portlet-boundary');
+				var nestedPortlets = column.all('.portlet-nested-portlets');
+
+				portletPosition = columnPortlets.indexOf(placeHolder);
+
+				var nestedPortletOffset = 0;
+
+				for (var i = 0; (nestedPortlets != null) && (i < nestedPortlets._nodes.length); i++) {
+					var nestedPortletsPortlet = nestedPortlets._nodes[i];
+
+					var nestedPortletIndex = columnPortlets.indexOf(nestedPortletsPortlet);
+
+					if ((nestedPortletIndex != -1) && (nestedPortletIndex < portletPosition)) {
+						nestedPortletOffset += nestedPortletsPortlet.getElementsByClassName('portlet-boundary').length;
+					}
+					else if (nestedPortletIndex >= portletPosition) {
+						break;
+					}
+				}
+
+				portletPosition -= nestedPortletOffset;
 
 				currentColumnId = Util.getColumnId(column.attr('id'));
 			}


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-26894
https://issues.liferay.com/browse/LPS-74607

Adding a Nested Applications portlet with content inside of it, then dragging Web Content under it in a particular order may add the portlets in the wrong order internally, causing the order to change after being refreshed.

This appears to be caused by the numbering of portlets in the 'add' function in portlet.js (with the '.portlet-boundary' class) including nested portlets, when the update_layout path is expecting it to only include portlets strictly within in the layout's column. My proposed fix is to simply count all nested portlets (with 'portlet-boundary') that come before newly added portlets, and remove that from the index to address this issue.

I think this solution could possibly be improved, but I'm hoping for input on that. Let me know if there are any problems or concerns with this. Thanks!