### PR TITLE
J cords lps 78900 2

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java
@@ -48,6 +48,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandlerStatusMessageSender
 import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleManager;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.portlet.data.handler.provider.PortletDataHandlerProvider;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
@@ -66,6 +67,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletConstants;
@@ -76,6 +79,7 @@ import com.liferay.portal.kernel.model.adapter.ModelAdapterUtil;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.PortletItemLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -463,6 +467,37 @@ public class PortletExportControllerImpl implements PortletExportController {
 		// Portlet preferences
 
 		if (exportPortletSetup) {
+			try {
+				ServiceContext serviceContext =
+					ServiceContextThreadLocal.getServiceContext();
+
+				if ((serviceContext == null) || !serviceContext.isSignedIn() ||
+					(layout == null)) {
+
+					throw new PortalException();
+				}
+
+				LayoutSet layoutSet = layout.getLayoutSet();
+
+				long layoutSetBranchId = 0;
+
+				long userId = serviceContext.getUserId();
+
+				User user = _userLocalService.getUser(userId);
+
+				LayoutSetBranch layoutSetBranch =
+					_layoutSetBranchLocalService.getUserLayoutSetBranch(
+						userId, layout.getGroupId(), layout.isPrivateLayout(),
+						layoutSet.getLayoutSetId(), layoutSetBranchId);
+
+				layoutSetBranchId = layoutSetBranch.getLayoutSetBranchId();
+
+				plid = _staging.getRecentLayoutRevisionId(
+					user, layoutSetBranchId, true, plid);
+			}
+			catch (PortalException pe) {
+				_log.debug("No layout revision for plid " + plid, pe);
+			}
 
 			// Company
 
@@ -1357,6 +1392,13 @@ public class PortletExportControllerImpl implements PortletExportController {
 	}
 
 	@Reference(unbind = "-")
+	protected void setLayoutSetBranchLocalService(
+		LayoutSetBranchLocalService layoutSetBranchLocalService) {
+
+		_layoutSetBranchLocalService = layoutSetBranchLocalService;
+	}
+
+	@Reference(unbind = "-")
 	protected void setPortletItemLocalService(
 		PortletItemLocalService portletItemLocalService) {
 
@@ -1401,6 +1443,7 @@ public class PortletExportControllerImpl implements PortletExportController {
 
 	private GroupLocalService _groupLocalService;
 	private LayoutLocalService _layoutLocalService;
+	private LayoutSetBranchLocalService _layoutSetBranchLocalService;
 	private final PermissionExporter _permissionExporter =
 		PermissionExporter.getInstance();
 
@@ -1420,6 +1463,10 @@ public class PortletExportControllerImpl implements PortletExportController {
 	private PortletItemLocalService _portletItemLocalService;
 	private PortletLocalService _portletLocalService;
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Reference
+	private Staging _staging;
+
 	private UserLocalService _userLocalService;
 
 	private class UpdatePortletLastPublishDateCallable

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -1726,6 +1726,15 @@ public class StagingImpl implements Staging {
 
 	@Override
 	public long getRecentLayoutRevisionId(
+			User user, long layoutSetBranchId, boolean head, long plid)
+		throws PortalException {
+
+		return getRecentLayoutRevisionId(
+			user.getUserId(), layoutSetBranchId, head, plid);
+	}
+
+	@Override
+	public long getRecentLayoutRevisionId(
 			User user, long layoutSetBranchId, long plid)
 		throws PortalException {
 
@@ -3315,6 +3324,54 @@ public class StagingImpl implements Staging {
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(nslbe, nslbe);
+			}
+		}
+
+		return 0;
+	}
+
+	protected long getRecentLayoutRevisionId(
+			long userId, long layoutSetBranchId, boolean head, long plid)
+		throws PortalException {
+
+		RecentLayoutRevision recentLayoutRevision =
+			_recentLayoutRevisionLocalService.fetchRecentLayoutRevision(
+				userId, layoutSetBranchId, plid);
+
+		if (recentLayoutRevision != null) {
+			return recentLayoutRevision.getLayoutRevisionId();
+		}
+
+		long layoutBranchId = getRecentLayoutBranchId(
+			userId, layoutSetBranchId, plid);
+
+		LayoutBranch layoutBranch = _layoutBranchLocalService.fetchLayoutBranch(
+			layoutBranchId);
+
+		if (layoutBranch == null) {
+			try {
+				layoutBranch = _layoutBranchLocalService.getMasterLayoutBranch(
+					layoutSetBranchId, plid);
+
+				layoutBranchId = layoutBranch.getLayoutBranchId();
+			}
+			catch (NoSuchLayoutBranchException nslbe) {
+
+				// LPS-52675
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(nslbe, nslbe);
+				}
+			}
+		}
+
+		if (layoutBranchId > 0) {
+			LayoutRevision layoutRevision =
+				_layoutRevisionLocalService.fetchLayoutRevision(
+					layoutSetBranchId, layoutBranchId, head, plid);
+
+			if (layoutRevision != null) {
+				return layoutRevision.getLayoutRevisionId();
 			}
 		}
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/Staging.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/Staging.java
@@ -202,6 +202,10 @@ public interface Staging {
 		throws PortalException;
 
 	public long getRecentLayoutRevisionId(
+			User user, long layoutSetBranchId, boolean head, long plid)
+		throws PortalException;
+
+	public long getRecentLayoutRevisionId(
 			User user, long layoutSetBranchId, long plid)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/StagingUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/StagingUtil.java
@@ -303,6 +303,14 @@ public class StagingUtil {
 	}
 
 	public static long getRecentLayoutRevisionId(
+			User user, long layoutSetBranchId, boolean head, long plid)
+		throws PortalException {
+
+		return _staging.getRecentLayoutRevisionId(
+			user, layoutSetBranchId, head, plid);
+	}
+
+	public static long getRecentLayoutRevisionId(
 			User user, long layoutSetBranchId, long plid)
 		throws PortalException {
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79800
https://issues.liferay.com/browse/LPP-29788

Hello Sam, 

Here's what's behind these changes. When exporting portlets the most recent layoutRevision was being used instead of the latest layoutRevision set as Head. This causes the portlets configurations to reference the last revision instead of the last revision marked as "Ready for Publication". In order to change this I tried changing the [StagingImpl.getRecentLayoutRevisionId](https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java#L3324-L3380) method. However, that change affects many other calls, including how the layoutRevision to view in Staged Version is returned, breaking it. I'm convinced that any changes below PortalExportControllerImpl will cause similar issues. 

My approach is to add a new StagingImpl.getRecentLayoutRevision which takes a Head attribute and returns the most recent layout revision where Head is true. Most of the code is duplicated from other parts of the portal. The new StagingImpl.getRecentLayoutRevisionId is the same as the one [without head](StagingImpl.getRecentLayoutRevisionId) except it uses fetchLayoutRevision(layoutSetBranchId, layoutBranchId, head, plid). 

In the PortletExportControllerImpl I needed to add a way to get the User and LayoutSetBranch. This code is copied from [LayoutStagingHandler._getLayoutRevision](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java#L143-L256) and then I edited out what I believe is irrelevant code.

Let me know your thoughts on this direction. I can break out a separate commit adding the new method to StagingImpl if that would be better. I could also see changing the already existing StagingImpl.getRecentLayoutRevisionId to  include logic for a head parameter.