### PR TITLE
LPS-77922 Set title of thread RSS feed to site name

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageServiceImpl.java
@@ -644,8 +644,12 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 			ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		String name = StringPool.BLANK;
-		String description = StringPool.BLANK;
+		Group group = groupLocalService.getGroup(
+			themeDisplay.getScopeGroupId());
+
+		String name = group.getDescriptiveName();
+		String description = group.getDescription(
+			LocaleUtil.getMostRelevantLocale());
 
 		List<MBMessage> messages = new ArrayList<>();
 
@@ -672,13 +676,6 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 
 					messages.add(message);
 				}
-			}
-
-			if (!messages.isEmpty()) {
-				MBMessage message = messages.get(messages.size() - 1);
-
-				name = message.getSubject();
-				description = message.getSubject();
 			}
 		}
 


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-77922

I just wonder if themeDisplay.getLocale should be used instead of LocaleUtil.getMostRelevantLocale but leaving it be to follow the same pattern as LPS-77288.

@austinskim123's notes
Issue: RSS title should be name of the site, not the thread itself as it is redundant information.

Solution: Modeled fix after the one made for https://issues.liferay.com/browse/LPS-77288. In short, set the name and description to the site name and description retrieved from the themeDisplay for the method, respectively.