### PR TITLE
LPS-65331

### DIFF
--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
@@ -99,7 +99,7 @@ public interface CaptchaConfiguration {
 	public String[] simpleCaptchaBackgroundProducers();
 
 	@Meta.AD(
-		deflt = "nl.captcha.gimpy.BlockGimpyRenderer|nl.captcha.gimpy.DropShadowGimpyRenderer|nl.captcha.gimpy.FishEyeGimpyRenderer|nl.captcha.gimpy.RippleGimpyRenderer|nl.captcha.gimpy.ShearGimpyRenderer",
+		deflt = "nl.captcha.gimpy.BlockGimpyRenderer|nl.captcha.gimpy.FishEyeGimpyRenderer|nl.captcha.gimpy.RippleGimpyRenderer|nl.captcha.gimpy.ShearGimpyRenderer",
 		description = "simple-captcha-gimpy-renderers-help",
 		name = "simple-captcha-gimpy-renderers", required = false
 	)


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-27107
https://issues.liferay.com/browse/LPS-65331

There is about a 20% chance when refreshing the CAPTCHA image when creating a new account (or just when loading it for the first time) for it to generate a NullPointerException in the logs.

This is because, of all the registered "Gimpy renderers" (of which there are five by default), we always randomly select one to use, but the `DropShadowGimpyRenderer` in particular appears to always throw NullPointerExceptions. As noted in [this comment on LPS-62609](https://issues.liferay.com/browse/LPS-62609?focusedCommentId=728229&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-728229), this appears to be a known issue in the third-party library (see https://sourceforge.net/p/simplecaptcha/bugs/14/).

Since our code does not apparently have any preference for a particular renderer, and the other four all seem to work fine, I propose a fix of simply removing the one with issues from our default configuration. Of course we would need to document this for existing users, but I feel this is probably the easiest and most practical approach. Let me know if there are any problems with this or alternative suggestions, though.

Thanks!