### PR TITLE
LPS-76712 Add optional wires for database drivers

### DIFF
--- a/modules/apps/foundation/portal/portal-cluster-multiple/bnd.bnd
+++ b/modules/apps/foundation/portal/portal-cluster-multiple/bnd.bnd
@@ -14,6 +14,24 @@ Import-Package:\
 	\
 	!org.mozilla.javascript.*,\
 	\
+	com.ibm.db2.jcc;resolution:=optional,\
+	\
+	com.microsoft.sqlserver.jdbc;resolution:=optional,\
+	\
+	com.mysql.jdbc;resolution:=optional,\
+	\
+	com.p6spy.engine.spy;resolution:=optional,\
+	\
+	com.sybase.jdbc4.jdbc;resolution:=optional,\
+	\
+	oracle.jdbc;resolution:=optional,\
+	\
+	org.hsqldb.jdbc;resolution:=optional,\
+	\
+	org.mariadb.jdbc;resolution:=optional,\
+	\
+	org.postgresql;resolution:=optional,\
+	\
 	*
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Clustering


### PR DESCRIPTION
**Related Tickets:**
[LPP-28397](https://issues.liferay.com/browse/LPP-28397)
[LPS-76712](https://issues.liferay.com/browse/LPS-76712)

Hi @SamZiemer,

This commit adds optional dependencies for database drivers that Liferay supports.
The list of database driver classes are based on the ones listed in [portal.properties#L1027-L1094](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/portal.properties#L1027-L1094).

Please let me know if you have any questions.
Thanks!