### PR TITLE
J cords lps 83186

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/search/BlogsEntryIndexer.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/search/BlogsEntryIndexer.java
@@ -126,7 +126,7 @@ public class BlogsEntryIndexer extends BaseIndexer<BlogsEntry> {
 
 		Summary summary = createSummary(document);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/search/BookmarksFolderIndexer.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/search/BookmarksFolderIndexer.java
@@ -129,7 +129,7 @@ public class BookmarksFolderIndexer
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingIndexer.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingIndexer.java
@@ -246,7 +246,7 @@ public class CalendarBookingIndexer extends BaseIndexer<CalendarBooking> {
 
 		Summary summary = new Summary(snippetLocale, title, description);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
@@ -18,8 +18,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 import com.liferay.portal.search.summary.SummaryHelper;
@@ -80,7 +82,7 @@ public class CalendarBookingModelSummaryContributor
 				defaultLocale, prefix + Field.DESCRIPTION, Field.DESCRIPTION);
 		}
 
-		description = HtmlUtil.extractText(description);
+		description = _stripAndHighlight(description);
 
 		Summary summary = new Summary(snippetLocale, title, description);
 
@@ -107,6 +109,24 @@ public class CalendarBookingModelSummaryContributor
 
 		return summary;
 	}
+
+	private String _stripAndHighlight(String text) {
+		text = StringUtil.replace(
+			text, _HIGHLIGHT_TAGS, _ESCAPE_SAFE_HIGHLIGHTS);
+
+		text = HtmlUtil.stripHtml(text);
+
+		text = StringUtil.replace(
+			text, _ESCAPE_SAFE_HIGHLIGHTS, _HIGHLIGHT_TAGS);
+
+		return text;
+	}
+
+	private static final String[] _ESCAPE_SAFE_HIGHLIGHTS =
+		{"[@HIGHLIGHT1@]", "[@HIGHLIGHT2@]"};
+
+	private static final String[] _HIGHLIGHT_TAGS =
+		{HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE};
 
 	@Reference
 	protected SummaryHelper summaryHelper;

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
@@ -84,7 +84,26 @@ public class CalendarBookingModelSummaryContributor
 
 		Summary summary = new Summary(snippetLocale, title, description);
 
-		summary.setMaxContentLength(200);
+		int defaultContentLength = 200;
+
+		if (defaultContentLength < description.length()) {
+			String strippedDescription = HtmlUtil.stripHtml(description);
+
+			int strippedLength = strippedDescription.length();
+
+			if (strippedLength < defaultContentLength) {
+				defaultContentLength = description.length();
+			}
+			else if (strippedLength < description.length()) {
+				String strippedBeginning = HtmlUtil.stripHtml(
+					description.substring(0, defaultContentLength));
+
+				defaultContentLength =
+					defaultContentLength * 2 - strippedBeginning.length();
+			}
+		}
+
+		summary.setMaxContentLength(defaultContentLength);
 
 		return summary;
 	}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarIndexer.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarIndexer.java
@@ -131,7 +131,7 @@ public class CalendarIndexer extends BaseIndexer<Calendar> {
 		Summary summary = createSummary(
 			document, Field.NAME, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelSummaryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelSummaryContributor.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
 import java.util.Locale;
@@ -47,7 +48,26 @@ public class CalendarModelSummaryContributor
 
 		Summary summary = new Summary(title, content);
 
-		summary.setMaxContentLength(200);
+		int defaultContentLength = 200;
+
+		if (defaultContentLength < content.length()) {
+			String strippedContent = HtmlUtil.stripHtml(content);
+
+			int strippedLength = strippedContent.length();
+
+			if (strippedLength < defaultContentLength) {
+				defaultContentLength = content.length();
+			}
+			else if (strippedLength < content.length()) {
+				String strippedBeginning = HtmlUtil.stripHtml(
+					content.substring(0, defaultContentLength));
+
+				defaultContentLength =
+					defaultContentLength * 2 - strippedBeginning.length();
+			}
+		}
+
+		summary.setMaxContentLength(defaultContentLength);
 
 		return summary;
 	}

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/search/ConfigurationModelIndexer.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/search/ConfigurationModelIndexer.java
@@ -271,7 +271,7 @@ public class ConfigurationModelIndexer extends BaseIndexer<ConfigurationModel> {
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelSummaryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelSummaryContributor.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
@@ -53,7 +54,26 @@ public class DLFileEntryModelSummaryContributor
 
 		Summary summary = new Summary(title, content);
 
-		summary.setMaxContentLength(200);
+		int defaultContentLength = 200;
+
+		if (defaultContentLength < content.length()) {
+			String strippedContent = HtmlUtil.stripHtml(content);
+
+			int strippedLength = strippedContent.length();
+
+			if (strippedLength < defaultContentLength) {
+				defaultContentLength = content.length();
+			}
+			else if (strippedLength < content.length()) {
+				String strippedBeginning = HtmlUtil.stripHtml(
+					content.substring(0, defaultContentLength));
+
+				defaultContentLength =
+					defaultContentLength * 2 - strippedBeginning.length();
+			}
+		}
+
+		summary.setMaxContentLength(defaultContentLength);
 
 		return summary;
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelSummaryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelSummaryContributor.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 
 import java.util.Locale;
@@ -47,7 +48,26 @@ public class DLFolderModelSummaryContributor
 
 		Summary summary = new Summary(title, content);
 
-		summary.setMaxContentLength(200);
+		int defaultContentLength = 200;
+
+		if (defaultContentLength < content.length()) {
+			String strippedContent = HtmlUtil.stripHtml(content);
+
+			int strippedLength = strippedContent.length();
+
+			if (strippedLength < defaultContentLength) {
+				defaultContentLength = content.length();
+			}
+			else if (strippedLength < content.length()) {
+				String strippedBeginning = HtmlUtil.stripHtml(
+					content.substring(0, defaultContentLength));
+
+				defaultContentLength =
+					defaultContentLength * 2 - strippedBeginning.length();
+			}
+		}
+
+		summary.setMaxContentLength(defaultContentLength);
 
 		return summary;
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/DDLRecordIndexer.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/DDLRecordIndexer.java
@@ -247,7 +247,7 @@ public class DDLRecordIndexer extends BaseIndexer<DDLRecord> {
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 		summary.setTitle(title);
 
 		return summary;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
@@ -261,7 +261,7 @@ public class DDMFormInstanceRecordIndexer
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 		summary.setTitle(title);
 
 		return summary;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -675,7 +675,7 @@ public class JournalArticleIndexer
 
 		Summary summary = new Summary(snippetLocale, title, content);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalFolderIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalFolderIndexer.java
@@ -137,7 +137,7 @@ public class JournalFolderIndexer
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -164,7 +164,7 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 
 		Summary summary = new Summary(title, content);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/MBMessageIndexer.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/MBMessageIndexer.java
@@ -354,7 +354,7 @@ public class MBMessageIndexer
 
 		Summary summary = createSummary(document, title, content);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/search/PollsQuestionIndexer.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/internal/search/PollsQuestionIndexer.java
@@ -88,7 +88,7 @@ public class PollsQuestionIndexer extends BaseIndexer<PollsQuestion> {
 
 		Summary summary = createSummary(document);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/powwow/powwow-portlet/docroot/WEB-INF/src/com/liferay/powwow/util/PowwowMeetingIndexer.java
+++ b/modules/apps/powwow/powwow-portlet/docroot/WEB-INF/src/com/liferay/powwow/util/PowwowMeetingIndexer.java
@@ -207,7 +207,7 @@ public class PowwowMeetingIndexer extends BaseIndexer {
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -233,7 +233,7 @@ public class WikiPageIndexer
 
 		Summary summary = createSummary(document, Field.TITLE, Field.CONTENT);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -539,7 +539,7 @@ public class DLFileEntryIndexer
 			summary = createSummary(document, Field.TITLE, Field.DESCRIPTION);
 		}
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFolderIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFolderIndexer.java
@@ -141,7 +141,7 @@ public class DLFolderIndexer
 		Summary summary = createSummary(
 			document, Field.TITLE, Field.DESCRIPTION);
 
-		summary.setMaxContentLength(200);
+		setSummaryMaxContentLength(summary);
 
 		return summary;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.service.RegionServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -1754,6 +1755,31 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 
 	protected void setStagingAware(boolean stagingAware) {
 		_stagingAware = stagingAware;
+	}
+
+	protected void setSummaryMaxContentLength(Summary summary) {
+		String content = summary.getContent();
+
+		int defaultContentLength = 200;
+
+		if (defaultContentLength < content.length()) {
+			String strippedContent = HtmlUtil.stripHtml(content);
+
+			int strippedLength = strippedContent.length();
+
+			if (strippedLength < defaultContentLength) {
+				defaultContentLength = content.length();
+			}
+			else if (strippedLength < content.length()) {
+				String strippedBeginning = HtmlUtil.stripHtml(
+					content.substring(0, defaultContentLength));
+
+				defaultContentLength =
+					defaultContentLength * 2 - strippedBeginning.length();
+			}
+		}
+
+		summary.setMaxContentLength(defaultContentLength);
 	}
 
 	private void _addPreFilters(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83186

The core issue is that highlighting tags in search snippets were being counted towards the max content size even though the tags do not take up any visual room. I added a setSummaryMaxContentLength() method to approximate a more appropriate size for the max content length and added similar code to the Summary Contributors. 

The idea of the code is to base the length on what will be visually shown by looking at the size of the content after stripping out the highlight tags using HtmlUtil.stripHtml(). If the stripped content is under the default 200 limit, then the full content of the highlighted snippet can be shown and the default size is set to the full content's size. However, if the stripped content is still too large, I do a best guess that still guarantees that the final visual content will not exceed the default limit. While it is possible to find the actual max content length for the visual content, I believe the String checking and matching necessary would end up being too expensive time-wise for populating search results. I also believe that most returned snippets should fall within the default max content length and the best guess approach used here should be adequate for the rest.

Lastly I noticed that the highlights of CalendarBookings were being stripped. I believe this is unintentional as it does not match the behavior of any other assets, so I corrected them to maintain highlights in the same fashion as Journal Articles.