### PR TITLE
LPS-80996 Unescape form name in Form Portlet Configuration

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -40,7 +40,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 					<liferay-ui:message key="please-select-a-form-from-the-list-below" />
 				</span>
 				<span class="displaying-form-instance-id-holder <%= (selFormInstance == null) ? "hide" : StringPool.BLANK %>">
-					<liferay-ui:message key="displaying-form" />: <span class="displaying-form-instance-id"><%= (selFormInstance != null) ? HtmlUtil.escape(selFormInstance.getName(locale)) : StringPool.BLANK %></span>
+					<liferay-ui:message key="displaying-form" />: <span class="displaying-form-instance-id"><%= (selFormInstance != null) ? HtmlUtil.unescape(selFormInstance.getName(locale)) : StringPool.BLANK %></span>
 				</span>
 			</div>
 
@@ -88,7 +88,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 									href="<%= rowURL %>"
 									name="name"
 									orderable="<%= false %>"
-									value="<%= formInstance.getName(locale) %>"
+									value="<%= HtmlUtil.unescape(formInstance.getName(locale)) %>"
 								/>
 
 								<liferay-ui:search-container-column-text
@@ -147,7 +147,10 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 
 			var displayFormInstanceId = A.one('.displaying-form-instance-id');
 
-			displayFormInstanceId.set('innerHTML', formInstanceName + ' (<liferay-ui:message key="modified" />)');
+			var doc = new DOMParser().parseFromString(formInstanceName, "text/html");
+			var unescapedFormInstanceName = doc.documentElement.textContent;
+
+			displayFormInstanceId.set('innerHTML', unescapedFormInstanceName + ' (<liferay-ui:message key="modified" />)');
 			displayFormInstanceId.addClass('modified');
 		},
 		['aui-base']


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80996

The FormInstanceNames were being escaped instead of unescaped. The AUI:script doesn't have access to HtmlUtil and the parameters set to the function must be escaped, so I used a workaround.