### PR TITLE
LPS-85183 Use correct escape methods for HTML attributes

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/end.jspf
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/end.jspf
@@ -26,13 +26,13 @@
 						<c:if test="<%= Validator.isNotNull(title) %>">
 							<span class="lfr-card-title-text truncate-text">
 								<aui:a href="<%= url %>" onClick="<%= onClick %>" title="<%= HtmlUtil.escape(title) %>">
-									<%= HtmlUtil.escape(title) %>
+									<%= HtmlUtil.escapeAttribute(title) %>
 								</aui:a>
 							</span>
 						</c:if>
 
 						<c:if test="<%= Validator.isNotNull(subtitle) %>">
-							<span class="lfr-card-subtitle-text truncate-text" title="<%= HtmlUtil.escape(subtitle) %>">
+							<span class="lfr-card-subtitle-text truncate-text" title="<%= HtmlUtil.escapeAttribute(subtitle) %>">
 								<%= HtmlUtil.escape(subtitle) %>
 							</span>
 						</c:if>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/start.jspf
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/start.jspf
@@ -33,7 +33,7 @@
 		<c:when test="<%= showCheckbox %>">
 			<div class="checkbox checkbox-card checkbox-top-left">
 				<label>
-					<aui:input checked="<%= checkboxChecked %>" cssClass="<%= checkboxCSSClass %>" data="<%= checkboxData %>" disabled="<%= checkboxDisabled %>" id="<%= checkboxId %>" label="" name="<%= checkboxName %>" title='<%= LanguageUtil.format(request, "select-x", new Object[] {HtmlUtil.escape(title)}) %>' type="checkbox" useNamespace="<%= false %>" value="<%= checkboxValue %>" wrappedField="<%= true %>" />
+					<aui:input checked="<%= checkboxChecked %>" cssClass="<%= checkboxCSSClass %>" data="<%= checkboxData %>" disabled="<%= checkboxDisabled %>" id="<%= checkboxId %>" label="" name="<%= checkboxName %>" title='<%= LanguageUtil.format(request, "select-x", new Object[] {HtmlUtil.escapeAttribute(title)}) %>' type="checkbox" useNamespace="<%= false %>" value="<%= checkboxValue %>" wrappedField="<%= true %>" />
 				</label>
 		</c:when>
 	</c:choose>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85183

Hello @SamZiemer ,

This is a straight-forward PR to implement the suggested fix in LPS-85183.

HTML attributes should be escaped using HtmlUtil.escapeAttribute instead of HtmlUtil.escape() in liferay-frontend:vertical_card.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim