### PR TITLE
LPS 52107 - Children organizations do not inherit site membership from parent organizations

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -774,6 +774,27 @@ public class OrganizationLocalServiceImpl
 	}
 
 	/**
+	 * Returns the ids of suborganizations of the organizations.
+	 *
+	 * @param  organizationList the organizations from which to get
+	 *         suborganization ids
+	 * @return the ids of suborganizations of the organizations
+	 */
+	public long[] getSuborganizationsIds(List<Organization> organizationList) {
+		List<Organization> suborgList = getSuborganizations(organizationList);
+
+		long[] orgIds = new long[suborgList.size()];
+
+		for (int i = 0; i < suborgList.size(); i++) {
+			Organization org = suborgList.get(i);
+
+			orgIds[i] = org.getOrganizationId();
+		}
+
+		return orgIds;
+	}
+
+	/**
 	 * Returns the intersection of <code>allOrganizations</code> and
 	 * <code>availableOrganizations</code>.
 	 *

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationServiceImpl.java
@@ -69,6 +69,14 @@ public class OrganizationServiceImpl extends OrganizationServiceBaseImpl {
 
 		organizationLocalService.addGroupOrganizations(
 			groupId, organizationIds);
+
+		List<Organization> orgList = organizationLocalService.getOrganizations(
+			organizationIds);
+
+		long[] suborgIds = organizationLocalService.getSuborganizationsIds(
+			orgList);
+
+		organizationLocalService.addGroupOrganizations(groupId, suborgIds);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalService.java
@@ -583,6 +583,16 @@ public interface OrganizationLocalService extends BaseLocalService,
 	public int getSuborganizationsCount(long companyId, long organizationId);
 
 	/**
+	* Returns the ids of suborganizations of the organizations.
+	*
+	* @param organizationList the organizations from which to get
+	suborganization ids
+	* @return the ids of suborganizations of the organizations
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public long[] getSuborganizationsIds(List<Organization> organizationList);
+
+	/**
 	* Returns the intersection of <code>allOrganizations</code> and
 	* <code>availableOrganizations</code>.
 	*

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceUtil.java
@@ -704,6 +704,18 @@ public class OrganizationLocalServiceUtil {
 	}
 
 	/**
+	* Returns the ids of suborganizations of the organizations.
+	*
+	* @param organizationList the organizations from which to get
+	suborganization ids
+	* @return the ids of suborganizations of the organizations
+	*/
+	public static long[] getSuborganizationsIds(
+		java.util.List<com.liferay.portal.kernel.model.Organization> organizationList) {
+		return getService().getSuborganizationsIds(organizationList);
+	}
+
+	/**
 	* Returns the intersection of <code>allOrganizations</code> and
 	* <code>availableOrganizations</code>.
 	*

--- a/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/OrganizationLocalServiceWrapper.java
@@ -768,6 +768,19 @@ public class OrganizationLocalServiceWrapper implements OrganizationLocalService
 	}
 
 	/**
+	* Returns the ids of suborganizations of the organizations.
+	*
+	* @param organizationList the organizations from which to get
+	suborganization ids
+	* @return the ids of suborganizations of the organizations
+	*/
+	@Override
+	public long[] getSuborganizationsIds(
+		java.util.List<com.liferay.portal.kernel.model.Organization> organizationList) {
+		return _organizationLocalService.getSuborganizationsIds(organizationList);
+	}
+
+	/**
 	* Returns the intersection of <code>allOrganizations</code> and
 	* <code>availableOrganizations</code>.
 	*


### PR DESCRIPTION
Hi Sam!

LPP: https://issues.liferay.com/browse/LPP-28259
LPS: https://issues.liferay.com/browse/LPS-52107

**Issue:**
The issue being reported by the client is that child organizations do not inherit site membership from parent organizations. 

**Summary of History:**
A previous LPP provides context for this fix. Specifically several decisions were made including:
- that the behavior of children organizations being added automatically is [intended](https://issues.liferay.com/browse/LPP-14323?focusedCommentId=548245&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-548245)
- that [users belonging to child orgs should be visible](https://issues.liferay.com/browse/LPP-14323?focusedCommentId=556942&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-556942) in Site Memberships -> Users upon being added through a parent org being added

Minhchau made an SDH for the aforementioned LPP, but since it was both exclusive to 6.2 and made three years ago so much has changed that I mostly started anew.

**The Fix:**
The fix itself simply searches for and adds all suborganizations during the initial addition of the parent organization to the site. After that it treats all organizations as individual entities. This means that adding the parent org adds all child orgs, but removing the parent org only removes the parent org. Each org must be removed individually. I figured this would be optimal due to possible cases where keeping the child org when removing the parent org is preferred (e.g. adding a parent org to a child organization's site and later removing it).

Please tell me if you think I should change tacks or have any questions or concerns. Thanks!
  
  