### PR TITLE
LPS-83236 Null check on display name

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
@@ -859,7 +859,11 @@ public class PortletImpl extends PortletBaseImpl {
 	 */
 	@Override
 	public String getDisplayName() {
-		return _displayName;
+		if (Validator.isNull(_displayName)) {
+			return "";
+		} else {
+			return _displayName;
+		}
 	}
 
 	/**


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83236
https://issues.liferay.com/browse/LPP-30763

From my research it is not necessary for a portlet to have a defined display name in the JSR 168 standard and liferay 6.2 and DXP up till de-36 never had issues with portlets not having it. 