### PR TITLE
LPS-85960 Edited endPos to replace trailing "/"s

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -261,6 +261,7 @@ public class LayoutReferencesExportImportContentProcessor
 
 			if (url.endsWith(StringPool.SLASH)) {
 				url = url.substring(0, url.length() - 1);
+				endPos--;
 			}
 
 			StringBundler urlSB = new StringBundler(6);


### PR DESCRIPTION
@ [LPS-85960](https://issues.liferay.com/browse/LPS-85960)

Notes from @ricky-pan
> Issue: When staging, Liferay parses URLs in content to check for relative URLs within different environments and modifies them as needed to preserve links.The current implementation of URL parsing alters URLs by possibly removing a "/", thus breaking some links. This specifically can happen when a link has a "/#".
> 
> Solution: The `endPos` variable wasn't adjusted properly to replace the trailing "/"s, so I modified the counter.