### PR TITLE
LPS-82764

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -255,6 +255,12 @@ public class PortletDataContextImpl implements PortletDataContext {
 			_references.add(getReferenceKey(classedModel));
 		}
 
+		if (classedModel instanceof AuditedModel) {
+			AuditedModel auditedModel = (AuditedModel)classedModel;
+
+			_addUserUuid(element, auditedModel.getUserUuid());
+		}
+
 		addZipEntry(path, classedModel);
 	}
 
@@ -2878,6 +2884,10 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 		element.addAttribute(
 			"asset-entry-priority", String.valueOf(assetEntryPriority));
+	}
+
+	private void _addUserUuid(Element element, String userUuid) {
+		element.addAttribute("user-uuid", userUuid);
 	}
 
 	private static final Class<?>[] _XSTREAM_DEFAULT_ALLOWED_TYPES = {

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerUtil.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.AuditedModel;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
@@ -564,6 +565,14 @@ public class StagedModelDataHandlerUtil {
 
 			stagedModel = (StagedModel)portletDataContext.getZipEntryAsObject(
 				element, path);
+
+			String userUuid = element.attributeValue("user-uuid");
+
+			if ((userUuid != null) && (stagedModel instanceof AuditedModel)) {
+				AuditedModel auditedModel = (AuditedModel)stagedModel;
+
+				auditedModel.setUserId(portletDataContext.getUserId(userUuid));
+			}
 		}
 
 		return stagedModel;


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-30461
https://issues.liferay.com/browse/LPS-82764

If LDAP users are imported into multiple environments, exporting and importing data between these environments will not maintain ownership by those users. This is because the users will most likely have differing userId's between these environments, and UUID (unlike userId) is no longer included in the StagedModel itself for export/imports.

This is caused by [LPS-44571](https://issues.liferay.com/browse/LPS-44571), which removed user UUIDs from the StagedModel used in LAR exports so that there is no way left for Liferay to identify the users with UUID. On [the SME subtask opened for this issue](https://issues.liferay.com/browse/LPP-30532), it was noted that we would need to find another way to do it, probably as with the `asset-entry-priority` attribute. Thus, this fix instead adds it to the containing data element in the LAR rather than the StagedModel itself.