### PR TITLE
LPS-74024

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/lar/DLPortletDataHandler.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/lar/DLPortletDataHandler.java
@@ -102,6 +102,11 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 		return DLConstants.SERVICE_NAME;
 	}
 
+	@Override
+	public boolean isSupportsDataStrategyMirrorWithOverwriting() {
+		return true;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLocalized(true);

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/lar/packageinfo
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/lar/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_resources.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_resources.jsp
@@ -298,7 +298,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(them
 					<aui:input checked="<%= true %>" data-name='<%= LanguageUtil.get(request, "mirror") %>' id="mirror" label="<%= taglibMirrorLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_MIRROR %>" />
 
 					<%
-					String taglibMirrorWithOverwritingLabel = LanguageUtil.get(request, "mirror-with-overwriting") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, (portletDataHandler.isSupportsDataStrategyMirrorWithOverwriting() ? "import-data-strategy-mirror-with-overwriting-help" : "not-supported")) + "</span>";
+					String taglibMirrorWithOverwritingLabel = LanguageUtil.get(request, "mirror-with-overwriting") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, (portletDataHandler.isSupportsDataStrategyMirrorWithOverwriting() ? "import-data-strategy-mirror-with-overwriting-help" : "import-data-strategy-mirror-with-overwriting-is-not-available-help")) + "</span>";
 					%>
 
 					<aui:input data-name='<%= LanguageUtil.get(request, "mirror-with-overwriting") %>' disabled="<%= !portletDataHandler.isSupportsDataStrategyMirrorWithOverwriting() %>" id="mirrorWithOverwriting" label="<%= taglibMirrorWithOverwritingLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_MIRROR_OVERWRITE %>" />

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language.properties
@@ -64,6 +64,7 @@ go-to-this-version=Go to This Version
 import-data-strategy-copy-as-new-help=All data and content inside the imported LAR is created as new entries within the current site every time the LAR is imported.
 import-data-strategy-mirror-help=All data and content inside the imported LAR is created as new the first time while maintaining a reference to the source. Subsequent imports from the same source update the entries instead of creating new entries.
 import-data-strategy-mirror-with-overwriting-help=Same behavior as the mirror strategy, but if a document or an image with the same name is found, it is overwritten.
+import-data-strategy-mirror-with-overwriting-is-not-available-help=The mirror with overwriting import strategy is not available for this application. This application does not use applicable data, or it does not uniquely identify data by name.
 import-entity=Import Asset
 import-permissions=Import Permissions
 import-private-pages=Import Private Pages

--- a/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/web-experience/staging/staging-lang/src/main/resources/content/Language_en.properties
@@ -64,6 +64,7 @@ go-to-this-version=Go to This Version
 import-data-strategy-copy-as-new-help=All data and content inside the imported LAR is created as new entries within the current site every time the LAR is imported.
 import-data-strategy-mirror-help=All data and content inside the imported LAR is created as new the first time while maintaining a reference to the source. Subsequent imports from the same source update the entries instead of creating new entries.
 import-data-strategy-mirror-with-overwriting-help=Same behavior as the mirror strategy, but if a document or an image with the same name is found, it is overwritten.
+import-data-strategy-mirror-with-overwriting-is-not-available-help=The mirror with overwriting import strategy is not available for this application. This application does not use applicable data, or it does not uniquely identify data by name.
 import-entity=Import Asset
 import-permissions=Import Permissions
 import-private-pages=Import Private Pages

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
@@ -255,7 +255,7 @@ public interface PortletDataHandler {
 	}
 
 	public default boolean isSupportsDataStrategyMirrorWithOverwriting() {
-		return true;
+		return false;
 	}
 
 	public void prepareManifestSummary(PortletDataContext portletDataContext)


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPS-74024
https://issues.liferay.com/browse/LPP-28136
https://issues.liferay.com/browse/PTR-83

This change improves the explanation given when the "Mirror with overwriting" import strategy is not available for a given portlet. The current implementation simply reads "Not Supported," but this is unhelpful and confusing for users.

There was a long conversation on [PTR-83](https://issues.liferay.com/browse/PTR-83) about the proper way to handle this, which culminated in the decision to remove the option altogether in 7.1, and update the help message in 7.0. However, as per [this comment on LPP-28136](https://issues.liferay.com/browse/LPP-28136?focusedCommentId=1213462&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1213462), it seems that there is not enough bandwidth to be able to push through the removal of this feature from 7.1, so to be able to get this fix in for 7.0, we must first commit it to master.

Due to problems related to [LPS-76221](https://issues.liferay.com/browse/LPS-76221), we have not been able to generate new language keys -- but as per [this comment on LRSUPPORT-19936](https://issues.liferay.com/browse/LRSUPPORT-19936?focusedCommentId=1218406&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1218406), for now we should be able to manually add the language keys to the languages needed (for a customer's issue). Thus, since a `gradlew buildLang` will not work for now, the message was simply manually added to Language_en.properties.

Please let me know of any questions or concerns about this. Thank you.