### PR TITLE
LPS-82717

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
@@ -27,10 +27,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.test.randomizerbumpers.TikaSafeRandomizerBumper;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.documentlibrary.service.test.BaseDLAppTestCase;
+import com.liferay.portlet.documentlibrary.util.DLAppUtil;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -372,8 +372,8 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 
 		return DLAppLocalServiceUtil.addFileEntry(
 			TestPropsValues.getUserId(), group.getGroupId(),
-			parentFolder.getFolderId(), sourceFileName, ContentTypes.TEXT_PLAIN,
-			title, StringPool.BLANK, StringPool.BLANK,
+			parentFolder.getFolderId(), sourceFileName, "", title,
+			StringPool.BLANK, StringPool.BLANK,
 			RandomTestUtil.randomBytes(TikaSafeRandomizerBumper.INSTANCE),
 			serviceContext);
 	}
@@ -387,8 +387,8 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		DLAppServiceUtil.updateFileEntry(
-			fileEntry.getFileEntryId(), sourceFileName, ContentTypes.TEXT_PLAIN,
-			title, StringPool.BLANK, StringPool.BLANK, false,
+			fileEntry.getFileEntryId(), sourceFileName, "", title,
+			StringPool.BLANK, StringPool.BLANK, false,
 			RandomTestUtil.randomBytes(TikaSafeRandomizerBumper.INSTANCE),
 			serviceContext);
 	}
@@ -400,12 +400,19 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 
 		FileEntry fileEntry = addFileEntry(sourceFileName, title);
 
-		Assert.assertEquals(
-			"Invalid file extension", extension, fileEntry.getExtension());
+		if (DLAppUtil.getExtension(sourceFileName).equals("") &&
+			!extension.equals("")) {
+
+			Assert.assertEquals(
+				"Invalid file extension", "", fileEntry.getExtension());
+		}
+		else {
+			Assert.assertEquals(
+				"Invalid file extension", extension, fileEntry.getExtension());
+		}
 
 		Assert.assertEquals(
 			titleWithExtension, DLUtil.getTitleWithExtension(fileEntry));
-
 		DLAppLocalServiceUtil.deleteFileEntry(fileEntry.getFileEntryId());
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -901,7 +901,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				 cmd.equals(Constants.ADD_DYNAMIC)) &&
 				(size == 0)) {
 
-				contentType = MimeTypesUtil.getContentType(title);
+				contentType = MimeTypesUtil.getContentType(sourceFileName);
 			}
 
 			if (cmd.equals(Constants.ADD) ||

--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -604,7 +604,7 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 
 		int pos = fileName.lastIndexOf(CharPool.PERIOD);
 
-		if (pos > 0) {
+		if (pos >= 0) {
 			return StringUtil.toLowerCase(fileName.substring(pos + 1));
 		}
 		else {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLAppUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLAppUtil.java
@@ -29,14 +29,19 @@ import java.io.File;
  */
 public class DLAppUtil {
 
-	public static String getExtension(String title, String sourceFileName) {
+	public static String getExtension(String sourceFileName) {
 		String extension = FileUtil.getExtension(sourceFileName);
 
-		if (Validator.isNull(extension)) {
-			extension = FileUtil.getExtension(title);
-		}
-
 		return extension;
+	}
+
+	/**
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 *             #getExtension(String)}
+	 */
+	@Deprecated
+	public static String getExtension(String title, String sourceFileName) {
+		return getExtension(sourceFileName);
 	}
 
 	public static String getMimeType(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0


### PR DESCRIPTION
Hello @SamZiemer, Sending a new PR from here: https://github.com/SamZiemer/liferay-portal/pull/464

> 
> Hello @SamZiemer ,
> 
> https://issues.liferay.com/browse/LPS-82717
> 
> The issue is that DLAppUtil's getExtension is passing in the Title to be checked for an extension if a sourceFile does not exist. The logic here is flawed because a Title of a document entry should never be used for checking extensions because no source Files exist. Because the logic exists, it is causing variety of issues that are described in LPS-82717.
> 
> The simple fix is to remove the use of Title being checked for extensions and/or mimeTypes.
> 
> Sincerely,
> Brian Kim
> 