### PR TITLE
LPS-84408 Format time with leading zeroes

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/resources.jsp
@@ -25,7 +25,7 @@ long seconds = (uptimeDiff / Time.SECOND) % 60;
 
 Runtime runtime = Runtime.getRuntime();
 
-numberFormat = NumberFormat.getInstance(locale);
+NumberFormat basicNumberFormat = NumberFormat.getInstance(locale);
 
 long totalMemory = runtime.totalMemory();
 long usedMemory = totalMemory - runtime.freeMemory();
@@ -75,7 +75,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 						<h4 class="pull-right"><liferay-ui:message key="used-memory" /></h4>
 					</td>
 					<td>
-						<span class="text-muted"><%= numberFormat.format(usedMemory) %> <liferay-ui:message key="bytes" /></span>
+						<span class="text-muted"><%= basicNumberFormat.format(usedMemory) %> <liferay-ui:message key="bytes" /></span>
 					</td>
 				</tr>
 				<tr>
@@ -83,7 +83,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 						<h4 class="pull-right"><liferay-ui:message key="total-memory" /></h4>
 					</td>
 					<td>
-						<span class="text-muted"><%= numberFormat.format(runtime.totalMemory()) %> <liferay-ui:message key="bytes" /></span>
+						<span class="text-muted"><%= basicNumberFormat.format(runtime.totalMemory()) %> <liferay-ui:message key="bytes" /></span>
 					</td>
 				</tr>
 				<tr>
@@ -91,7 +91,7 @@ long usedMemory = totalMemory - runtime.freeMemory();
 						<h4 class="pull-right"><liferay-ui:message key="maximum-memory" /></h4>
 					</td>
 					<td>
-						<span class="text-muted"><%= numberFormat.format(runtime.maxMemory()) %> <liferay-ui:message key="bytes" /></span>
+						<span class="text-muted"><%= basicNumberFormat.format(runtime.maxMemory()) %> <liferay-ui:message key="bytes" /></span>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84408

This change allows the hours, minutes, and seconds to use the numberFormat initialized here: https://github.com/joshuacords/liferay-portal/blob/a7d01e03127bd1dcd09abe64c80462bb0a0796a1/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp#L108-L111

