### PR TITLE
LPS-76707

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -91,8 +91,18 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 
 	for (AssetRendererFactory<?> assetRendererFactory : assetRendererFactories) {
 		ClassTypeReader classTypeReader = assetRendererFactory.getClassTypeReader();
+		String portletId = assetRendererFactory.getPortletId();
+		long[] referencedModelsGroupIds = assetPublisherDisplayContext.getReferencedModelsGroupIds();
 
-		List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedModelsGroupIds(), locale);
+		for (int i = 0; i < referencedModelsGroupIds.length; i++) {
+			Group referencedModelsGroup = GroupLocalServiceUtil.getGroup(referencedModelsGroupIds[i]);
+
+			if (referencedModelsGroup.isStagingGroup() && !referencedModelsGroup.isStagedPortlet(portletId)) {
+				referencedModelsGroupIds[i] = referencedModelsGroup.getLiveGroupId();
+			}
+		}
+
+		List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(referencedModelsGroupIds, locale);
 
 		if (classTypes.isEmpty()) {
 			continue;


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-28363
https://issues.liferay.com/browse/LPS-76707

When Staging is enabled for a Site, Asset Publishers cannot filter by structure for types of content that are not staged. For example, Asset Publishers cannot filter by Web Content structure if Staging is not enabled for Web Content.

This occurs because the Web Content structures cannot be added to the Staging site if they are not staged, and are directly added to the live site instead, but the Asset Publisher still references the Staging site. No extra logic is done to verify whether the structures themselves are staged or not, so it tries and fails to find them in the Staging site.

This fix simply does more logic in the JSP to validate the groupId's for each relevant content type, once it retrieves them. For reference, this fix is very similar to that of [LPS-68453](https://issues.liferay.com/browse/LPS-68453) (see https://github.com/brianchandotcom/liferay-portal/pull/47749/commits/3e894e0ba56e5753ec115fdbc677e8e5c9fa6a80#diff-871d84ca38f415c92fb0be4944cf0be9R126).

Please let me know if there are any questions or concerns. Thanks!