### PR TITLE
LPS-77842

### DIFF
--- a/modules/util/portal-tools-service-builder/build.gradle
+++ b/modules/util/portal-tools-service-builder/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 	provided group: "com.liferay", name: "com.liferay.petra.string", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.petra.xml", version: "1.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.20.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.49.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.5.0"
 	provided group: "org.apache.ant", name: "ant", transitive: false, version: "1.9.4"

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1153,7 +1153,9 @@
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
 		<field name="classNameId" type="long" />
-		<field name="name" type="String" />
+		<field name="name" type="String" >
+			<hint name="max-length">200</hint>
+		</field>
 		<field name="description" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPS-77842

The Repository table in the database has both a name and portletId column, and Liferay at times expects to put the same value in both columns. However, with long portletId's (which have a limit of 200 characters), adding a row will fail because the name column can only hold 75 characters.

[LPS-35711](https://issues.liferay.com/browse/LPS-35711) extended the size of the portletId column, but not the name column. From the description, it looks like this was done to allow it to match the size of portletId columns in other tables. Additionally, we found through investigating the code that there are some places in the code that expect to put the same value into each of these columns or for them to be the same (for example, see [PortletFileRepositoryImpl](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java#L270-L274)). Thus, we believe this is an oversight that can be treated as a bug.

In my testing, I faced issues with the Service Builder that prevented me from generating the changes to update the schema. Because of this, the changes to the Repository table that would resolve this issue were not reflected in my testing. I was following this documentation, and faced errors with the last step that seem to be specific to my environment: https://grow.liferay.com/people/Modifying+Liferay+Core+schema

Can these extra changes be added in? Thanks in advance!

Of course, please also let me know if there are any concerns about this fix. Thank you.