### PR TITLE
LPS-78748

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/util/FileSystemImporter.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/util/FileSystemImporter.java
@@ -780,8 +780,6 @@ public class FileSystemImporter extends BaseImporter {
 			long length)
 		throws Exception {
 
-		String title = FileUtil.stripExtension(fileName);
-
 		setServiceContext(fileName);
 
 		FileEntry fileEntry = null;
@@ -790,8 +788,9 @@ public class FileSystemImporter extends BaseImporter {
 			try {
 				fileEntry = dlAppLocalService.addFileEntry(
 					userId, groupId, parentFolderId, fileName,
-					mimeTypes.getContentType(fileName), title, StringPool.BLANK,
-					StringPool.BLANK, inputStream, length, serviceContext);
+					mimeTypes.getContentType(fileName), fileName,
+					StringPool.BLANK, StringPool.BLANK, inputStream, length,
+					serviceContext);
 			}
 			catch (DuplicateFileEntryException dfee) {
 
@@ -802,15 +801,15 @@ public class FileSystemImporter extends BaseImporter {
 				}
 
 				fileEntry = dlAppLocalService.getFileEntry(
-					groupId, parentFolderId, title);
+					groupId, parentFolderId, fileName);
 
 				String previousVersion = fileEntry.getVersion();
 
 				fileEntry = dlAppLocalService.updateFileEntry(
 					userId, fileEntry.getFileEntryId(), fileName,
-					mimeTypes.getContentType(fileName), title, StringPool.BLANK,
-					StringPool.BLANK, true, inputStream, length,
-					serviceContext);
+					mimeTypes.getContentType(fileName), fileName,
+					StringPool.BLANK, StringPool.BLANK, true, inputStream,
+					length, serviceContext);
 
 				dlFileEntryLocalService.deleteFileVersion(
 					fileEntry.getUserId(), fileEntry.getFileEntryId(),


### PR DESCRIPTION
Hey @SamZiemer,

It looks like the logic to call `FileUtil.stripExtension` was added in https://github.com/liferay/liferay-plugins-ee/commit/8cc3bef4fe2d23db634b5bd36473a0791098f9db. I couldn't figure out from the LPS description or commit message why this decision was made, so I think it's OK to reverse it.

If you think we should fix the problem a different way, we can do it, but the code will have to be ugly because we don't have any fetch methods in DLAppLocalServiceImpl, so we'll have to rely on catching a lot of Exceptions for our control flow.