### PR TITLE
J cords lps 82412 2

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -832,31 +832,40 @@ public class JournalArticleIndexer
 				Field.SNIPPET + StringPool.UNDERLINE + Field.DESCRIPTION,
 				Field.DESCRIPTION);
 
+			String snippet = document.get(
+				snippetLocale,
+				Field.SNIPPET + StringPool.UNDERLINE + Field.CONTENT,
+				Field.CONTENT);
+
 			if (Validator.isNull(description)) {
 				content = HtmlUtil.stripHtml(articleDisplay.getDescription());
+
+				if (Validator.isNotNull(snippet)) {
+					if (Validator.isNotNull(content)) {
+						Set<String> highlights = new HashSet<>();
+
+						HighlightUtil.addSnippet(
+							document, highlights, snippet, "temp");
+
+						content = HighlightUtil.highlight(
+							content, ArrayUtil.toStringArray(highlights),
+							HighlightUtil.HIGHLIGHT_TAG_OPEN,
+							HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+					}
+					else {
+						content = _stripAndHighlight(snippet);
+					}
+				}
+
+				if (Validator.isNull(content)) {
+					content = HtmlUtil.extractText(articleDisplay.getContent());
+				}
 			}
 			else {
 				content = _stripAndHighlight(description);
 			}
 
 			content = HtmlUtil.replaceNewLine(content);
-
-			if (Validator.isNull(content)) {
-				content = HtmlUtil.extractText(articleDisplay.getContent());
-			}
-
-			String snippet = document.get(
-				snippetLocale,
-				Field.SNIPPET + StringPool.UNDERLINE + Field.CONTENT);
-
-			Set<String> highlights = new HashSet<>();
-
-			HighlightUtil.addSnippet(document, highlights, snippet, "temp");
-
-			content = HighlightUtil.highlight(
-				content, ArrayUtil.toStringArray(highlights),
-				HighlightUtil.HIGHLIGHT_TAG_OPEN,
-				HighlightUtil.HIGHLIGHT_TAG_CLOSE);
 		}
 		catch (Exception e) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerSummaryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerSummaryTest.java
@@ -100,11 +100,12 @@ public class JournalArticleIndexerSummaryTest {
 	@Test
 	public void testGetSummary() throws Exception {
 		String content = "test content";
+		String indexedContent = "test content ";
 		String title = "test title";
 
 		Document document = getDocument(title, content);
 
-		assertSummary(title, content, document);
+		assertSummary(title, indexedContent, document);
 	}
 
 	@Test
@@ -127,21 +128,6 @@ public class JournalArticleIndexerSummaryTest {
 	}
 
 	@Test
-	public void testStaleTitleFreshContent() throws Exception {
-		String content = "test content";
-		String title = "test title";
-
-		Document document = getDocument(title, content);
-
-		String staleContent = "stale content";
-		String staleTitle = "stale title";
-
-		setFields(staleTitle, staleContent, document);
-
-		assertSummary(staleTitle, content, document);
-	}
-
-	@Test
 	public void testStaleTitleFreshContentHighlighted() throws Exception {
 		String content = "test content";
 		String title = "test title";
@@ -150,7 +136,7 @@ public class JournalArticleIndexerSummaryTest {
 
 		String staleHighlightedContent = StringBundler.concat(
 			HighlightUtil.HIGHLIGHT_TAG_OPEN, "test",
-			HighlightUtil.HIGHLIGHT_TAG_CLOSE, " stale content");
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE, " content");
 		String staleHighlightedTitle = StringBundler.concat(
 			HighlightUtil.HIGHLIGHT_TAG_OPEN, "test",
 			HighlightUtil.HIGHLIGHT_TAG_CLOSE, " stale title");

--- a/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
@@ -79,8 +79,6 @@ public class HighlightUtil {
 			}
 
 			sb.append(Pattern.quote(queryTerms[i].trim()));
-
-			sb.append(_REGEXP_WORD_BOUNDARY);
 		}
 
 		Pattern pattern = Pattern.compile(

--- a/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/highlight/HighlightUtil.java
@@ -22,6 +22,8 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -70,6 +72,9 @@ public class HighlightUtil {
 		if (Validator.isBlank(s) || ArrayUtil.isEmpty(queryTerms)) {
 			return s;
 		}
+
+		Arrays.sort(
+			queryTerms, Comparator.comparingInt(String::length).reversed());
 
 		StringBundler sb = new StringBundler(3 * queryTerms.length - 1);
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/search/util/HighlightUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/search/util/HighlightUtilTest.java
@@ -107,7 +107,7 @@ public class HighlightUtilTest {
 			"sidewalk repair", "sidewalk repaired");
 		assertHighlight(
 			"japanese food is better in japan",
-			"japanese food is [[better]] in [[japan]]", "better", "japan");
+			"[[japan]]ese food is [[better]] in [[japan]]", "better", "japan");
 		assertHighlight(
 			"japanese food is better in japan",
 			"[[japanese]] food is better in [[japan]]", "japan", "japanese");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82412

I made a change to the HighlighterUtil. Previously it required a word boundary in the pattern that created strange behavior where if a term appeared at the end of the word it would be highlighted, but if it did not appear at the end of a word it would not be highlighted. Ex: If the content had "tabletop", searching for "top" would highlight top, but searching for "table" would not highlight table. It also had the issue where the ordering of the terms to highlight wasn't considers. Ex: if the search terms where "life", "liferay" and "liferay" was the search string, the string would be highlighted like so "[[life]]ray", but if the search terms were reversed it would be highlighted like this instead "[[liferay]]". This issue was introduced with [LPS-72222](https://issues.liferay.com/browse/LPS-72222) along with the test which originally failed. I've updated the test and HighlighUtil and ensured the original problem remains resolved.

The larger change was to the JournalArticleIndexer. Here I preserved the logic that if there is description field in the document, that would be used as first priority, otherwise if the articleDisplay had a description, that would be used at second priority and highlighted by all terms highlighted in the document's content.

What is changed is it will use the document's content, it one exists, instead of always using the articleDisplay's content and highlighting it with the highlighting terms present in the document's content.

The benefits of this are:
1) The snippets returned by search engine in the document are properly focused on highlighted terms, so there will not be the case that a summary of the content will displayed without showing a search term present in the content. 
2) Because multiple snippets are returned by the search engine and used, results will now show multiple highlighted search terms in concatenated snippets instead of only as much of the content that is visible starting from the beginning of the content.
3) Japanese text is better matched to what is expected - see the comments on [LPS-74642](https://issues.liferay.com/browse/LPS-74642?focusedCommentId=1191495&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1191495) and compare to the before and after attached.
Before searching JA content as an english user where only terms at the end of a word are highlighted:
![search before ja as eng](https://user-images.githubusercontent.com/20051725/42403762-5f1b3b9c-8138-11e8-866a-dae127a1bbd9.png)
After searching JA content as an english user:
![search after ja as eng](https://user-images.githubusercontent.com/20051725/42403760-5ee4ae38-8138-11e8-884a-442bcc5f7e41.png)
Before searching JA content as JA user only ending term is highlighting properly:
![search before ja as ja](https://user-images.githubusercontent.com/20051725/42403761-5efee7d0-8138-11e8-8468-3ac278ea5755.png)
After searching JA content as JA user the tokenized words are highlighted:
![search after ja as ja](https://user-images.githubusercontent.com/20051725/42403759-5ec6b248-8138-11e8-934f-8dd819552ca5.png)

This changed the behavior so I had to update the tests. The tests dealing with "StaleTitleFreshContent" were added to ensure that the snippet returned from the search engine is never displayed, which I consider a poor approach based on the points above. As such I do not believe testStaleTitleFreshContent() is a necessary test and testStaleTitleFreshContentHighlighted() I also modified. testGetSummary() needed to be tweaked because the [DDMIndexer](https://github.com/joshuacords/liferay-portal/blob/83c8717c1c98b126a2717e88068cff732170e54d/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java#L339) adds a space at the end to prepare the content for the search engine. The search engine results would never return the space at the end but the tests does not use the search engine so that space will appear. As the point of the test is to check getSummary(), I just added the space to the expected result.