### PR TITLE
Diana lin lps 85915 master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormInstanceRecordHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormInstanceRecordHelper.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.util;
+
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Diana Lin
+ */
+public interface DDMFormInstanceRecordHelper {
+
+	public void updateRequiredFieldsAccordingToVisibility(
+			long groupId, long formInstanceId,
+			HttpServletRequest httpServletRequest, DDMForm ddmForm,
+			DDMFormValues ddmFormValues, Locale locale)
+		throws Exception;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
 import com.liferay.portal.kernel.captcha.CaptchaTextException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -48,6 +49,8 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletSession;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -102,15 +105,18 @@ public class AddFormInstanceRecordMVCActionCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		_addFormInstanceMVCCommandHelper.
+		HttpServletRequest request = _portal.getHttpServletRequest(
+			actionRequest);
+
+		_ddmFormInstanceRecordHelper.
 			updateRequiredFieldsAccordingToVisibility(
-				actionRequest, ddmForm, ddmFormValues,
+				groupId, formInstanceId, request, ddmForm, ddmFormValues,
 				themeDisplay.getLocale());
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DDMFormInstanceRecord.class.getName(), actionRequest);
 
-		serviceContext.setRequest(_portal.getHttpServletRequest(actionRequest));
+		serviceContext.setRequest(request);
 
 		DDMFormInstanceRecordVersion ddmFormInstanceRecordVersion =
 			_ddmFormInstanceRecordVersionLocalService.
@@ -210,8 +216,7 @@ public class AddFormInstanceRecordMVCActionCommand
 	}
 
 	@Reference
-	private AddFormInstanceRecordMVCCommandHelper
-		_addFormInstanceMVCCommandHelper;
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 	private DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
@@ -14,35 +14,17 @@
 
 package com.liferay.dynamic.data.mapping.form.web.internal.portlet.action;
 
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluationResult;
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluator;
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorContext;
-import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormFieldEvaluationResult;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
-import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayoutColumn;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayoutPage;
-import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.portlet.ActionRequest;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -55,161 +37,31 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class AddFormInstanceRecordMVCCommandHelper {
 
+	/**
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 *             DDMFormInstanceRecordHelper#updateRequiredFieldsAccordingToVisibility(
+	 *             long, long, HttpServletRequest, DDMForm, DDMFormValues,
+	 *             Locale)}
+	 */
+	@Deprecated
 	public void updateRequiredFieldsAccordingToVisibility(
 			ActionRequest actionRequest, DDMForm ddmForm,
 			DDMFormValues ddmFormValues, Locale locale)
 		throws Exception {
 
-		List<DDMFormField> requiredFields = getRequiredFields(ddmForm);
-
-		if (requiredFields.isEmpty()) {
-			return;
-		}
-
-		DDMFormEvaluationResult ddmFormEvaluationResult = evaluate(
-			actionRequest, ddmForm, ddmFormValues, locale);
-
-		Set<String> invisibleFields = getInvisibleFields(
-			ddmFormEvaluationResult);
-
-		DDMFormLayout ddmFormLayout = getDDMFormLayout(actionRequest);
-
-		Set<String> fieldsFromDisabledPages = getFieldNamesFromDisabledPages(
-			ddmFormEvaluationResult, ddmFormLayout);
-
-		invisibleFields.addAll(fieldsFromDisabledPages);
-
-		if (invisibleFields.isEmpty()) {
-			return;
-		}
-
-		removeRequiredProperty(invisibleFields, requiredFields);
-	}
-
-	protected DDMFormEvaluationResult evaluate(
-			ActionRequest actionRequest, DDMForm ddmForm,
-			DDMFormValues ddmFormValues, Locale locale)
-		throws Exception {
-
-		DDMFormEvaluatorContext ddmFormEvaluatorContext =
-			new DDMFormEvaluatorContext(ddmForm, ddmFormValues, locale);
-
-		ddmFormEvaluatorContext.addProperty(
-			"groupId", ParamUtil.getLong(actionRequest, "groupId"));
-		ddmFormEvaluatorContext.addProperty(
-			"request", _portal.getHttpServletRequest(actionRequest));
-
-		return _ddmFormEvaluator.evaluate(ddmFormEvaluatorContext);
-	}
-
-	protected DDMFormLayout getDDMFormLayout(ActionRequest actionRequest)
-		throws PortalException {
-
+		long groupId = ParamUtil.getLong(actionRequest, "groupId");
 		long formInstanceId = ParamUtil.getLong(
 			actionRequest, "formInstanceId");
 
-		DDMFormInstance formInstance = _ddmFormInstanceService.getFormInstance(
-			formInstanceId);
+		HttpServletRequest request = _portal.getHttpServletRequest(
+			actionRequest);
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
-			formInstance.getStructureId());
-
-		return ddmStructure.getDDMFormLayout();
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			groupId, formInstanceId, request, ddmForm, ddmFormValues, locale);
 	}
 
-	protected Set<String> getFieldNamesFromDisabledPages(
-		DDMFormEvaluationResult ddmFormEvaluationResult,
-		DDMFormLayout ddmFormLayout) {
-
-		Set<Integer> disabledPagesIndexes =
-			ddmFormEvaluationResult.getDisabledPagesIndexes();
-
-		Stream<Integer> disablePagesIndexesStream =
-			disabledPagesIndexes.stream();
-
-		Stream<String> fieldsStream = disablePagesIndexesStream.map(
-			index -> getFieldNamesFromPage(index, ddmFormLayout)
-		).flatMap(
-			field -> field.stream()
-		);
-
-		return fieldsStream.collect(Collectors.toSet());
-	}
-
-	protected Set<String> getFieldNamesFromPage(
-		int index, DDMFormLayout ddmFormLayout) {
-
-		DDMFormLayoutPage ddmFormLayoutPage =
-			ddmFormLayout.getDDMFormLayoutPage(index);
-
-		List<DDMFormLayoutRow> ddmFormLayoutRows =
-			ddmFormLayoutPage.getDDMFormLayoutRows();
-
-		Set<String> fieldNames = new HashSet<>();
-
-		for (DDMFormLayoutRow ddmFormLayoutRow : ddmFormLayoutRows) {
-			for (DDMFormLayoutColumn ddmFormLayoutColumn :
-					ddmFormLayoutRow.getDDMFormLayoutColumns()) {
-
-				fieldNames.addAll(ddmFormLayoutColumn.getDDMFormFieldNames());
-			}
-		}
-
-		return fieldNames;
-	}
-
-	protected Set<String> getInvisibleFields(
-		DDMFormEvaluationResult ddmFormEvaluationResult) {
-
-		List<DDMFormFieldEvaluationResult> ddmFormFieldEvaluationResults =
-			ddmFormEvaluationResult.getDDMFormFieldEvaluationResults();
-
-		Stream<DDMFormFieldEvaluationResult> stream =
-			ddmFormFieldEvaluationResults.stream();
-
-		stream = stream.filter(result -> !result.isVisible());
-
-		Stream<String> fieldNameStream = stream.map(result -> result.getName());
-
-		return fieldNameStream.collect(Collectors.toSet());
-	}
-
-	protected List<DDMFormField> getRequiredFields(DDMForm ddmForm) {
-		Map<String, DDMFormField> ddmFormFieldsMap =
-			ddmForm.getDDMFormFieldsMap(true);
-
-		Collection<DDMFormField> ddmFormFields = ddmFormFieldsMap.values();
-
-		Stream<DDMFormField> stream = ddmFormFields.stream();
-
-		stream = stream.filter(ddmFormField -> ddmFormField.isRequired());
-
-		return stream.collect(Collectors.toList());
-	}
-
-	protected void removeRequiredProperty(DDMFormField ddmFormField) {
-		ddmFormField.setRequired(false);
-	}
-
-	protected void removeRequiredProperty(
-		Set<String> invisibleFields, List<DDMFormField> requiredFields) {
-
-		Stream<DDMFormField> stream = requiredFields.stream();
-
-		stream = stream.filter(
-			field -> invisibleFields.contains(field.getName()));
-
-		stream.forEach(this::removeRequiredProperty);
-	}
-
-	@Reference
-	private DDMFormEvaluator _ddmFormEvaluator;
-
-	@Reference
-	private DDMFormInstanceService _ddmFormInstanceService;
-
-	@Reference
-	private DDMStructureLocalService _ddmStructureLocalService;
+	@Reference(service = DDMFormInstanceRecordHelper.class)
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
@@ -37,13 +37,6 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class AddFormInstanceRecordMVCCommandHelper {
 
-	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
-	 *             DDMFormInstanceRecordHelper#updateRequiredFieldsAccordingToVisibility(
-	 *             long, long, HttpServletRequest, DDMForm, DDMFormValues,
-	 *             Locale)}
-	 */
-	@Deprecated
 	public void updateRequiredFieldsAccordingToVisibility(
 			ActionRequest actionRequest, DDMForm ddmForm,
 			DDMFormValues ddmFormValues, Locale locale)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/data/handler/DDMFormInstanceRecordStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/data/handler/DDMFormInstanceRecordStagedModelDataHandler.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
@@ -37,6 +38,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -134,6 +136,14 @@ public class DDMFormInstanceRecordStagedModelDataHandler
 
 		DDMFormValues ddmFormValues = getImportDDMFormValues(
 			portletDataContext, recordElement, ddmFormInstanceId);
+
+		ServiceContext serviceContext = portletDataContext.createServiceContext(
+			record);
+
+		_ddmFormInstanceRecordHelper.updateRequiredFieldsAccordingToVisibility(
+			serviceContext.getScopeGroupId(), ddmFormInstanceId,
+			serviceContext.getRequest(), ddmFormValues.getDDMForm(),
+			ddmFormValues, serviceContext.getLocale());
 
 		DDMFormInstanceRecord importedRecord =
 			(DDMFormInstanceRecord)record.clone();
@@ -264,6 +274,9 @@ public class DDMFormInstanceRecordStagedModelDataHandler
 
 	@Reference(service = DDMFormInstanceLocalService.class)
 	private DDMFormInstanceLocalService _ddmFormInstanceLocalService;
+
+	@Reference(service = DDMFormInstanceRecordHelper.class)
+	private DDMFormInstanceRecordHelper _ddmFormInstanceRecordHelper;
 
 	@Reference(
 		service = DDMFormInstanceRecordStagedModelRepository.class,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormInstanceRecordHelperImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormInstanceRecordHelperImpl.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.util;
+
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluationResult;
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluator;
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormEvaluatorContext;
+import com.liferay.dynamic.data.mapping.form.evaluator.DDMFormFieldEvaluationResult;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormInstanceRecordHelper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Leonardo Barros
+ */
+@Component(immediate = true, service = DDMFormInstanceRecordHelper.class)
+public class DDMFormInstanceRecordHelperImpl
+	implements DDMFormInstanceRecordHelper {
+
+	@Override
+	public void updateRequiredFieldsAccordingToVisibility(
+			long groupId, long formInstanceId,
+			HttpServletRequest httpServletRequest, DDMForm ddmForm,
+			DDMFormValues ddmFormValues, Locale locale)
+		throws Exception {
+
+		List<DDMFormField> requiredFields = getRequiredFields(ddmForm);
+
+		if (requiredFields.isEmpty()) {
+			return;
+		}
+
+		DDMFormEvaluationResult ddmFormEvaluationResult = evaluate(
+			groupId, httpServletRequest, ddmForm, ddmFormValues, locale);
+
+		Set<String> invisibleFields = getInvisibleFields(
+			ddmFormEvaluationResult);
+
+		DDMFormLayout ddmFormLayout = getDDMFormLayout(formInstanceId);
+
+		Set<String> fieldsFromDisabledPages = getFieldNamesFromDisabledPages(
+			ddmFormEvaluationResult, ddmFormLayout);
+
+		invisibleFields.addAll(fieldsFromDisabledPages);
+
+		if (invisibleFields.isEmpty()) {
+			return;
+		}
+
+		removeRequiredProperty(invisibleFields, requiredFields);
+	}
+
+	protected DDMFormEvaluationResult evaluate(
+			long groupId, HttpServletRequest httpServletRequest,
+			DDMForm ddmForm, DDMFormValues ddmFormValues, Locale locale)
+		throws Exception {
+
+		DDMFormEvaluatorContext ddmFormEvaluatorContext =
+			new DDMFormEvaluatorContext(ddmForm, ddmFormValues, locale);
+
+		ddmFormEvaluatorContext.addProperty("groupId", groupId);
+		ddmFormEvaluatorContext.addProperty("request", httpServletRequest);
+
+		return _ddmFormEvaluator.evaluate(ddmFormEvaluatorContext);
+	}
+
+	protected DDMFormLayout getDDMFormLayout(long formInstanceId)
+		throws PortalException {
+
+		DDMFormInstance formInstance = _ddmFormInstanceService.getFormInstance(
+			formInstanceId);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			formInstance.getStructureId());
+
+		return ddmStructure.getDDMFormLayout();
+	}
+
+	protected Set<String> getFieldNamesFromDisabledPages(
+		DDMFormEvaluationResult ddmFormEvaluationResult,
+		DDMFormLayout ddmFormLayout) {
+
+		Set<Integer> disabledPagesIndexes =
+			ddmFormEvaluationResult.getDisabledPagesIndexes();
+
+		Stream<Integer> disablePagesIndexesStream =
+			disabledPagesIndexes.stream();
+
+		Stream<String> fieldsStream = disablePagesIndexesStream.map(
+			index -> getFieldNamesFromPage(index, ddmFormLayout)
+		).flatMap(
+			field -> field.stream()
+		);
+
+		return fieldsStream.collect(Collectors.toSet());
+	}
+
+	protected Set<String> getFieldNamesFromPage(
+		int index, DDMFormLayout ddmFormLayout) {
+
+		DDMFormLayoutPage ddmFormLayoutPage =
+			ddmFormLayout.getDDMFormLayoutPage(index);
+
+		List<DDMFormLayoutRow> ddmFormLayoutRows =
+			ddmFormLayoutPage.getDDMFormLayoutRows();
+
+		Set<String> fieldNames = new HashSet<>();
+
+		for (DDMFormLayoutRow ddmFormLayoutRow : ddmFormLayoutRows) {
+			for (DDMFormLayoutColumn ddmFormLayoutColumn :
+					ddmFormLayoutRow.getDDMFormLayoutColumns()) {
+
+				fieldNames.addAll(ddmFormLayoutColumn.getDDMFormFieldNames());
+			}
+		}
+
+		return fieldNames;
+	}
+
+	protected Set<String> getInvisibleFields(
+		DDMFormEvaluationResult ddmFormEvaluationResult) {
+
+		List<DDMFormFieldEvaluationResult> ddmFormFieldEvaluationResults =
+			ddmFormEvaluationResult.getDDMFormFieldEvaluationResults();
+
+		Stream<DDMFormFieldEvaluationResult> stream =
+			ddmFormFieldEvaluationResults.stream();
+
+		stream = stream.filter(result -> !result.isVisible());
+
+		Stream<String> fieldNameStream = stream.map(result -> result.getName());
+
+		return fieldNameStream.collect(Collectors.toSet());
+	}
+
+	protected List<DDMFormField> getRequiredFields(DDMForm ddmForm) {
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmForm.getDDMFormFieldsMap(true);
+
+		Collection<DDMFormField> ddmFormFields = ddmFormFieldsMap.values();
+
+		Stream<DDMFormField> stream = ddmFormFields.stream();
+
+		stream = stream.filter(ddmFormField -> ddmFormField.isRequired());
+
+		return stream.collect(Collectors.toList());
+	}
+
+	protected void removeRequiredProperty(DDMFormField ddmFormField) {
+		ddmFormField.setRequired(false);
+	}
+
+	protected void removeRequiredProperty(
+		Set<String> invisibleFields, List<DDMFormField> requiredFields) {
+
+		Stream<DDMFormField> stream = requiredFields.stream();
+
+		stream = stream.filter(
+			field -> invisibleFields.contains(field.getName()));
+
+		stream.forEach(this::removeRequiredProperty);
+	}
+
+	@Reference
+	private DDMFormEvaluator _ddmFormEvaluator;
+
+	@Reference
+	private DDMFormInstanceService _ddmFormInstanceService;
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-85915

Notes from @diana-lin 

> Problem:  Required fields which have been skipped from Form Rules remain marked as required when they are imported.  This causes a `RequiredValue` exception to be thrown.
> 
> Context:  On Form submission, required fields which have been skipped have their `required` property updated to `false`.  This same update should be imposed on Form import.
> 
> Solution:  Update Form fields to required/not required on import.  Since the functionality of `AddFormInstanceRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(...)` will be used in both the `dynamic-data-mapping-form-web` and `dynamic-data-mapping-service` modules, we propose creating a service.