### PR TITLE
LPS-79743 Fetch Iframe Namespace Correctly and Store It for Later Use

### DIFF
--- a/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,10 +36,12 @@
 		function <portlet:namespace />monitorIframe() {
 			var A = AUI();
 
+			var iframe = null;
+
 			var url = null;
 
 			try {
-				var iframe = document.getElementById('<portlet:namespace />iframe');
+				iframe = A.one('#<portlet:namespace />iframe');
 
 				url = iframe.contentWindow.document.location.href;
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79743

Hello @SamZiemer  ,

The issue is that the Iframe portlet does not load on Google Chrome after refreshing the page because this code is never ran:
https://github.com/liferay/liferay-portal/blob/13c6a6b4f26effb5d42e82db120c60a8698ae071/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp#L50

The reason for the issue is that the var iframe is initialized within the try & catch in:
https://github.com/liferay/liferay-portal/blob/13c6a6b4f26effb5d42e82db120c60a8698ae071/modules/apps/web-experience/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp#L41-L47
which means it cannot be used for later use as it is never locally stored.

This issue needs to be resolved as soon as possible as it is blocking QA from testing LPS-79300.
https://issues.liferay.com/browse/LPS-79300

Although LPS-79300 does not have anything to do the issue being discussed in this PR, QA would like this to be fixed first so they can confirm that LPS-79300 works on its own properly.

Sincerely,
Brian Kim