### PR TITLE
LPS-79530

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -1233,6 +1233,7 @@ configuration-templates=Configuration Templates
 configure=Configure
 configure-email-accounts=Configure email accounts.
 configure-pages=Configure Pages
+configure-this-application=Configure this application.
 configure-this-application-and-place-it-where-desired-on-the-page=Configure this application and place it where desired on the page.
 configured-database=Configured Database
 confirm=Confirm

--- a/portal-web/docroot/html/common/themes/portlet_content_wrapper.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_content_wrapper.jspf
@@ -34,9 +34,18 @@
 
 				<c:choose>
 					<c:when test="<%= PortalUtil.isSkipPortletContentRendering(group, layoutTypePortlet, portletDisplay, portletName) %>">
-						<div class="alert alert-info">
-							<liferay-ui:message key="configure-this-application-and-place-it-where-desired-on-the-page" />
-						</div>
+						<c:choose>
+							<c:when test="<%= layout.isPortletEmbedded(portlet.getPortletId(), group.getGroupId()) %>">
+								<div class="alert alert-info">
+									<liferay-ui:message key="configure-this-application" />
+								</div>
+							</c:when>
+							<c:otherwise>
+								<div class="alert alert-info">
+									<liferay-ui:message key="configure-this-application-and-place-it-where-desired-on-the-page" />
+								</div>
+							</c:otherwise>
+						</c:choose>
 					</c:when>
 					<c:otherwise>
 						<%@ include file="/html/common/themes/portlet_content.jspf" %>


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-29688
https://issues.liferay.com/browse/LPS-79530

As per the discussion on [LPP-29737](https://issues.liferay.com/browse/LPP-29737), embedded portlets (like the search portlet and navigation menu portlet in the Classic theme) are expected to not be movable on the page, so it does not make sense for the message to indicate you can "place it where desired on the page" when editing a page template. Thus, this change is just to change those portlets to remove that part of the message.