### PR TITLE
LPS-83255 Clarify what search.container.show.pagination properties do

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7004,13 +7004,15 @@
 
     #
     # Set this to false to remove the pagination controls above or below
-    # results.
+    # results on the Roles Define Permissions page.
     #
     search.container.show.pagination.top=true
     search.container.show.pagination.bottom=true
 
     #
-    # Set the number of entries to display per page for top pagination controls.
+    # Set the number of entries to display per page for top pagination controls
+    # on the Roles Define Permissions page.
+    #
     # The property "search.container.show.pagination.top" must also be set to
     # true.
     #


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83255
https://issues.liferay.com/browse/LPP-30788

These properties are only used in Roles Define Permission page. They were previously used in the other pages in Users, Organizations, and Roles added here: https://issues.liferay.com/browse/LPS-44220 - however the UI of the other pages has changed and the Define Permission page is the only current usage. Because of the limit of their scope along with the generality of their description, customers were expecting much more from these properties.

Note: the description needs to be updated in the Japanese portal properties as well.