### PR TITLE
LPS-76667 - Organization sites do not properly process membership from other organizations

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1543,7 +1543,7 @@ public class GroupFinderImpl
 		if (classNameIds == null) {
 			params1.put("classNameIds", groupOrganizationClassNameIds);
 			params2.put("classNameIds", organizationClassNameId);
-			params3.put("classNameIds", groupClassNameId);
+			params3.put("classNameIds", groupOrganizationClassNameIds);
 			params4.put("classNameIds", groupOrganizationClassNameIds);
 		}
 		else {


### PR DESCRIPTION
Hi Sam!

LPP: https://issues.liferay.com/browse/LPP-28076
LPS: https://issues.liferay.com/browse/LPS-76667

Summary:
This is a regression bug caused by [LPS-64261](https://issues.liferay.com/browse/LPS-64261) where manually adding membership of another organization to an organization site does not properly grant view/access permissions to the users in that organization. User groups are found in "populateUnionParams" where params3 corresponds with "groupsOrgs" or groups linked to organizations. Therefore the fix is to have it check both the groupClassNameId and OrganizationClassNameId to not miss groups granted to the user by any organizations they are members of.

If you have any questions, please let me know. Thanks!