### PR TITLE
LPS-85410 Update workflowContext to save the approver's id

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
@@ -14,12 +14,21 @@
 
 package com.liferay.portal.workflow.task.web.internal.portlet.action;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowInstance;
+import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
+
+import java.io.Serializable;
+
+import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -56,12 +65,34 @@ public class CompleteTaskMVCActionCommand
 			actionRequest, "transitionName");
 		String comment = ParamUtil.getString(actionRequest, "comment");
 
+		long userId = themeDisplay.getUserId();
+
+		Map<String, Serializable> workflowContext = _getWorkflowContext(
+			themeDisplay.getCompanyId(), workflowTaskId);
+
+		workflowContext.put(
+			WorkflowConstants.CONTEXT_USER_ID, String.valueOf(userId));
+
 		workflowTaskManager.completeWorkflowTask(
-			themeDisplay.getCompanyId(), themeDisplay.getUserId(),
-			workflowTaskId, transitionName, comment, null);
+			themeDisplay.getCompanyId(), userId, workflowTaskId, transitionName,
+			comment, workflowContext);
 	}
 
 	@Reference
 	protected WorkflowTaskManager workflowTaskManager;
+
+	private Map<String, Serializable> _getWorkflowContext(
+			long companyId, long workflowTaskId)
+		throws PortalException {
+
+		WorkflowTask workflowTask = workflowTaskManager.getWorkflowTask(
+			companyId, workflowTaskId);
+
+		WorkflowInstance workflowInstance =
+			WorkflowInstanceManagerUtil.getWorkflowInstance(
+				companyId, workflowTask.getWorkflowInstanceId());
+
+		return workflowInstance.getWorkflowContext();
+	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85410

Problem: The workflowContext is never updated with the approver's userId when the completeWorkflowTask() is called.

Solution: Pass in a workflowContext with the userId of the approver updated using same logic as [WorkflowHelper](https://github.com/joshuacords/liferay-portal/blob/83c8717c1c98b126a2717e88068cff732170e54d/modules/apps/portal-workflow/portal-workflow-rest/src/main/java/com/liferay/portal/workflow/rest/internal/helper/WorkflowHelper.java#L431-L439).
Considering there is no dependency from portal-workflow-task-web on portal-workflow-rest and the WorkflowHelper getWorkflowContext() method is protected, I believe it's better to mimic the logic rather than call the method.
I could also see the change being made at a lower level, such as in [DefaultTaskManagerImpl.doCompleteWorkflowTask()](https://github.com/joshuacords/liferay-portal/blob/ecd1a18ec043d0c50329d410ee2f8a8e7ba31bf5/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultTaskManagerImpl.java#L361-L362) but that logic is shared by other calls and the method signatures would need to add the userId, so I think this version of the fix is preferable.