### PR TITLE
LPS-81511 Partial Revert of LPS-79610

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -355,7 +355,8 @@ public class FriendlyURLEntryLocalServiceImpl
 				Math.min(
 					maxLength - suffix.length(), normalizedUrlTitle.length()));
 
-			curUrlTitle = prefix + suffix;
+			curUrlTitle = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+				prefix + suffix);
 		}
 
 		return curUrlTitle;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-81511

Problem: [LPS-79610 removed the normalize call](https://github.com/joshuacords/liferay-portal/commit/a13d8a51dfb6dbd5c051be44f242c0b2452a320c) from the getUniqueURLTitle method in the FriendlyURLService. This caused a mismatched between what was being checked and the entity's actual final name. Example: "a--1" would be checked for duplicates when in fact the url would later attempt to be saved as "a-1" which threw an exception.

Solution: I re-added the normalize check but used the normalizeWithEncoding method to account for non-ascii characters as LPS-79610 did other places.