### PR TITLE
LPS-85281 Append string "From Data Provider" exactly once for Autofill

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder_action_autofill.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder_action_autofill.js
@@ -95,14 +95,16 @@ AUI.add(
 
 						var fieldsListContainer = boundingBox.one('.target-' + index);
 
-						fieldMessageContainer.append(
-							Lang.sub(
-								TPL_LABEL_ACTION,
-								{
-									message: Liferay.Language.get('from-data-provider')
-								}
-							)
-						);
+						if (!fieldMessageContainer._node.hasChildNodes()) {
+							fieldMessageContainer.append(
+								Lang.sub(
+									TPL_LABEL_ACTION,
+									{
+										message: Liferay.Language.get('from-data-provider')
+									}
+								)
+							);
+						}
 
 						instance._createDataProviderList().render(fieldsListContainer);
 


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-85281

cc: @diana-lin

Problem: The string "From Data Provider" is appended to the message container each time the Autofill option is selected from the drop down.

Solution: Append "From Data Provider" to the message container only if it has not already been appended.