### PR TITLE
LPS-77348 - Prevent incrementing viewcount from overwriting DLFileEntry with stale data

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -132,6 +132,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Provides the local service for accessing, adding, checking in/out, deleting,
@@ -1643,16 +1644,59 @@ public class DLFileEntryLocalServiceImpl
 		configuration = "DLFileEntry", incrementClass = NumberIncrement.class
 	)
 	@Override
-	public void incrementViewCounter(DLFileEntry dlFileEntry, int increment) {
+	public void incrementViewCounter(DLFileEntry dlFileEntry, int increment)
+		throws PortalException {
+
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			return;
 		}
 
-		dlFileEntry = dlFileEntryPersistence.fetchByPrimaryKey(
-			dlFileEntry.getFileEntryId());
-
 		if (dlFileEntry == null) {
 			return;
+		}
+
+		long fileEntryId = dlFileEntry.getFileEntryId();
+
+		dlFileEntry = dlFileEntryPersistence.fetchByPrimaryKey(fileEntryId);
+
+		String newFileVersion = dlFileEntry.getVersion();
+
+		DLFileVersion dlFileVersion = dlFileEntry.getLatestFileVersion(true);
+
+		if (dlFileVersion != null) {
+			String latestVersion = dlFileVersion.getVersion();
+
+			if (!newFileVersion.equals(latestVersion)) {
+				String[] splitNewVersion = newFileVersion.split(
+					Pattern.quote("."));
+				String[] splitLatestVersion = latestVersion.split(
+					Pattern.quote("."));
+
+				try {
+					int firstNewToken = Integer.valueOf(splitNewVersion[0]);
+					int firstLatestToken = Integer.valueOf(
+						splitLatestVersion[0]);
+
+					if (firstNewToken < firstLatestToken) {
+						dlFileEntry.setVersion(latestVersion);
+					}
+					else {
+						int secondNewToken = Integer.valueOf(
+							splitNewVersion[1]);
+						int secondLatestToken = Integer.valueOf(
+							splitLatestVersion[1]);
+
+						if (secondNewToken < secondLatestToken) {
+							dlFileEntry.setVersion(latestVersion);
+						}
+					}
+				}
+				catch (NumberFormatException nfe) {
+					if (_log.isWarnEnabled()) {
+						_log.warn("File version is non-numeric.");
+					}
+				}
+			}
 		}
 
 		dlFileEntry.setModifiedDate(dlFileEntry.getModifiedDate());

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -605,7 +605,8 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 		throws PortalException;
 
 	@BufferedIncrement(configuration = "DLFileEntry", incrementClass = NumberIncrement.class)
-	public void incrementViewCounter(DLFileEntry dlFileEntry, int increment);
+	public void incrementViewCounter(DLFileEntry dlFileEntry, int increment)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public boolean isFileEntryCheckedOut(long fileEntryId)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -800,7 +800,8 @@ public class DLFileEntryLocalServiceUtil {
 
 	public static void incrementViewCounter(
 		com.liferay.document.library.kernel.model.DLFileEntry dlFileEntry,
-		int increment) {
+		int increment)
+		throws com.liferay.portal.kernel.exception.PortalException {
 		getService().incrementViewCounter(dlFileEntry, increment);
 	}
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -886,7 +886,8 @@ public class DLFileEntryLocalServiceWrapper implements DLFileEntryLocalService,
 	@Override
 	public void incrementViewCounter(
 		com.liferay.document.library.kernel.model.DLFileEntry dlFileEntry,
-		int increment) {
+		int increment)
+		throws com.liferay.portal.kernel.exception.PortalException {
 		_dlFileEntryLocalService.incrementViewCounter(dlFileEntry, increment);
 	}
 


### PR DESCRIPTION
Hi Sam!

LPP: https://issues.liferay.com/browse/LPP-28644
LPS: https://issues.liferay.com/browse/LPS-77348

The fix is identical to #408, just placed in the proper spot in the implementation layer, so all comments in that PR apply here. If you have any questions or concerns, please let me know. Thanks!