### PR TITLE
LPS-78227

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
@@ -165,7 +165,7 @@ boolean hasAddOrganizationPermission = PortalPermissionUtil.contains(permissionC
 					parentOrganizationId = OrganizationConstants.ANY_PARENT_ORGANIZATION_ID;
 				}
 				else {
-					parentOrganizationId = ParamUtil.getLong(request, "parentOrganizationId", OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
+					parentOrganizationId = ParamUtil.getLong(request, "parentOrganizationId", OrganizationConstants.ANY_PARENT_ORGANIZATION_ID);
 				}
 				%>
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationFinderImpl.java
@@ -1129,13 +1129,12 @@ public class OrganizationFinderImpl
 
 				if (!organizationsTree.isEmpty()) {
 					for (Organization organization : organizationsTree) {
-						StringBundler sb = new StringBundler(5);
+						StringBundler sb = new StringBundler(4);
 
 						sb.append(StringPool.PERCENT);
 						sb.append(StringPool.SLASH);
 						sb.append(organization.getOrganizationId());
 						sb.append(StringPool.SLASH);
-						sb.append(StringPool.PERCENT);
 
 						qPos.add(sb.toString());
 					}


### PR DESCRIPTION
Resent from https://github.com/SamZiemer/liferay-portal/pull/427

Relevant tickets:

https://issues.liferay.com/browse/LPP-28913
https://issues.liferay.com/browse/LPS-78227
https://issues.liferay.com/browse/PTR-269

Viewing Organizations through either the Control Panel portlet or through "My Organizations" cannot show non-root Organizations by default (without searching). Additionally, if searching with index is disabled through use of the property `organizations.search.with.index=false`, then the results will differ in that child Organizations can be returned and viewed this way, when searching with index will not do so.

After discussion on [PTR-269](https://issues.liferay.com/browse/PTR-269), it was decided that the configuration to allow searching without index should be removed from master, although for released versions, we will push for consistency. To do this, the change introduced here makes searching without index (in `OrganizationFinderImpl`) remove the wild card from the organizationsTree that allows returning child Organizations.

Additionally, for usability purposes, we made a change to make the `parentOrganizationId` match any Organization when none is specified and there are no search terms (so, when the Organizations are first loaded). That way, non-root Organizations can be viewed without having to search explicitly for them, which should be less confusing for members of those Organizations.

See [this comment](https://issues.liferay.com/browse/PTR-269?focusedCommentId=1253417&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1253417) (and the following discussion) for more on our reasoning.

Let me know if there are any questions or concerns. Thanks!