### PR TITLE
LPS-82336 Reset sessionState if session was extended on another page

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -340,6 +340,16 @@ AUI.add(
 									timeOffset = Math.floor((Date.now() - timestamp) / 1000) * 1000;
 
 									elapsed = timeOffset;
+
+									if (Lang.toInt(instance._localTimestamp) < timestamp) {
+										instance._localTimestamp = timestamp;
+
+										var sessionState = instance.get('sessionState');
+
+										if (sessionState != 'active') {
+											instance.set('sessionState', 'active', SRC_EVENT_OBJ);
+										}
+									}
 								}
 								else {
 									timestamp = 'expired';


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82336
https://issues.liferay.com/browse/LPP-30492

Problem: When a user's session is shared between 2 browser windows, extending the session on one window will reset the timestamp cookie (which the other window will see) but will not reset the sessionState in the other window. This makes it so the other window's warning will not reappear when the extend warning should appear on both windows.

Solution: Keep track of the current timestamp locally, and update the sessionState and the timestamp if the session is extended on another page.