### PR TITLE
LPS-74690 & LPS-74777

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
@@ -16,7 +16,9 @@ package com.liferay.portal.dao.sql.transformer;
 
 import com.liferay.portal.kernel.dao.db.DB;
 
+import java.util.function.Function;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Manuel de la Peña
@@ -31,12 +33,44 @@ public class SQLServerSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getCastClobTextFunction(), getCastLongFunction(),
 			getCastTextFunction(), getInstrFunction(),
 			getIntegerDivisionFunction(), getModFunction(),
-			getNullDateFunction(), getSubstrFunction());
+			getNullDateFunction(), getSubstrFunction(), _getConcatFunction(),
+			_getLengthFunction());
 	}
 
 	@Override
 	protected String replaceCastText(Matcher matcher) {
 		return matcher.replaceAll("CAST($1 AS NVARCHAR(MAX))");
 	}
+
+	private Function<String, String> _getConcatFunction() {
+		return (String sql) -> {
+			Matcher matcher = _concatPattern.matcher(sql);
+
+			while (matcher.find()) {
+				matcher.reset();
+
+				sql = matcher.replaceAll("($1 || $2)");
+
+				matcher = _concatPattern.matcher(sql);
+			}
+
+			return sql;
+		};
+	}
+
+	private Function<String, String> _getLengthFunction() {
+		return (String sql) -> {
+			Matcher matcher = _lengthPattern.matcher(sql);
+
+			return matcher.replaceAll("LEN(");
+		};
+	}
+
+	private static final Pattern _concatPattern = Pattern.compile(
+		"CONCAT\\(((?:'[^']*'|\"[^\"]*\"|[^,]*)*), " +
+			"((?:'[^']*'|\"[^\"]*\"|[^,]*)*)\\)",
+		Pattern.CASE_INSENSITIVE);
+	private static final Pattern _lengthPattern = Pattern.compile(
+		"LENGTH\\(", Pattern.CASE_INSENSITIVE);
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.function.Function;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Manuel de la Peña
@@ -34,8 +35,8 @@ public class SybaseSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getCastClobTextFunction(), getCastLongFunction(),
 			getCastTextFunction(), getInstrFunction(),
 			getIntegerDivisionFunction(), getModFunction(),
-			getNullDateFunction(), getSubstrFunction(), _getCrossJoinFunction(),
-			_getReplaceFunction());
+			getNullDateFunction(), getSubstrFunction(), _getConcatFunction(),
+			_getCrossJoinFunction(), _getReplaceFunction());
 	}
 
 	@Override
@@ -48,6 +49,22 @@ public class SybaseSQLTransformerLogic extends BaseSQLTransformerLogic {
 		return matcher.replaceAll("CAST($1 AS NVARCHAR(5461))");
 	}
 
+	private Function<String, String> _getConcatFunction() {
+		return (String sql) -> {
+			Matcher matcher = _concatPattern.matcher(sql);
+
+			while (matcher.find()) {
+				matcher.reset();
+
+				sql = matcher.replaceAll("($1 || $2)");
+
+				matcher = _concatPattern.matcher(sql);
+			}
+
+			return sql;
+		};
+	}
+
 	private Function<String, String> _getCrossJoinFunction() {
 		return (String sql) -> StringUtil.replace(
 			sql, "CROSS JOIN", StringPool.COMMA);
@@ -56,5 +73,10 @@ public class SybaseSQLTransformerLogic extends BaseSQLTransformerLogic {
 	private Function<String, String> _getReplaceFunction() {
 		return (String sql) -> sql.replaceAll("(?i)replace\\(", "str_replace(");
 	}
+
+	private static final Pattern _concatPattern = Pattern.compile(
+		"CONCAT\\(((?:'[^']*'|\"[^\"]*\"|[^,]*)*), " +
+			"((?:'[^']*'|\"[^\"]*\"|[^,]*)*)\\)",
+		Pattern.CASE_INSENSITIVE);
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -473,6 +473,8 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 			ps1.setString(3, fileName);
 
 			try (ResultSet rs = ps1.executeQuery()) {
+				rs.next();
+
 				while (rs.next()) {
 					long fileEntryId = rs.getLong("fileEntryId");
 					String extension = GetterUtil.getString(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -495,9 +495,20 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					}
 
 					for (int i = 1;; i++) {
+						String iString = String.valueOf(i);
+
+						int availableLength =
+							254 - (titleExtension.length() + iString.length());
+
+						if (titleWithoutExtension.length() > availableLength) {
+							titleWithoutExtension =
+								titleWithoutExtension.substring(
+									0, availableLength);
+						}
+
 						title =
 							titleWithoutExtension + StringPool.UNDERLINE +
-								String.valueOf(i);
+								iString;
 
 						if (Validator.isNotNull(titleExtension)) {
 							title = title.concat(titleExtension);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -432,22 +432,25 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 	private void _fixDuplicateFileEntryFileNames() throws Exception {
 		try (PreparedStatement ps = connection.prepareStatement(
-				"select groupId, folderId, fileName from DLFileEntry group " +
-					"by groupId, folderId, fileName having count(*) > 1");
+				"select groupId, folderId, fileName, extension from " +
+					"DLFileEntry group by groupId, folderId, fileName having " +
+						"count(*) > 1");
 			ResultSet rs = ps.executeQuery()) {
 
 			while (rs.next()) {
 				long groupId = rs.getLong("groupId");
 				long folderId = rs.getLong("folderId");
 				String fileName = rs.getString("fileName");
+				String extension = rs.getString("extension");
 
-				_fixDuplicateFileEntryFileNames(groupId, folderId, fileName);
+				_fixDuplicateFileEntryFileNames(
+					groupId, folderId, fileName, extension);
 			}
 		}
 	}
 
 	private void _fixDuplicateFileEntryFileNames(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String fileName, String extension)
 		throws Exception {
 
 		Set<String> generatedUniqueFileNames = new HashSet<>();
@@ -476,7 +479,6 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 				while (rs.next()) {
 					long fileEntryId = rs.getLong("fileEntryId");
-					String extension = rs.getString("extension");
 					String title = rs.getString("title");
 					String version = rs.getString("version");
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -24,11 +24,11 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -372,34 +372,21 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			runSQL("alter table DLFileVersion add fileName VARCHAR(255) null");
 
-			try (PreparedStatement ps1 = connection.prepareStatement(
-					"select fileVersionId, extension, title from " +
-						"DLFileVersion");
-				PreparedStatement ps2 =
-					AutoBatchPreparedStatementUtil.concurrentAutoBatch(
-						connection,
-						"update DLFileVersion set fileName = ? where " +
-							"fileVersionId = ?");
-				ResultSet rs = ps1.executeQuery()) {
+			runSQL(
+				"update DLFileVersion set fileName = title where title like " +
+					"CONCAT('%.', extension) or extension = '' or extension " +
+						"is null");
 
-				while (rs.next()) {
-					long fileVersionId = rs.getLong("fileVersionId");
-					String extension = GetterUtil.getString(
-						rs.getString("extension"));
-					String title = GetterUtil.getString(rs.getString("title"));
+			StringBundler sb = new StringBundler(4);
 
-					String fileName = DLUtil.getSanitizedFileName(
-						title, extension);
+			sb.append("update DLFileVersion set fileName = CONCAT(title, ");
+			sb.append("CONCAT('.', extension)) where (fileName is null or ");
+			sb.append("fileName = '') and LENGTH(title) + LENGTH(extension) ");
+			sb.append("< 255");
 
-					ps2.setString(1, fileName);
+			runSQL(sb.toString());
 
-					ps2.setLong(2, fileVersionId);
-
-					ps2.addBatch();
-				}
-
-				ps2.executeBatch();
-			}
+			_updateLongFileVersionFileNames();
 		}
 	}
 
@@ -559,6 +546,38 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 				connection.prepareStatement(
 					"update DLFileEntry set fileName = ? where fileEntryId = " +
 						"?"));
+			ResultSet rs = ps1.executeQuery()) {
+
+			while (rs.next()) {
+				long fileEntryId = rs.getLong("fileEntryId");
+				String extension = rs.getString("extension");
+				String title = rs.getString("title");
+
+				int availableLength = 254 - extension.length();
+
+				String fileName =
+					title.substring(0, availableLength) + StringPool.PERIOD +
+						extension;
+
+				ps2.setString(1, fileName);
+
+				ps2.setLong(2, fileEntryId);
+
+				ps2.addBatch();
+			}
+
+			ps2.executeBatch();
+		}
+	}
+
+	private void _updateLongFileVersionFileNames() throws Exception {
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select fileEntryId, title, extension from DLFileVersion " +
+					"where fileName = '' or fileName is null");
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBatch(
+				connection.prepareStatement(
+					"update DLFileVersion set fileName = ? where fileEntryId " +
+						"= ?"));
 			ResultSet rs = ps1.executeQuery()) {
 
 			while (rs.next()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -481,8 +481,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					String title = rs.getString("title");
 					String version = rs.getString("version");
 
-					String uniqueFileName = DLUtil.getSanitizedFileName(
-						title, extension);
+					String uniqueFileName = null;
 
 					String titleExtension = StringPool.BLANK;
 					String titleWithoutExtension = title;
@@ -492,61 +491,44 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						titleWithoutExtension = FileUtil.stripExtension(title);
 					}
 
-					boolean generatedUniqueFileName = false;
-					String uniqueTitle = title;
-
 					for (int i = 1;; i++) {
-						if (!generatedUniqueFileNames.contains(
-								uniqueFileName) &&
-							!generatedUniqueTitles.contains(uniqueTitle) &&
-							!hasFileEntry(
-								groupId, folderId, fileEntryId, uniqueTitle,
-								uniqueFileName)) {
-
-							break;
-						}
-
-						generatedUniqueFileName = true;
-
-						uniqueTitle =
+						title =
 							titleWithoutExtension + StringPool.UNDERLINE +
 								String.valueOf(i);
 
 						if (Validator.isNotNull(titleExtension)) {
-							uniqueTitle += StringPool.PERIOD.concat(
-								titleExtension);
+							title += StringPool.PERIOD.concat(titleExtension);
 						}
 
 						uniqueFileName = DLUtil.getSanitizedFileName(
-							uniqueTitle, extension);
+							title, extension);
+
+						if (!generatedUniqueFileNames.contains(
+								uniqueFileName) &&
+							!generatedUniqueTitles.contains(title) &&
+							!hasFileEntry(
+								groupId, folderId, fileEntryId, title,
+								uniqueFileName)) {
+
+							break;
+						}
 					}
 
-					if (generatedUniqueFileName) {
-						generatedUniqueFileNames.add(uniqueFileName);
-						generatedUniqueTitles.add(uniqueTitle);
-					}
+					generatedUniqueFileNames.add(uniqueFileName);
+					generatedUniqueTitles.add(title);
 
 					ps2.setString(1, uniqueFileName);
-
-					if (Validator.isNotNull(uniqueTitle)) {
-						ps2.setString(2, uniqueTitle);
-					}
-					else {
-						ps2.setString(2, title);
-					}
-
+					ps2.setString(2, title);
 					ps2.setLong(3, fileEntryId);
 
 					ps2.addBatch();
 
-					if (Validator.isNotNull(uniqueTitle)) {
-						ps3.setString(1, uniqueTitle);
-						ps3.setLong(2, fileEntryId);
-						ps3.setString(3, version);
-						ps3.setInt(4, WorkflowConstants.STATUS_IN_TRASH);
+					ps3.setString(1, title);
+					ps3.setLong(2, fileEntryId);
+					ps3.setString(3, version);
+					ps3.setInt(4, WorkflowConstants.STATUS_IN_TRASH);
 
-						ps3.addBatch();
-					}
+					ps3.addBatch();
 				}
 
 				ps2.executeBatch();

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -548,26 +548,32 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						"?"));
 			ResultSet rs = ps1.executeQuery()) {
 
-			while (rs.next()) {
-				long fileEntryId = rs.getLong("fileEntryId");
-				String extension = rs.getString("extension");
-				String title = rs.getString("title");
-
-				int availableLength = 254 - extension.length();
-
-				String fileName =
-					title.substring(0, availableLength) + StringPool.PERIOD +
-						extension;
-
-				ps2.setString(1, fileName);
-
-				ps2.setLong(2, fileEntryId);
-
-				ps2.addBatch();
-			}
-
-			ps2.executeBatch();
+			_updateLongFileNames(ps2, rs);
 		}
+	}
+
+	private void _updateLongFileNames(PreparedStatement ps, ResultSet rs)
+		throws Exception {
+
+		while (rs.next()) {
+			long fileEntryId = rs.getLong("fileEntryId");
+			String extension = rs.getString("extension");
+			String title = rs.getString("title");
+
+			int availableLength = 254 - extension.length();
+
+			String fileName =
+				title.substring(0, availableLength) + StringPool.PERIOD +
+					extension;
+
+			ps.setString(1, fileName);
+
+			ps.setLong(2, fileEntryId);
+
+			ps.addBatch();
+		}
+
+		ps.executeBatch();
 	}
 
 	private void _updateLongFileVersionFileNames() throws Exception {
@@ -580,25 +586,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						"= ?"));
 			ResultSet rs = ps1.executeQuery()) {
 
-			while (rs.next()) {
-				long fileEntryId = rs.getLong("fileEntryId");
-				String extension = rs.getString("extension");
-				String title = rs.getString("title");
-
-				int availableLength = 254 - extension.length();
-
-				String fileName =
-					title.substring(0, availableLength) + StringPool.PERIOD +
-						extension;
-
-				ps2.setString(1, fileName);
-
-				ps2.setLong(2, fileEntryId);
-
-				ps2.addBatch();
-			}
-
-			ps2.executeBatch();
+			_updateLongFileNames(ps2, rs);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -487,8 +486,10 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					String titleWithoutExtension = title;
 
 					if (title.endsWith(StringPool.PERIOD + extension)) {
-						titleExtension = extension;
-						titleWithoutExtension = FileUtil.stripExtension(title);
+						titleExtension = StringPool.PERIOD + extension;
+
+						titleWithoutExtension = titleWithoutExtension.substring(
+							0, title.length() - titleExtension.length());
 					}
 
 					for (int i = 1;; i++) {
@@ -497,7 +498,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 								String.valueOf(i);
 
 						if (Validator.isNotNull(titleExtension)) {
-							title += StringPool.PERIOD.concat(titleExtension);
+							title = title.concat(titleExtension);
 						}
 
 						uniqueFileName = DLUtil.getSanitizedFileName(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -162,12 +162,27 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			runSQL("alter table DLFileEntry add fileName VARCHAR(255) null");
 
+			runSQL(
+				"update DLFileEntry set fileName = title where title like " +
+					"CONCAT('%.', extension) or extension = '' or extension " +
+						"is null");
+
+			runSQL(
+				"update DLFileEntry set fileName = CONCAT(title, CONCAT('.', " +
+					"extension)) where (fileName is null or fileName = '') " +
+						"and LENGTH(title) + LENGTH(extension) < 255");
+
+			runSQL(
+				"update DLFileEntry set fileName = REPLACE(fileName, '/', " +
+					"'_') where fileName is not null and fileName != ''");
+
 			Set<String> generatedUniqueFileNames = new HashSet<>();
 			Set<String> generatedUniqueTitles = new HashSet<>();
 
 			try (PreparedStatement ps1 = connection.prepareStatement(
 					"select fileEntryId, groupId, folderId, extension, " +
-						"title, version from DLFileEntry");
+						"title, version from DLFileEntry where fileName = '' " +
+							"or fileName is null");
 				PreparedStatement ps2 =
 					AutoBatchPreparedStatementUtil.autoBatch(
 						connection.prepareStatement(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -477,6 +477,8 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 			try (ResultSet rs = ps1.executeQuery()) {
 				rs.next();
 
+				int i = 1;
+
 				while (rs.next()) {
 					long fileEntryId = rs.getLong("fileEntryId");
 					String title = rs.getString("title");
@@ -494,7 +496,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 							0, title.length() - titleExtension.length());
 					}
 
-					for (int i = 1;; i++) {
+					do {
 						String iString = String.valueOf(i);
 
 						int availableLength =
@@ -517,16 +519,13 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						uniqueFileName = DLUtil.getSanitizedFileName(
 							title, extension);
 
-						if (!generatedUniqueFileNames.contains(
-								uniqueFileName) &&
-							!generatedUniqueTitles.contains(title) &&
-							!hasFileEntry(
-								groupId, folderId, fileEntryId, title,
-								uniqueFileName)) {
-
-							break;
-						}
-					}
+						i++;
+					} while (
+						generatedUniqueFileNames.contains(uniqueFileName) ||
+						generatedUniqueTitles.contains(title) ||
+						hasFileEntry(
+							groupId, folderId, fileEntryId, title,
+							uniqueFileName));
 
 					generatedUniqueFileNames.add(uniqueFileName);
 					generatedUniqueTitles.add(title);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -172,6 +172,37 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					"extension)) where (fileName is null or fileName = '') " +
 						"and LENGTH(title) + LENGTH(extension) < 255");
 
+			try (PreparedStatement ps1 = connection.prepareStatement(
+					"select fileEntryId, title, extension from DLFileEntry " +
+						"where fileName = '' or fileName is null");
+				PreparedStatement ps2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection.prepareStatement(
+							"update DLFileEntry set fileName = ? where " +
+								"fileEntryId = ?"));
+				ResultSet rs = ps1.executeQuery()) {
+
+				while (rs.next()) {
+					long fileEntryId = rs.getLong("fileEntryId");
+					String extension = rs.getString("extension");
+					String title = rs.getString("title");
+
+					int availableLength = 254 - extension.length();
+
+					String fileName =
+						title.substring(0, availableLength) +
+							StringPool.PERIOD + extension;
+
+					ps2.setString(1, fileName);
+
+					ps2.setLong(2, fileEntryId);
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+
 			runSQL(
 				"update DLFileEntry set fileName = REPLACE(fileName, '/', " +
 					"'_') where fileName is not null and fileName != ''");

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -172,141 +172,13 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					"extension)) where (fileName is null or fileName = '') " +
 						"and LENGTH(title) + LENGTH(extension) < 255");
 
-			try (PreparedStatement ps1 = connection.prepareStatement(
-					"select fileEntryId, title, extension from DLFileEntry " +
-						"where fileName = '' or fileName is null");
-				PreparedStatement ps2 =
-					AutoBatchPreparedStatementUtil.autoBatch(
-						connection.prepareStatement(
-							"update DLFileEntry set fileName = ? where " +
-								"fileEntryId = ?"));
-				ResultSet rs = ps1.executeQuery()) {
-
-				while (rs.next()) {
-					long fileEntryId = rs.getLong("fileEntryId");
-					String extension = rs.getString("extension");
-					String title = rs.getString("title");
-
-					int availableLength = 254 - extension.length();
-
-					String fileName =
-						title.substring(0, availableLength) +
-							StringPool.PERIOD + extension;
-
-					ps2.setString(1, fileName);
-
-					ps2.setLong(2, fileEntryId);
-
-					ps2.addBatch();
-				}
-
-				ps2.executeBatch();
-			}
+			_updateLongFileEntryFileNames();
 
 			runSQL(
 				"update DLFileEntry set fileName = REPLACE(fileName, '/', " +
 					"'_') where fileName is not null and fileName != ''");
 
-			Set<String> generatedUniqueFileNames = new HashSet<>();
-			Set<String> generatedUniqueTitles = new HashSet<>();
-
-			try (PreparedStatement ps1 = connection.prepareStatement(
-					"select fileEntryId, groupId, folderId, extension, " +
-						"title, version from DLFileEntry where fileName = '' " +
-							"or fileName is null");
-				PreparedStatement ps2 =
-					AutoBatchPreparedStatementUtil.autoBatch(
-						connection.prepareStatement(
-							"update DLFileEntry set fileName = ?, title = ? " +
-								"where fileEntryId = ?"));
-				PreparedStatement ps3 =
-					AutoBatchPreparedStatementUtil.concurrentAutoBatch(
-						connection,
-						"update DLFileVersion set title = ? where " +
-							"fileEntryId = ? and version = ? and status != ?");
-				ResultSet rs = ps1.executeQuery()) {
-
-				while (rs.next()) {
-					long fileEntryId = rs.getLong("fileEntryId");
-					long groupId = rs.getLong("groupId");
-					long folderId = rs.getLong("folderId");
-					String extension = GetterUtil.getString(
-						rs.getString("extension"));
-					String title = GetterUtil.getString(rs.getString("title"));
-					String version = rs.getString("version");
-
-					String uniqueFileName = DLUtil.getSanitizedFileName(
-						title, extension);
-
-					String titleExtension = StringPool.BLANK;
-					String titleWithoutExtension = title;
-
-					if (title.endsWith(StringPool.PERIOD + extension)) {
-						titleExtension = extension;
-						titleWithoutExtension = FileUtil.stripExtension(title);
-					}
-
-					boolean generatedUniqueFileName = false;
-					String uniqueTitle = title;
-
-					for (int i = 1;; i++) {
-						if (!generatedUniqueFileNames.contains(
-								uniqueFileName) &&
-							!generatedUniqueTitles.contains(uniqueTitle) &&
-							!hasFileEntry(
-								groupId, folderId, fileEntryId, uniqueTitle,
-								uniqueFileName)) {
-
-							break;
-						}
-
-						generatedUniqueFileName = true;
-
-						uniqueTitle =
-							titleWithoutExtension + StringPool.UNDERLINE +
-								String.valueOf(i);
-
-						if (Validator.isNotNull(titleExtension)) {
-							uniqueTitle += StringPool.PERIOD.concat(
-								titleExtension);
-						}
-
-						uniqueFileName = DLUtil.getSanitizedFileName(
-							uniqueTitle, extension);
-					}
-
-					if (generatedUniqueFileName) {
-						generatedUniqueFileNames.add(uniqueFileName);
-						generatedUniqueTitles.add(uniqueTitle);
-					}
-
-					ps2.setString(1, uniqueFileName);
-
-					if (Validator.isNotNull(uniqueTitle)) {
-						ps2.setString(2, uniqueTitle);
-					}
-					else {
-						ps2.setString(2, title);
-					}
-
-					ps2.setLong(3, fileEntryId);
-
-					ps2.addBatch();
-
-					if (Validator.isNotNull(uniqueTitle)) {
-						ps3.setString(1, uniqueTitle);
-						ps3.setLong(2, fileEntryId);
-						ps3.setString(3, version);
-						ps3.setInt(4, WorkflowConstants.STATUS_IN_TRASH);
-
-						ps3.addBatch();
-					}
-				}
-
-				ps2.executeBatch();
-
-				ps3.executeBatch();
-			}
+			_fixDuplicateFileEntryFileNames();
 		}
 	}
 
@@ -556,6 +428,138 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 				ps.executeUpdate();
 			}
+		}
+	}
+
+	private void _fixDuplicateFileEntryFileNames() throws Exception {
+		Set<String> generatedUniqueFileNames = new HashSet<>();
+		Set<String> generatedUniqueTitles = new HashSet<>();
+
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select fileEntryId, groupId, folderId, extension, title, " +
+					"version from DLFileEntry where fileName = '' or " +
+						"fileName is null");
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBatch(
+				connection.prepareStatement(
+					"update DLFileEntry set fileName = ?, title = ? where " +
+						"fileEntryId = ?"));
+			PreparedStatement ps3 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DLFileVersion set title = ? where fileEntryId = " +
+						"? and version = ? and status != ?");
+			ResultSet rs = ps1.executeQuery()) {
+
+			while (rs.next()) {
+				long fileEntryId = rs.getLong("fileEntryId");
+				long groupId = rs.getLong("groupId");
+				long folderId = rs.getLong("folderId");
+				String extension = GetterUtil.getString(
+					rs.getString("extension"));
+				String title = GetterUtil.getString(rs.getString("title"));
+				String version = rs.getString("version");
+
+				String uniqueFileName = DLUtil.getSanitizedFileName(
+					title, extension);
+
+				String titleExtension = StringPool.BLANK;
+				String titleWithoutExtension = title;
+
+				if (title.endsWith(StringPool.PERIOD + extension)) {
+					titleExtension = extension;
+					titleWithoutExtension = FileUtil.stripExtension(title);
+				}
+
+				boolean generatedUniqueFileName = false;
+				String uniqueTitle = title;
+
+				for (int i = 1;; i++) {
+					if (!generatedUniqueFileNames.contains(uniqueFileName) &&
+						!generatedUniqueTitles.contains(uniqueTitle) &&
+						!hasFileEntry(
+							groupId, folderId, fileEntryId, uniqueTitle,
+							uniqueFileName)) {
+
+						break;
+					}
+
+					generatedUniqueFileName = true;
+
+					uniqueTitle =
+						titleWithoutExtension + StringPool.UNDERLINE +
+							String.valueOf(i);
+
+					if (Validator.isNotNull(titleExtension)) {
+						uniqueTitle += StringPool.PERIOD.concat(titleExtension);
+					}
+
+					uniqueFileName = DLUtil.getSanitizedFileName(
+						uniqueTitle, extension);
+				}
+
+				if (generatedUniqueFileName) {
+					generatedUniqueFileNames.add(uniqueFileName);
+					generatedUniqueTitles.add(uniqueTitle);
+				}
+
+				ps2.setString(1, uniqueFileName);
+
+				if (Validator.isNotNull(uniqueTitle)) {
+					ps2.setString(2, uniqueTitle);
+				}
+				else {
+					ps2.setString(2, title);
+				}
+
+				ps2.setLong(3, fileEntryId);
+
+				ps2.addBatch();
+
+				if (Validator.isNotNull(uniqueTitle)) {
+					ps3.setString(1, uniqueTitle);
+					ps3.setLong(2, fileEntryId);
+					ps3.setString(3, version);
+					ps3.setInt(4, WorkflowConstants.STATUS_IN_TRASH);
+
+					ps3.addBatch();
+				}
+			}
+
+			ps2.executeBatch();
+
+			ps3.executeBatch();
+		}
+	}
+
+	private void _updateLongFileEntryFileNames() throws Exception {
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select fileEntryId, title, extension from DLFileEntry where " +
+					"fileName = '' or fileName is null");
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBatch(
+				connection.prepareStatement(
+					"update DLFileEntry set fileName = ? where fileEntryId = " +
+						"?"));
+			ResultSet rs = ps1.executeQuery()) {
+
+			while (rs.next()) {
+				long fileEntryId = rs.getLong("fileEntryId");
+				String extension = rs.getString("extension");
+				String title = rs.getString("title");
+
+				int availableLength = 254 - extension.length();
+
+				String fileName =
+					title.substring(0, availableLength) + StringPool.PERIOD +
+						extension;
+
+				ps2.setString(1, fileName);
+
+				ps2.setLong(2, fileEntryId);
+
+				ps2.addBatch();
+			}
+
+			ps2.executeBatch();
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -477,9 +477,8 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 				while (rs.next()) {
 					long fileEntryId = rs.getLong("fileEntryId");
-					String extension = GetterUtil.getString(
-						rs.getString("extension"));
-					String title = GetterUtil.getString(rs.getString("title"));
+					String extension = rs.getString("extension");
+					String title = rs.getString("title");
 					String version = rs.getString("version");
 
 					String uniqueFileName = DLUtil.getSanitizedFileName(


### PR DESCRIPTION
Hi @SamZiemer,

I'm sending these fixes simultaneously because otherwise there will be merge conflicts if we try to merge them separately.

There is a known limitation of the CONCAT logic that I added to SQLServer. The regex avoids parsing commas that are inside of single quotes or double quotes, but it fails to account for a comma inside an inner function (for example, a REPLACE). It'll still work for an inner CONCAT since it processes the inner CONCAT first, but for any other inner function, it will fail. Someone who is better than making regexes than me can work on fixing this, but for now, I'm just calling it a known limitation.

The fix seeks to take advantage of the fact that most of the things done by DLUtil.sanitizeFileName can be automated and done in bulk by SQL. DLUtil.sanitizeFileName does the following three things:

1. Replaces forward slashes with underscores.
2. Appends the extension to the file name if the extension exists and the file name does not already have it.
3. Truncates the portion of the file name before the extension if necessary so that the file name is no greater than 255 characters.

Let me know if you have any questions about the fix.