### PR TITLE
LPS-76768 Add direction cssClass for lexicon

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -42,7 +42,7 @@ if (Validator.isNull(icon)) {
 %>
 
 <div class="dropdown lfr-icon-menu <%= cssClass %>" <%= AUIUtil.buildData(data) %>>
-	<a class="dropdown-toggle icon-monospaced <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" title="<%= message %>">
+	<a class="dropdown-toggle direction-<%= direction %> icon-monospaced <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" title="<%= message %>">
 		<aui:icon image="<%= icon %>" markupView="lexicon" />
 	</a>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-76768
https://issues.liferay.com/browse/LPP-28290

With lexicon dropdowns the cssClass does not contain the direction and always [fails to match our direction regex](https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js#L144).