### PR TITLE
LPS-83050

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_editor.js
@@ -118,7 +118,9 @@ AUI.add(
 							if (responseText.tempImageFileName) {
 								var previewURL = instance.get('previewURL');
 
-								previewURL = Liferay.Util.addParams(instance.get('namespace') + 'tempImageFileName=' + responseText.tempImageFileName, previewURL);
+								var tempImageFileName = encodeURIComponent(responseText.tempImageFileName);
+
+								previewURL = Liferay.Util.addParams(instance.get('namespace') + 'tempImageFileName=' + tempImageFileName, previewURL);
 								previewURL = Liferay.Util.addParams('t=' + Date.now(), previewURL);
 
 								portraitPreviewImg.attr('src', previewURL);


### PR DESCRIPTION
Hello @SamZiemer,

https://issues.liferay.com/browse/LPS-83050


The issue is that when we attempt to add an image with a file name that includes special characters in the file name (ex. &,+) for a page logo, the image is not rendered which prevents us from saving the change (Submit button is greyed out) and swapping the page logo. 

A quick reproduction steps:

1) Download and startup Liferay
3) Startup Liferay
4) Navigate to Public or Private pages
5) Click the ellipsis menu and select Configure
6) Scroll to the bottom of the page and click Logo
7) Choose an image to upload with a special character (ex. ata&t.png)
8) Attempt to select Done

The reason this issue occurs is because certain characters such as (& and +) are not being treated as values inside the query string of the image-preview URL.

Thus, the fix here is to make sure the tempImageFileName is being encoded to account for the special characters so the URL can be displayed properly.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim