### PR TITLE
LPS-85380 Structure ClassPKs unnecessary for query

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateDisplayContext.java
@@ -32,8 +32,6 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -177,8 +175,7 @@ public class JournalDDMTemplateDisplayContext {
 
 		int total = DDMTemplateServiceUtil.searchCount(
 			themeDisplay.getCompanyId(), groupIds,
-			new long[] {PortalUtil.getClassNameId(DDMStructure.class)},
-			_getDDMTemplateClassPKs(),
+			new long[] {PortalUtil.getClassNameId(DDMStructure.class)}, null,
 			PortalUtil.getClassNameId(JournalArticle.class), _getKeywords(),
 			StringPool.BLANK, StringPool.BLANK, WorkflowConstants.STATUS_ANY);
 
@@ -186,8 +183,7 @@ public class JournalDDMTemplateDisplayContext {
 
 		List<DDMTemplate> results = DDMTemplateServiceUtil.search(
 			themeDisplay.getCompanyId(), groupIds,
-			new long[] {PortalUtil.getClassNameId(DDMStructure.class)},
-			_getDDMTemplateClassPKs(),
+			new long[] {PortalUtil.getClassNameId(DDMStructure.class)}, null,
 			PortalUtil.getClassNameId(JournalArticle.class), _getKeywords(),
 			StringPool.BLANK, StringPool.BLANK, WorkflowConstants.STATUS_ANY,
 			ddmTemplateSearch.getStart(), ddmTemplateSearch.getEnd(),
@@ -320,27 +316,6 @@ public class JournalDDMTemplateDisplayContext {
 		_classPK = ParamUtil.getLong(_request, "classPK");
 
 		return _classPK;
-	}
-
-	private long[] _getDDMTemplateClassPKs() {
-		if (_getClassPK() > 0) {
-			return new long[] {_getClassPK()};
-		}
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		List<DDMStructure> ddmStructures =
-			DDMStructureLocalServiceUtil.getClassStructures(
-				themeDisplay.getCompanyId(),
-				PortalUtil.getClassNameId(JournalArticle.class));
-
-		List<Long> classPKs = ListUtil.toList(
-			ddmStructures, DDMStructure.STRUCTURE_ID_ACCESSOR);
-
-		classPKs.add(0, 0L);
-
-		return ArrayUtil.toLongArray(classPKs);
 	}
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85380
https://issues.liferay.com/browse/LPP-31502

_getDDMTemplateClassPKs() simply [returns all structure classPKs](https://github.com/SamZiemer/liferay-portal/commit/24a84fa257d03ca5c76a997817bc0e2b15a402a5#diff-a9f3d01e18a3027a4c983bf15d5daf61L334) for the search presumably so that no templates are missed. Using "null" will have the same effect and search for all templates as well. 
This handles the issue that can happen where the size of the classPKs can exceed the maximum "in()" query size allowed by SQL Server which is 2100, as well as being much better performance. 