### PR TITLE
LPS-84784 Importing a layout based on a preloaded layoutPrototype wil…

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -691,7 +691,11 @@ public class LayoutStagedModelDataHandler
 			}
 		}
 
-		importedLayout.setLayoutPrototypeUuid(layout.getLayoutPrototypeUuid());
+		String layoutPrototypeUuid = getLayoutPrototypeUuid(
+			portletDataContext.getCompanyId(), layout, layoutElement);
+
+		importedLayout.setLayoutPrototypeUuid(layoutPrototypeUuid);
+
 		importedLayout.setLayoutPrototypeLinkEnabled(
 			layout.isLayoutPrototypeLinkEnabled());
 
@@ -1067,6 +1071,28 @@ public class LayoutStagedModelDataHandler
 		typeSettings.setProperty(
 			"url",
 			url.substring(0, x) + group.getFriendlyURL() + url.substring(y));
+	}
+
+	protected String getLayoutPrototypeUuid(
+		long companyId, Layout layout, Element layoutElement) {
+
+		boolean preloaded = GetterUtil.getBoolean(
+			layoutElement.attributeValue("preloaded"));
+
+		if (preloaded) {
+			String layoutPrototypeName = GetterUtil.getString(
+				layoutElement.attributeValue("layout-prototype-name"));
+
+			LayoutPrototype layoutPrototype =
+				_layoutPrototypeLocalService.fetchLayoutProtoype(
+					companyId, layoutPrototypeName);
+
+			if (layoutPrototype != null) {
+				return layoutPrototype.getUuid();
+			}
+		}
+
+		return layout.getLayoutPrototypeUuid();
 	}
 
 	protected Map<String, Object[]> getPortletids(


### PR DESCRIPTION
…l now try to find that prototype by name in the new portal

https://issues.liferay.com/browse/LPS-84784
https://issues.liferay.com/browse/LPP-31297

**Problem**: Publishing a page created by a Global Template in 7.1/master can be Imported into a separate bundle, but then when that page it was imported to is Exported, the export fails. This is because the Global Template the page was based on was never imported.

**Solution**: Based on Tamas' suggestion [here](https://issues.liferay.com/browse/LPP-31343?focusedCommentId=1523738&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1523738). During the import we will search for the layoutPrototype if it was preloaded and connect the page based on the Global Template to what is found. This was already happening during the validation process [here](https://github.com/joshuacords/liferay-portal/blob/8da25429f78276cf8ff934541f8a7b427a2e280d/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutImportController.java#L1377-L1404). 