### PR TITLE
LPS-85600 Page names should be retained after failed save actions.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_layout_serializer.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_layout_serializer.js
@@ -69,13 +69,15 @@ AUI.add(
 
 						var pages = builder.get('pages');
 
-						var descriptions = pages.get('localizedDescriptions');
-						var titles = pages.get('localizedTitles');
+						var localizedDescriptions = pages.get('localizedDescriptions');
+						var localizedTitles = pages.get('localizedTitles');
 
 						return {
-							description: descriptions[index] || '',
+							description: localizedDescriptions[index] || '',
+							localizedDescription: localizedDescriptions[index] || '',
+							localizedTitle: localizedTitles[index] || '',
 							rows: instance._visitRows(page.get('rows')),
-							title: titles[index] || ''
+							title: localizedTitles[index] || ''
 						};
 					},
 


### PR DESCRIPTION
Hello @SamZiemer ,

https://issues.liferay.com/browse/LPS-85952

My PR from https://github.com/SamZiemer/liferay-portal/pull/499 that links https://issues.liferay.com/browse/LPS-85600 is not correct. Although LPS-85600 is related to LPS-85952, they are two separate bugs.

The issue here is that whenever you try to save a form with its page name and description filled in and you fail any form validation checks during the submit, the page will refresh and the form content will be reset for page names and descriptions.

The fix is to ensure that we pass in localizedDescription and localizedTitle to the back-end as page name and description are handled under the mentioned two specific variable names.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim