### PR TITLE
LPS-82059 Permissioned PollsQuestions should not throw Exception

### DIFF
--- a/modules/apps/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/util/PollsUtil.java
+++ b/modules/apps/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/util/PollsUtil.java
@@ -54,11 +54,16 @@ public class PollsUtil {
 		long questionId = GetterUtil.getLong(
 			portletPreferences.getValue("questionId", StringPool.BLANK));
 
-		if (questionId > 0) {
-			return PollsQuestionServiceUtil.getQuestion(questionId);
+		if (questionId <= 0) {
+			return null;
 		}
 
-		return null;
+		try {
+			return PollsQuestionServiceUtil.getQuestion(questionId);
+		}
+		catch (Exception e) {
+			return null;
+		}
 	}
 
 	public static CategoryDataset getVotesDataset(long questionId) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82059
https://issues.liferay.com/browse/LPP-30445

Problem: Polls Questions permissioned not to display to a user causes the portlet to become unavailable.
