### PR TITLE
LPS-81990

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewOrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewOrganizationsManagementToolbarDisplayContext.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.usersadmin.search.OrganizationSearch;
 import com.liferay.portlet.usersadmin.search.OrganizationSearchTerms;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 import com.liferay.users.admin.web.internal.search.OrganizationChecker;
 
 import java.util.LinkedHashMap;
@@ -211,7 +212,11 @@ public class ViewOrganizationsManagementToolbarDisplayContext {
 
 		String keywords = organizationSearchTerms.getKeywords();
 
-		if (Validator.isNotNull(keywords)) {
+		String portletName = (String)organizationParams.get("portletName");
+
+		if (Validator.isNotNull(keywords) ||
+			portletName.equals(UsersAdminPortletKeys.MY_ORGANIZATIONS)) {
+
 			parentOrganizationId =
 				OrganizationConstants.ANY_PARENT_ORGANIZATION_ID;
 		}

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
@@ -52,6 +52,8 @@ if (filterManageableOrganizations) {
 		organizationParams.put("organizationsTree", userOrganizations);
 	}
 }
+
+organizationParams.put("portletName", portletName);
 %>
 
 <c:choose>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-81990

If a user belongs to a non-root level Organization, then navigating to "My Organizations" will not display it by default (it will only, by default, show root-level Organizations).

A fix for this was previously rejected due to concerns with changing the Organizations displayed for both the Control Panel portlet and "My Organizations" portlet (see https://github.com/pei-jung/liferay-portal/pull/267#issuecomment-378329128). In light of this, this fix is attempting something similar, but instead only changing it for the My Organizations portlet. This way, it will not impact the performance for the Control Panel portlet, where it is more likely a very large number of Organizations may be displayed.

Please let me know if this fix still does not correctly address the issue, or if there are any other concerns with it. Thanks!