### PR TITLE
LPS-85499 Add modified attribute to searchContext to enable frequency

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilder.java
@@ -56,6 +56,8 @@ public class ModifiedFacetBuilder {
 
 		if (!Validator.isBlank(rangeString)) {
 			facet.select(rangeString);
+
+			_searchContext.setAttribute(facet.getFieldId(), rangeString);
 		}
 
 		return facet;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85499

Problem: The facet for Custom Range in search results showed 0 frequency because the "modified" attribute was never set in the search context and couldn't be found [here](https://github.com/joshuacords/liferay-portal/blob/4376221ec47faaef14d32c0b7bcff34095c2ad94/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/facet/RangeFacetProcessor.java#L98-L99).

Solution: Add the "modified" attribute while the ModifiedFacetBuilder is building the facet.