### PR TITLE
LPS-74486 Stop permissions menu from opening inside another frame.

### DIFF
--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -122,7 +122,7 @@ RoleSearchTerms searchTerms = (RoleSearchTerms)roleSearchContainer.getSearchTerm
 %>
 
 <div class="edit-permissions portlet-configuration-edit-permissions">
-	<div class="portlet-configuration-body-content">
+	<div class="lfr-form-content portlet-configuration-body-content">
 		<aui:nav-bar cssClass="collapse-basic-search" markupView="lexicon">
 			<aui:nav cssClass="navbar-nav">
 				<aui:nav-item label="permissions" selected="<%= true %>" />


### PR DESCRIPTION
Hi Sam, this is a fix related to: https://issues.liferay.com/browse/LPS-74486

The change essentially classifies the permission menu as the contents of the iframe/window, so it doesn't open up nested within another frame. This nesting is what caused the misaligned button row as shown in the gif in the issue report.

This behavior doesn't appear in the master branch in all of the tests I've done, only in the 7.0.x branch. I'm guessing it might have to do with the switch on master to Bootstrap 4, but I'm personally not certain.

Thanks!