### PR TITLE
LPS-78227

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationFinderImpl.java
@@ -1129,13 +1129,12 @@ public class OrganizationFinderImpl
 
 				if (!organizationsTree.isEmpty()) {
 					for (Organization organization : organizationsTree) {
-						StringBundler sb = new StringBundler(5);
+						StringBundler sb = new StringBundler(4);
 
 						sb.append(StringPool.PERCENT);
 						sb.append(StringPool.SLASH);
 						sb.append(organization.getOrganizationId());
 						sb.append(StringPool.SLASH);
-						sb.append(StringPool.PERCENT);
 
 						qPos.add(sb.toString());
 					}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78227

Resent from: https://github.com/pei-jung/liferay-portal/pull/267

If searching with index is disabled through use of the property `organizations.search.with.index=false`, then the results will differ in that child Organizations can be returned and viewed this way, when searching with index will not do so.

After discussion on [PTR-269](https://issues.liferay.com/browse/PTR-269), it was decided that the configuration to allow searching without index should be removed from master, although for released versions, we will push for consistency. To do this, the change introduced here makes searching without index (in `OrganizationFinderImpl`) remove the wild card from the organizationsTree that allows returning child Organizations.