### PR TITLE
LPS-80849 Remove extra instance id

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder/form_builder.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder/form_builder.js
@@ -265,13 +265,13 @@ AUI.add(
 					createFieldFromContext: function(fieldContext) {
 						var instance = this;
 
-						var newFieldName = fieldContext.fieldName + Util.generateInstanceId(6);
+						var currentFieldName = fieldContext.fieldName;
 
 						var config = A.merge(
 							fieldContext,
 							{
-								fieldName: newFieldName,
-								name: newFieldName
+								fieldName: currentFieldName,
+								name: currentFieldName
 							}
 						);
 
@@ -297,7 +297,7 @@ AUI.add(
 								var fieldName = settingsFieldContext.fieldName;
 
 								if (fieldName === 'name') {
-									settingsFieldContext.value = newFieldName;
+									settingsFieldContext.value = currentFieldName;
 								}
 							}
 						);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80849

The probelm was an extra instanceId was being added to the fieldName of fields in a fieldSet (Element Set). This caused their validation to fail because the fieldName did not match the validation name. The instanceId is not necessary because a unique instanceId is already included on the fields by another process.