### PR TITLE
LPS-77348 - Prevent incrementing viewcount from overwriting DLFileEntry with stale data

### DIFF
--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -605,7 +605,8 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 		throws PortalException;
 
 	@BufferedIncrement(configuration = "DLFileEntry", incrementClass = NumberIncrement.class)
-	public void incrementViewCounter(DLFileEntry dlFileEntry, int increment);
+	public void incrementViewCounter(DLFileEntry dlFileEntry, int increment)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public boolean isFileEntryCheckedOut(long fileEntryId)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -800,7 +800,8 @@ public class DLFileEntryLocalServiceUtil {
 
 	public static void incrementViewCounter(
 		com.liferay.document.library.kernel.model.DLFileEntry dlFileEntry,
-		int increment) {
+		int increment)
+		throws com.liferay.portal.kernel.exception.PortalException {
 		getService().incrementViewCounter(dlFileEntry, increment);
 	}
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -886,7 +886,8 @@ public class DLFileEntryLocalServiceWrapper implements DLFileEntryLocalService,
 	@Override
 	public void incrementViewCounter(
 		com.liferay.document.library.kernel.model.DLFileEntry dlFileEntry,
-		int increment) {
+		int increment)
+		throws com.liferay.portal.kernel.exception.PortalException {
 		_dlFileEntryLocalService.incrementViewCounter(dlFileEntry, increment);
 	}
 


### PR DESCRIPTION
Hi Sam!

LPP: https://issues.liferay.com/browse/LPP-28644
LPS: https://issues.liferay.com/browse/LPS-77348

The fix is identical to #408, just placed in the proper spot in the implementation layer, so all comments in that PR apply here. I ran CI here: https://github.com/wanderlast/liferay-portal/pull/2 and it seems like the test results look fine again, although I'll run it again here too if necessary.

If you have any questions or concerns, please let me know. Thanks!