### PR TITLE
J cords lps 82412 2

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -832,31 +832,40 @@ public class JournalArticleIndexer
 				Field.SNIPPET + StringPool.UNDERLINE + Field.DESCRIPTION,
 				Field.DESCRIPTION);
 
+			String snippet = document.get(
+				snippetLocale,
+				Field.SNIPPET + StringPool.UNDERLINE + Field.CONTENT,
+				Field.CONTENT);
+
 			if (Validator.isNull(description)) {
 				content = HtmlUtil.stripHtml(articleDisplay.getDescription());
+
+				if (Validator.isNotNull(snippet)) {
+					if (Validator.isNotNull(content)) {
+						Set<String> highlights = new HashSet<>();
+
+						HighlightUtil.addSnippet(
+							document, highlights, snippet, "temp");
+
+						content = HighlightUtil.highlight(
+							content, ArrayUtil.toStringArray(highlights),
+							HighlightUtil.HIGHLIGHT_TAG_OPEN,
+							HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+					}
+					else {
+						content = _stripAndHighlight(snippet);
+					}
+				}
+
+				if (Validator.isNull(content)) {
+					content = HtmlUtil.extractText(articleDisplay.getContent());
+				}
 			}
 			else {
 				content = _stripAndHighlight(description);
 			}
 
 			content = HtmlUtil.replaceNewLine(content);
-
-			if (Validator.isNull(content)) {
-				content = HtmlUtil.extractText(articleDisplay.getContent());
-			}
-
-			String snippet = document.get(
-				snippetLocale,
-				Field.SNIPPET + StringPool.UNDERLINE + Field.CONTENT);
-
-			Set<String> highlights = new HashSet<>();
-
-			HighlightUtil.addSnippet(document, highlights, snippet, "temp");
-
-			content = HighlightUtil.highlight(
-				content, ArrayUtil.toStringArray(highlights),
-				HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE);
 		}
 		catch (Exception e) {
 			if (_log.isDebugEnabled()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
@@ -79,8 +79,6 @@ public class HighlightUtil {
 			}
 
 			sb.append(Pattern.quote(queryTerms[i].trim()));
-
-			sb.append(_REGEXP_WORD_BOUNDARY);
 		}
 
 		Pattern pattern = Pattern.compile(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82412

I made a change to the HighlighterUtil. Previously it required a word boundary in the pattern that created strange behavior where if a term appeared at the end of the word it would be highlighted, but if it did not appear at the end of a word it would not be highlighted. Ex: If the content had "tabletop", searching for "top" would highlight top, but searching for "table" would not highlight table.

The larger change was to the JournalArticleIndexer. Here I preserved the logic that if there is description field in the document, that would be used as first priority, otherwise if the articleDisplay had a description, that would be used at second priority and highlighted by all terms highlighted in the document's content.

What is changed is it will use the document's content, it one exists, instead of always using the articleDisplay's content and highlighting it with the highlighting terms present in the document's content.

The benefits of this are:
1) The snippets returned by search engine in the document are properly focused on highlighted terms, so there will not be the case that a summary of the content will displayed without showing a search term present in the content. 
2) Because multiple snippets are returned by the search engine and used, results will now show multiple highlighted search terms in concatenated snippets instead of only as much of the content that is visible starting from the beginning of the content.
3) Japanese text is better matched to what is expected - see the comments on [LPS-74642](https://issues.liferay.com/browse/LPS-74642?focusedCommentId=1191495&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1191495) and compare to the before and after attached.
Before searching JA content as an english user where only terms at the end of a word are highlighted:
![search before ja as eng](https://user-images.githubusercontent.com/20051725/42403762-5f1b3b9c-8138-11e8-866a-dae127a1bbd9.png)
After searching JA content as an english user:
![search after ja as eng](https://user-images.githubusercontent.com/20051725/42403760-5ee4ae38-8138-11e8-884a-442bcc5f7e41.png)
Before searching JA content as JA user only ending term is highlighting properly:
![search before ja as ja](https://user-images.githubusercontent.com/20051725/42403761-5efee7d0-8138-11e8-8468-3ac278ea5755.png)
After searching JA content as JA user the tokenized words are highlighted:
![search after ja as ja](https://user-images.githubusercontent.com/20051725/42403759-5ec6b248-8138-11e8-934f-8dd819552ca5.png)






