### PR TITLE
LPS-82412 Use Content that contains the highlighted matches for search summaries

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -818,6 +818,15 @@ public class JournalArticleIndexer
 
 			HighlightUtil.addSnippet(document, highlights, snippet, "temp");
 
+			if (!snippet.equals(StringPool.BLANK)) {
+				String fieldName = Field.SNIPPET.concat(
+					StringPool.UNDERLINE).concat("temp");
+
+				Field tempField = document.getField(fieldName);
+
+				content = tempField.getValue();
+			}
+
 			content = HighlightUtil.highlight(
 				content, ArrayUtil.toStringArray(highlights),
 				HighlightUtil.HIGHLIGHT_TAG_OPEN,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82412

Problem: When summaries in the search portlet are too long, they cut off the highlighted word.

Solution: Use the snippet returned from the search engine.

I worked around the changes made by LPS-72670 https://github.com/joshuacords/liferay-portal/commit/4bc38c8de743e5ad0debb55f4bbd3784e2d2727a so that our highlighter is deciding how to highlight the summary. However, I'm not actually sure if LPS-72670 is working as designed or if it is still necessary based on this comment: https://issues.liferay.com/browse/LPS-74642?focusedCommentId=1191495&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1191495