### PR TITLE
LPS-79188

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -167,34 +167,6 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 		_groupService.updateGroup(liveGroupId, liveGroup.getTypeSettings());
 	}
 
-	protected String updateRobots(
-			ActionRequest actionRequest, long liveGroupId,
-			boolean privateLayout)
-		throws Exception {
-
-		Group liveGroup = _groupLocalService.getGroup(liveGroupId);
-
-		UnicodeProperties typeSettingsProperties =
-			liveGroup.getTypeSettingsProperties();
-
-		String propertyName = "false-robots.txt";
-
-		if (privateLayout) {
-			propertyName = "true-robots.txt";
-		}
-
-		String robots = ParamUtil.getString(
-			actionRequest, "robots",
-			liveGroup.getTypeSettingsProperty(propertyName));
-
-		typeSettingsProperties.setProperty(propertyName, robots);
-
-		_groupService.updateGroup(
-			liveGroup.getGroupId(), typeSettingsProperties.toString());
-
-		return robots;
-	}
-
 	protected void updateSettings(
 			ActionRequest actionRequest, long liveGroupId, long stagingGroupId,
 			boolean privateLayout, UnicodeProperties settingsProperties)
@@ -211,16 +183,6 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 		if (stagingGroupId > 0) {
 			groupId = stagingGroupId;
 		}
-
-		String robots = updateRobots(actionRequest, liveGroupId, privateLayout);
-
-		String robotsPropertyName = "false-robots.txt";
-
-		if (privateLayout) {
-			robotsPropertyName = "true-robots.txt";
-		}
-
-		settingsProperties.put(robotsPropertyName, robots);
 
 		_layoutSetService.updateSettings(
 			groupId, privateLayout, settingsProperties.toString());

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -79,8 +79,6 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 
 		updateMergePages(actionRequest, liveGroupId);
 
-		updateRobots(actionRequest, liveGroupId, privateLayout);
-
 		updateSettings(
 			actionRequest, liveGroupId, stagingGroupId, privateLayout,
 			layoutSet.getSettingsProperties());
@@ -169,7 +167,7 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 		_groupService.updateGroup(liveGroupId, liveGroup.getTypeSettings());
 	}
 
-	protected void updateRobots(
+	protected String updateRobots(
 			ActionRequest actionRequest, long liveGroupId,
 			boolean privateLayout)
 		throws Exception {
@@ -193,6 +191,8 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 
 		_groupService.updateGroup(
 			liveGroup.getGroupId(), typeSettingsProperties.toString());
+
+		return robots;
 	}
 
 	protected void updateSettings(
@@ -211,6 +211,16 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 		if (stagingGroupId > 0) {
 			groupId = stagingGroupId;
 		}
+
+		String robots = updateRobots(actionRequest, liveGroupId, privateLayout);
+
+		String robotsPropertyName = "false-robots.txt";
+
+		if (privateLayout) {
+			robotsPropertyName = "true-robots.txt";
+		}
+
+		settingsProperties.put(robotsPropertyName, robots);
 
 		_layoutSetService.updateSettings(
 			groupId, privateLayout, settingsProperties.toString());

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/LayoutAdminWebUpgrade.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/LayoutAdminWebUpgrade.java
@@ -17,6 +17,9 @@ package com.liferay.layout.admin.web.internal.upgrade;
 import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.layout.admin.web.internal.upgrade.v_1_0_0.UpgradeLayout;
 import com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType;
+import com.liferay.layout.admin.web.internal.upgrade.v_1_0_2.UpgradeLayoutSetTypeSettings;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -44,6 +47,16 @@ public class LayoutAdminWebUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"com.liferay.layout.admin.web", "1.0.0", "1.0.1",
 			new UpgradeLayoutType(_journalArticleResourceLocalService));
+
+		registry.register(
+			"com.liferay.layout.admin.web", "1.0.1", "1.0.2",
+			new UpgradeLayoutSetTypeSettings(
+				_groupLocalService, _layoutSetLocalService));
+	}
+
+	@Reference(unbind = "-")
+	protected void setGroupLocalService(GroupLocalService groupLocalService) {
+		_groupLocalService = groupLocalService;
 	}
 
 	@Reference(unbind = "-")
@@ -54,7 +67,16 @@ public class LayoutAdminWebUpgrade implements UpgradeStepRegistrator {
 			journalArticleResourceLocalService;
 	}
 
+	@Reference(unbind = "-")
+	protected void setLayoutSetLocalService(
+		LayoutSetLocalService layoutSetLocalService) {
+
+		_layoutSetLocalService = layoutSetLocalService;
+	}
+
+	private GroupLocalService _groupLocalService;
 	private JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;
+	private LayoutSetLocalService _layoutSetLocalService;
 
 }

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_2/UpgradeLayoutSetTypeSettings.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_2/UpgradeLayoutSetTypeSettings.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.admin.web.internal.upgrade.v_1_0_2;
+
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Alec Shay
+ */
+public class UpgradeLayoutSetTypeSettings extends UpgradeProcess {
+
+	public UpgradeLayoutSetTypeSettings(
+		GroupLocalService groupLocalService,
+		LayoutSetLocalService layoutSetLocalService) {
+
+		_groupLocalService = groupLocalService;
+		_layoutSetLocalService = layoutSetLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		updateRobots();
+	}
+
+	protected void updateGroupTypeSettings(
+			long groupId, UnicodeProperties typeSettings)
+		throws Exception {
+
+		_groupLocalService.updateGroup(groupId, typeSettings.toString());
+	}
+
+	protected void updateLayoutSetTypeSettings(
+			String key, String property, long groupId, boolean privateLayout)
+		throws Exception {
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			groupId, privateLayout);
+
+		UnicodeProperties typeSettings = layoutSet.getSettingsProperties();
+
+		typeSettings.setProperty(key, property);
+
+		_layoutSetLocalService.updateSettings(
+			groupId, privateLayout, typeSettings.toString());
+	}
+
+	protected void updateRobots() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+				"select groupId, typeSettings from Group_ where typeSettings " +
+					"like '%robots.txt%'")) {
+
+			try (ResultSet rs = ps.executeQuery()) {
+				while (rs.next()) {
+					long groupId = rs.getLong("groupId");
+					String typeSettings = rs.getString("typeSettings");
+
+					UnicodeProperties unicodeProperties =
+						new UnicodeProperties();
+
+					unicodeProperties.load(typeSettings);
+
+					String privateLayoutSetProperty =
+						unicodeProperties.getProperty("true-robots.txt");
+
+					if (privateLayoutSetProperty != null) {
+						updateLayoutSetTypeSettings(
+							"true-robots.txt", privateLayoutSetProperty,
+							groupId, true);
+
+						unicodeProperties.remove("true-robots.txt");
+					}
+
+					String publicLayoutSetProperty =
+						unicodeProperties.getProperty("false-robots.txt");
+
+					if (publicLayoutSetProperty != null) {
+						updateLayoutSetTypeSettings(
+							"false-robots.txt", publicLayoutSetProperty,
+							groupId, false);
+
+						unicodeProperties.remove("false-robots.txt");
+					}
+
+					updateGroupTypeSettings(groupId, unicodeProperties);
+				}
+			}
+		}
+	}
+
+	private final GroupLocalService _groupLocalService;
+	private final LayoutSetLocalService _layoutSetLocalService;
+
+}

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/robots.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/robots.jsp
@@ -17,11 +17,14 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String virtualHostName = PortalUtil.getVirtualHostname(layoutsAdminDisplayContext.getSelLayoutSet());
+LayoutSet layoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
+
+String virtualHostName = PortalUtil.getVirtualHostname(layoutSet);
 
 String defaultRobots = RobotsUtil.getRobots(layoutsAdminDisplayContext.getSelLayoutSet());
 
 String robots = ParamUtil.getString(request, "robots", defaultRobots);
+String robotsFieldName = "TypeSettingsProperties--" + layoutSet.isPrivateLayout() + "-robots.txt--";
 %>
 
 <liferay-ui:error-marker
@@ -31,7 +34,7 @@ String robots = ParamUtil.getString(request, "robots", defaultRobots);
 
 <c:choose>
 	<c:when test="<%= Validator.isNotNull(virtualHostName) %>">
-		<aui:input label="set-the-robots-txt" name="robots" placeholder="robots" type="textarea" value="<%= robots %>" />
+		<aui:input label="set-the-robots-txt" name="<%= robotsFieldName %>" placeholder="robots" type="textarea" value="<%= robots %>" />
 	</c:when>
 	<c:otherwise>
 		<div class="alert alert-info">

--- a/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
@@ -53,12 +53,24 @@ public class RobotsUtil {
 			return getDefaultRobots(null);
 		}
 
-		Group group = layoutSet.getGroup();
+		String defaultRobots = getDefaultRobots(
+			PortalUtil.getVirtualHostname(layoutSet));
 
-		return GetterUtil.get(
-			group.getTypeSettingsProperty(
+		String robots = GetterUtil.get(
+			layoutSet.getSettingsProperty(
 				layoutSet.isPrivateLayout() + "-robots.txt"),
-			getDefaultRobots(PortalUtil.getVirtualHostname(layoutSet)));
+			defaultRobots);
+
+		if (robots.equals(defaultRobots)) {
+			Group group = layoutSet.getGroup();
+
+			robots = GetterUtil.get(
+				group.getTypeSettingsProperty(
+					layoutSet.isPrivateLayout() + "-robots.txt"),
+				defaultRobots);
+		}
+
+		return robots;
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
@@ -16,7 +16,6 @@ package com.liferay.portal.util;
 
 import com.liferay.petra.content.ContentUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -56,21 +55,10 @@ public class RobotsUtil {
 		String defaultRobots = getDefaultRobots(
 			PortalUtil.getVirtualHostname(layoutSet));
 
-		String robots = GetterUtil.get(
+		return GetterUtil.get(
 			layoutSet.getSettingsProperty(
 				layoutSet.isPrivateLayout() + "-robots.txt"),
 			defaultRobots);
-
-		if (robots.equals(defaultRobots)) {
-			Group group = layoutSet.getGroup();
-
-			robots = GetterUtil.get(
-				group.getTypeSettingsProperty(
-					layoutSet.isPrivateLayout() + "-robots.txt"),
-				defaultRobots);
-		}
-
-		return robots;
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -41,7 +40,6 @@ import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -49,7 +47,6 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.impl.GroupLocalServiceImpl;
 import com.liferay.portal.util.PortalInstances;
-import com.liferay.portal.util.RobotsUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -68,29 +65,9 @@ public class VerifyGroup extends VerifyProcess {
 		verifyCompanyGroups();
 		verifyNullFriendlyURLGroups();
 		verifyOrganizationNames();
-		verifyRobots();
 		verifySites();
 		verifyStagedGroups();
 		verifyTree();
-	}
-
-	protected String getRobots(LayoutSet layoutSet) {
-		if (layoutSet == null) {
-			return RobotsUtil.getDefaultRobots(null);
-		}
-
-		String virtualHostname = StringPool.BLANK;
-
-		try {
-			virtualHostname = layoutSet.getVirtualHostname();
-		}
-		catch (Exception e) {
-		}
-
-		return GetterUtil.get(
-			layoutSet.getSettingsProperty(
-				layoutSet.isPrivateLayout() + "-robots.txt"),
-			RobotsUtil.getDefaultRobots(virtualHostname));
 	}
 
 	protected void verifyCompanyGroups() throws Exception {
@@ -211,31 +188,6 @@ public class VerifyGroup extends VerifyProcess {
 				}
 
 				ps2.executeBatch();
-			}
-		}
-	}
-
-	protected void verifyRobots() throws Exception {
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<Group> groups = GroupLocalServiceUtil.getLiveGroups();
-
-			for (Group group : groups) {
-				LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
-				LayoutSet publicLayoutSet = group.getPublicLayoutSet();
-
-				String privateLayoutSetRobots = getRobots(privateLayoutSet);
-				String publicLayoutSetRobots = getRobots(publicLayoutSet);
-
-				UnicodeProperties typeSettingsProperties =
-					group.getTypeSettingsProperties();
-
-				typeSettingsProperties.setProperty(
-					"true-robots.txt", privateLayoutSetRobots);
-				typeSettingsProperties.setProperty(
-					"false-robots.txt", publicLayoutSetRobots);
-
-				GroupLocalServiceUtil.updateGroup(
-					group.getGroupId(), typeSettingsProperties.toString());
 			}
 		}
 	}


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-29317
https://issues.liferay.com/browse/LPS-79188

The robots.txt for a given site's pages cannot be configured if it is the live site with Staging configured (the page configuration cannot be accessed on a live site with Staging, and robots.txt is not published, so there is no way to do so). This is because the robots.txt is one of the few settings in the page configurations that is not stored in the LayoutSet table, and also has no other special mechanism to publish with Staging.

As per the discussion on [LPP-29350](https://issues.liferay.com/browse/LPP-29350), the preferred way to handle this is to migrate robots.txt from the `typeSettings` in the `Group_` table to those in the `LayoutSet` table; the migration can be complete for master, but in 7.0.x we should allow it to be stored in both tables to prevent too much of a breaking change within 7.0. [LPS-56778](https://issues.liferay.com/browse/LPS-56778) actually had already moved much of the relevant code to LayoutSet code in what appears to be the start of a move to this pattern, but did not change the table it is stored in, so we are considering the fact that the migration is incomplete to be a bug.

I tried to find everything that I thought would need to be updated, although it's still possible I've missed something, so please let me know if there is anything that is still left to be addressed.

There is one thing remaining I am not sure about -- should we still continue to prepend "true" or "false" to the typeSettings property if they are no longer both going to be potentially stored within the same typeSettings? It made sense before because the same Group could have two in its typeSettings, but now it seems unnecessary. At the same time, though, that doesn't seem like much of an issue to me, so I wasn't sure.

Thanks!