### PR TITLE
LPS-69814 Implement Validation Check for Manual File Upload

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_repository_entry_browser.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_repository_entry_browser.js
@@ -174,27 +174,9 @@ AUI.add(
 									rootNode.removeClass(CSS_DROP_ACTIVE);
 
 									if (eventDrop) {
-										var fileExtension = dataTransfer.files[0].name.split('.').pop().toLowerCase();
+										var file = dataTransfer.files[0];
 
-										var validExtensions = instance.get('validExtensions');
-
-										if (validExtensions === '*' || validExtensions.indexOf(fileExtension) != -1) {
-											var maxFileSize = instance.get('maxFileSize');
-
-											if (dataTransfer.files[0].size <= maxFileSize) {
-												instance._previewFile(dataTransfer.files[0]);
-											}
-											else {
-												var message =  Lang.sub(Liferay.Language.get('please-enter-a-file-with-a-valid-file-size-no-larger-than-x'), [instance.formatStorage(instance.get('maxFileSize'))]);
-
-												instance._showError(message);
-											}
-										}
-										else {
-											var message = Lang.sub(Liferay.Language.get('please-enter-a-file-with-a-valid-extension-x'), [validExtensions]);
-
-											instance._showError(message);
-										}
+										instance._validateFile(file);
 									}
 								}
 							}
@@ -267,18 +249,9 @@ AUI.add(
 					_onInputFileChanged: function(event) {
 						var instance = this;
 
-						var maxFileSize = instance.get('maxFileSize');
-
 						var file = event.currentTarget.getDOMNode().files[0];
 
-						if (file.size > maxFileSize) {
-							var message = Lang.sub(Liferay.Language.get('please-enter-a-file-with-a-valid-file-size-no-larger-than-x'), [instance.formatStorage(instance.get('maxFileSize'))]);
-
-							instance._showError(message);
-						}
-						else {
-							instance._previewFile(file);
-						}
+						instance._validateFile(file);
 					},
 
 					_onItemSelected: function(itemViewer) {
@@ -394,6 +367,32 @@ AUI.add(
 						instance._uploadItemViewer.show();
 
 						instance._itemSelectorUploader.startUpload(file, instance.get('uploadItemURL'));
+					},
+
+					_validateFile: function(file) {
+						var instance = this;
+
+						var fileExtension = file.name.split('.').pop().toLowerCase();
+
+						var validExtensions = instance.get('validExtensions');
+
+						if (validExtensions === '*' || validExtensions.indexOf(fileExtension) != -1) {
+							var maxFileSize = instance.get('maxFileSize');
+
+							if (file.size <= maxFileSize) {
+								instance._previewFile(file);
+							}
+							else {
+								var message =  Lang.sub(Liferay.Language.get('please-enter-a-file-with-a-valid-file-size-no-larger-than-x'), [instance.formatStorage(instance.get('maxFileSize'))]);
+
+								instance._showError(message);
+							}
+						}
+						else {
+							var message = Lang.sub(Liferay.Language.get('please-enter-a-file-with-a-valid-extension-x'), [validExtensions]);
+
+							instance._showError(message);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-69814

Hello @SamZiemer ,

Currently, the behavior for drag-and-drop files in editors that only allow images are that there is a method that ensures that only files with allowed extensions can be uploaded.

The fix brings out the validation check to its own method so that it can be applied to both drag-and-drop-file and manual file upload situations.

Please let me know if you need any questions or require explanation on the behavior of the fix. I will gladly help. Thanks.

Sincerely,
Brian Kim
