### PR TITLE
J cords lps 86345

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/builder/AssetCategoriesFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/builder/AssetCategoriesFacetBuilder.java
@@ -34,6 +34,8 @@ public class AssetCategoriesFacetBuilder {
 	public Facet build() {
 		Facet facet = _categoryFacetFactory.newInstance(_searchContext);
 
+		facet.setAggregationName(_aggregationName);
+
 		facet.setFacetConfiguration(buildFacetConfiguration(facet));
 
 		if (_selectedCategoryIds != null) {
@@ -41,6 +43,10 @@ public class AssetCategoriesFacetBuilder {
 		}
 
 		return facet;
+	}
+
+	public void setAggregationName(String aggregationName) {
+		_aggregationName = aggregationName;
 	}
 
 	public void setFrequencyThreshold(int frequencyThreshold) {
@@ -78,6 +84,7 @@ public class AssetCategoriesFacetBuilder {
 		return facetConfiguration;
 	}
 
+	private String _aggregationName;
 	private final CategoryFacetFactory _categoryFacetFactory;
 	private int _frequencyThreshold;
 	private int _maxTerms;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortlet.java
@@ -15,9 +15,12 @@
 package com.liferay.portal.search.web.internal.category.facet.portlet;
 
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.category.CategoryFacetFactory;
 import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetConfiguration;
@@ -98,7 +101,8 @@ public class CategoryFacetPortlet extends MVCPortlet {
 		PortletSharedSearchResponse portletSharedSearchResponse,
 		RenderRequest renderRequest) {
 
-		Facet facet = portletSharedSearchResponse.getFacet(getFieldName());
+		Facet facet = portletSharedSearchResponse.getFacet(
+			getAggregationName(getPortletId(renderRequest)));
 
 		CategoryFacetPortletPreferences categoryFacetPortletPreferences =
 			new CategoryFacetPortletPreferencesImpl(
@@ -149,10 +153,18 @@ public class CategoryFacetPortlet extends MVCPortlet {
 		return assetCategoriesSearchFacetDisplayBuilder.build();
 	}
 
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
+	}
+
 	protected String getFieldName() {
 		Facet facet = categoryFacetFactory.newInstance(null);
 
 		return facet.getFieldName();
+	}
+
+	protected String getPortletId(RenderRequest renderRequest) {
+		return _portal.getPortletId(renderRequest);
 	}
 
 	@Reference
@@ -163,5 +175,8 @@ public class CategoryFacetPortlet extends MVCPortlet {
 
 	@Reference
 	protected PortletSharedSearchRequest portletSharedSearchRequest;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/shared/search/CategoryFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/shared/search/CategoryFacetPortletSharedSearchContributor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.web.internal.category.facet.portlet.shared.search;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -63,6 +65,8 @@ public class CategoryFacetPortletSharedSearchContributor
 		AssetCategoriesFacetBuilder assetCategoriesFacetBuilder =
 			new AssetCategoriesFacetBuilder(categoryFacetFactory);
 
+		assetCategoriesFacetBuilder.setAggregationName(
+			getAggregationName(portletSharedSearchSettings.getPortletId()));
 		assetCategoriesFacetBuilder.setFrequencyThreshold(
 			categoryFacetPortletPreferences.getFrequencyThreshold());
 		assetCategoriesFacetBuilder.setMaxTerms(
@@ -82,6 +86,10 @@ public class CategoryFacetPortletSharedSearchContributor
 			assetCategoriesFacetBuilder::setSelectedCategoryIds);
 
 		return assetCategoriesFacetBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetBuilder.java
@@ -32,6 +32,8 @@ public class FolderFacetBuilder {
 	public Facet build() {
 		Facet facet = _folderFacetFactory.newInstance(_searchContext);
 
+		facet.setAggregationName(_aggregationName);
+
 		facet.setFacetConfiguration(buildFacetConfiguration(facet));
 
 		if (_selectedFolderIds != null) {
@@ -39,6 +41,10 @@ public class FolderFacetBuilder {
 		}
 
 		return facet;
+	}
+
+	public void setAggregationName(String aggregationName) {
+		_aggregationName = aggregationName;
 	}
 
 	public void setFrequencyThreshold(int frequencyThreshold) {
@@ -75,6 +81,7 @@ public class FolderFacetBuilder {
 		return facetConfiguration;
 	}
 
+	private String _aggregationName;
 	private final FolderFacetFactory _folderFacetFactory;
 	private int _frequencyThreshold;
 	private int _maxTerms;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortlet.java
@@ -14,7 +14,9 @@
 
 package com.liferay.portal.search.web.internal.folder.facet.portlet;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -94,7 +96,8 @@ public class FolderFacetPortlet extends MVCPortlet {
 		PortletSharedSearchResponse portletSharedSearchResponse,
 		RenderRequest renderRequest) {
 
-		Facet facet = portletSharedSearchResponse.getFacet(getFieldName());
+		Facet facet = portletSharedSearchResponse.getFacet(
+			getAggregationName(getPortletId(renderRequest)));
 
 		FolderTitleLookup folderTitleLookup = new FolderTitleLookupImpl(
 			portal.getHttpServletRequest(renderRequest));
@@ -131,10 +134,18 @@ public class FolderFacetPortlet extends MVCPortlet {
 		return folderSearchFacetDisplayBuilder.build();
 	}
 
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
+	}
+
 	protected String getFieldName() {
 		Facet facet = folderFacetFactory.newInstance(null);
 
 		return facet.getFieldName();
+	}
+
+	protected String getPortletId(RenderRequest renderRequest) {
+		return portal.getPortletId(renderRequest);
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/shared/search/FolderFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/shared/search/FolderFacetPortletSharedSearchContributor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.web.internal.folder.facet.portlet.shared.search;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -64,6 +66,8 @@ public class FolderFacetPortletSharedSearchContributor
 		FolderFacetBuilder folderFacetBuilder = new FolderFacetBuilder(
 			folderFacetFactory);
 
+		folderFacetBuilder.setAggregationName(
+			getAggregationName(portletSharedSearchSettings.getPortletId()));
 		folderFacetBuilder.setFrequencyThreshold(
 			folderFacetPortletPreferences.getFrequencyThreshold());
 		folderFacetBuilder.setMaxTerms(
@@ -84,6 +88,10 @@ public class FolderFacetPortletSharedSearchContributor
 			folderFacetBuilder::setSelectedFolderIds);
 
 		return folderFacetBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/ScopeFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/ScopeFacetBuilder.java
@@ -32,6 +32,8 @@ public class ScopeFacetBuilder {
 	public Facet build() {
 		Facet facet = _facetFactory.newInstance(_searchContext);
 
+		facet.setAggregationName(_aggregationName);
+
 		facet.setFacetConfiguration(buildFacetConfiguration(facet));
 
 		if (ArrayUtil.isNotEmpty(_selectedGroupIds)) {
@@ -39,6 +41,10 @@ public class ScopeFacetBuilder {
 		}
 
 		return facet;
+	}
+
+	public void setAggregationName(String aggregationName) {
+		_aggregationName = aggregationName;
 	}
 
 	public void setFrequencyThreshold(int frequencyThreshold) {
@@ -75,6 +81,7 @@ public class ScopeFacetBuilder {
 		return facetConfiguration;
 	}
 
+	private String _aggregationName;
 	private final FacetFactory _facetFactory;
 	private int _frequencyThreshold;
 	private int _maxTerms;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/SiteFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/SiteFacetPortlet.java
@@ -14,11 +14,14 @@
 
 package com.liferay.portal.search.web.internal.site.facet.portlet;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.site.SiteFacetFactory;
 import com.liferay.portal.search.web.internal.facet.display.builder.ScopeSearchFacetDisplayBuilder;
@@ -100,7 +103,8 @@ public class SiteFacetPortlet extends MVCPortlet {
 		PortletSharedSearchResponse portletSharedSearchResponse,
 		RenderRequest renderRequest) {
 
-		Facet facet = portletSharedSearchResponse.getFacet(getFieldName());
+		Facet facet = portletSharedSearchResponse.getFacet(
+			getAggregationName(getPortletId(renderRequest)));
 
 		ScopeFacetConfiguration siteFacetConfiguration =
 			new ScopeFacetConfigurationImpl(facet.getFacetConfiguration());
@@ -139,6 +143,10 @@ public class SiteFacetPortlet extends MVCPortlet {
 			scopeSearchFacetDisplayBuilder::setParameterValues);
 
 		return scopeSearchFacetDisplayBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	protected String getFieldName() {
@@ -180,6 +188,10 @@ public class SiteFacetPortlet extends MVCPortlet {
 		return optional.map(Arrays::asList);
 	}
 
+	protected String getPortletId(RenderRequest renderRequest) {
+		return _portal.getPortletId(renderRequest);
+	}
+
 	@Reference
 	protected GroupLocalService groupLocalService;
 
@@ -188,5 +200,8 @@ public class SiteFacetPortlet extends MVCPortlet {
 
 	@Reference
 	protected SiteFacetFactory siteFacetFactory;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/shared/search/SiteFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/shared/search/SiteFacetPortletSharedSearchContributor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.web.internal.site.facet.portlet.shared.search;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.search.facet.site.SiteFacetFactory;
 import com.liferay.portal.search.web.internal.site.facet.constants.SiteFacetPortletKeys;
@@ -59,6 +61,8 @@ public class SiteFacetPortletSharedSearchContributor
 		ScopeFacetBuilder scopeFacetBuilder = new ScopeFacetBuilder(
 			siteFacetFactory);
 
+		scopeFacetBuilder.setAggregationName(
+			getAggregationName(portletSharedSearchSettings.getPortletId()));
 		scopeFacetBuilder.setFrequencyThreshold(
 			siteFacetPortletPreferences.getFrequencyThreshold());
 		scopeFacetBuilder.setMaxTerms(
@@ -72,6 +76,10 @@ public class SiteFacetPortletSharedSearchContributor
 			scopeFacetBuilder::setSelectedGroupIds);
 
 		return scopeFacetBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/builder/AssetTagsFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/builder/AssetTagsFacetBuilder.java
@@ -33,11 +33,17 @@ public class AssetTagsFacetBuilder {
 	public Facet build() {
 		Facet facet = _assetTagNamesFacetFactory.newInstance(_searchContext);
 
+		facet.setAggregationName(_aggregationName);
+
 		facet.setFacetConfiguration(buildFacetConfiguration(facet));
 
 		facet.select(_selectedTagNames);
 
 		return facet;
+	}
+
+	public void setAggregationName(String aggregationName) {
+		_aggregationName = aggregationName;
 	}
 
 	public void setFrequencyThreshold(int frequencyThreshold) {
@@ -74,6 +80,7 @@ public class AssetTagsFacetBuilder {
 		return facetConfiguration;
 	}
 
+	private String _aggregationName;
 	private final AssetTagNamesFacetFactory _assetTagNamesFacetFactory;
 	private int _frequencyThreshold;
 	private int _maxTerms;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/TagFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/TagFacetPortlet.java
@@ -14,8 +14,11 @@
 
 package com.liferay.portal.search.web.internal.tag.facet.portlet;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetTagsSearchFacetDisplayBuilder;
@@ -94,7 +97,8 @@ public class TagFacetPortlet extends MVCPortlet {
 		PortletSharedSearchResponse portletSharedSearchResponse,
 		RenderRequest renderRequest) {
 
-		Facet facet = portletSharedSearchResponse.getFacet(getFieldName());
+		Facet facet = portletSharedSearchResponse.getFacet(
+			getAggregationName(getPortletId(renderRequest)));
 
 		TagFacetPortletPreferences tagFacetPortletPreferences =
 			new TagFacetPortletPreferencesImpl(
@@ -129,10 +133,18 @@ public class TagFacetPortlet extends MVCPortlet {
 		return assetTagsSearchFacetDisplayBuilder.build();
 	}
 
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
+	}
+
 	protected String getFieldName() {
 		Facet facet = assetTagNamesFacetFactory.newInstance(null);
 
 		return facet.getFieldName();
+	}
+
+	protected String getPortletId(RenderRequest renderRequest) {
+		return _portal.getPortletId(renderRequest);
 	}
 
 	@Reference
@@ -140,5 +152,8 @@ public class TagFacetPortlet extends MVCPortlet {
 
 	@Reference
 	protected PortletSharedSearchRequest portletSharedSearchRequest;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/shared/search/TagFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/shared/search/TagFacetPortletSharedSearchContributor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.web.internal.tag.facet.portlet.shared.search;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
 import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetBuilder;
@@ -59,6 +61,8 @@ public class TagFacetPortletSharedSearchContributor
 		AssetTagsFacetBuilder assetTagsFacetBuilder = new AssetTagsFacetBuilder(
 			assetTagNamesFacetFactory);
 
+		assetTagsFacetBuilder.setAggregationName(
+			getAggregationName(portletSharedSearchSettings.getPortletId()));
 		assetTagsFacetBuilder.setFrequencyThreshold(
 			tagFacetPortletPreferences.getFrequencyThreshold());
 		assetTagsFacetBuilder.setMaxTerms(
@@ -72,6 +76,10 @@ public class TagFacetPortletSharedSearchContributor
 			assetTagsFacetBuilder::setSelectedTagNames);
 
 		return assetTagsFacetBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/AssetEntriesFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/AssetEntriesFacetBuilder.java
@@ -33,11 +33,17 @@ public class AssetEntriesFacetBuilder {
 	public Facet build() {
 		Facet facet = _assetEntriesFacetFactory.newInstance(_searchContext);
 
+		facet.setAggregationName(_aggregationName);
+
 		facet.setFacetConfiguration(buildFacetConfiguration(facet));
 
 		facet.select(_selectedEntryClassNames);
 
 		return facet;
+	}
+
+	public void setAggregationName(String aggregationName) {
+		_aggregationName = aggregationName;
 	}
 
 	public void setFrequencyThreshold(int frequencyThreshold) {
@@ -70,6 +76,7 @@ public class AssetEntriesFacetBuilder {
 		return facetConfiguration;
 	}
 
+	private String _aggregationName;
 	private final AssetEntriesFacetFactory _assetEntriesFacetFactory;
 	private int _frequencyThreshold;
 	private SearchContext _searchContext;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/TypeFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/TypeFacetPortlet.java
@@ -14,9 +14,12 @@
 
 package com.liferay.portal.search.web.internal.type.facet.portlet;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetEntriesSearchFacetDisplayBuilder;
@@ -97,7 +100,8 @@ public class TypeFacetPortlet extends MVCPortlet {
 		PortletSharedSearchResponse portletSharedSearchResponse,
 		RenderRequest renderRequest) {
 
-		Facet facet = portletSharedSearchResponse.getFacet(getFieldName());
+		Facet facet = portletSharedSearchResponse.getFacet(
+			getAggregationName(getPortletId(renderRequest)));
 
 		AssetEntriesFacetConfiguration assetEntriesFacetConfiguration =
 			new AssetEntriesFacetConfigurationImpl(
@@ -138,6 +142,10 @@ public class TypeFacetPortlet extends MVCPortlet {
 		return assetEntriesSearchFacetDisplayBuilder.build();
 	}
 
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
+	}
+
 	protected String[] getAssetTypesClassNames(
 		TypeFacetPortletPreferences typeFacetPortletPreferences,
 		ThemeDisplay themeDisplay) {
@@ -164,10 +172,17 @@ public class TypeFacetPortlet extends MVCPortlet {
 		return optional.map(Arrays::asList);
 	}
 
+	protected String getPortletId(RenderRequest renderRequest) {
+		return _portal.getPortletId(renderRequest);
+	}
+
 	@Reference
 	protected AssetEntriesFacetFactory assetEntriesFacetFactory;
 
 	@Reference
 	protected PortletSharedSearchRequest portletSharedSearchRequest;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/shared/search/TypeFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/shared/search/TypeFacetPortletSharedSearchContributor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.web.internal.type.facet.portlet.shared.search;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -70,6 +72,8 @@ public class TypeFacetPortletSharedSearchContributor
 		AssetEntriesFacetBuilder assetEntriesFacetBuilder =
 			new AssetEntriesFacetBuilder(assetEntriesFacetFactory);
 
+		assetEntriesFacetBuilder.setAggregationName(
+			getAggregationName(portletSharedSearchSettings.getPortletId()));
 		assetEntriesFacetBuilder.setFrequencyThreshold(
 			typeFacetPortletPreferences.getFrequencyThreshold());
 		assetEntriesFacetBuilder.setSearchContext(
@@ -81,6 +85,10 @@ public class TypeFacetPortletSharedSearchContributor
 			assetEntriesFacetBuilder::setSelectedEntryClassNames);
 
 		return assetEntriesFacetBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	protected String[] getAssetTypesClassNames(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetBuilder.java
@@ -31,11 +31,17 @@ public class UserFacetBuilder {
 	public Facet build() {
 		Facet facet = _userFacetFactory.newInstance(_searchContext);
 
+		facet.setAggregationName(_aggregationName);
+
 		facet.setFacetConfiguration(buildFacetConfiguration(facet));
 
 		facet.select(_selectedUserNames);
 
 		return facet;
+	}
+
+	public void setAggregationName(String aggregationName) {
+		_aggregationName = aggregationName;
 	}
 
 	public void setFrequencyThreshold(int frequencyThreshold) {
@@ -72,6 +78,7 @@ public class UserFacetBuilder {
 		return facetConfiguration;
 	}
 
+	private String _aggregationName;
 	private int _frequencyThreshold;
 	private int _maxTerms;
 	private SearchContext _searchContext;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetPortlet.java
@@ -14,8 +14,11 @@
 
 package com.liferay.portal.search.web.internal.user.facet.portlet;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.user.UserFacetFactory;
 import com.liferay.portal.search.web.internal.facet.display.builder.UserSearchFacetDisplayBuilder;
@@ -95,7 +98,8 @@ public class UserFacetPortlet extends MVCPortlet {
 		PortletSharedSearchResponse portletSharedSearchResponse,
 		RenderRequest renderRequest) {
 
-		Facet facet = portletSharedSearchResponse.getFacet(getFieldName());
+		Facet facet = portletSharedSearchResponse.getFacet(
+			getAggregationName(getPortletId(renderRequest)));
 
 		UserFacetConfiguration userFacetConfiguration =
 			new UserFacetConfigurationImpl(facet.getFacetConfiguration());
@@ -128,6 +132,10 @@ public class UserFacetPortlet extends MVCPortlet {
 		return userSearchFacetDisplayBuilder.build();
 	}
 
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
+	}
+
 	protected String getFieldName() {
 		Facet facet = userFacetFactory.newInstance(null);
 
@@ -146,10 +154,17 @@ public class UserFacetPortlet extends MVCPortlet {
 		return optional.map(Arrays::asList);
 	}
 
+	protected String getPortletId(RenderRequest renderRequest) {
+		return _portal.getPortletId(renderRequest);
+	}
+
 	@Reference
 	protected PortletSharedSearchRequest portletSharedSearchRequest;
 
 	@Reference
 	protected UserFacetFactory userFacetFactory;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/shared/search/UserFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/shared/search/UserFacetPortletSharedSearchContributor.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.web.internal.user.facet.portlet.shared.search;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.search.facet.user.UserFacetFactory;
 import com.liferay.portal.search.web.internal.user.facet.constants.UserFacetPortletKeys;
@@ -59,6 +61,8 @@ public class UserFacetPortletSharedSearchContributor
 		UserFacetBuilder userFacetBuilder = new UserFacetBuilder(
 			userFacetFactory);
 
+		userFacetBuilder.setAggregationName(
+			getAggregationName(portletSharedSearchSettings.getPortletId()));
 		userFacetBuilder.setFrequencyThreshold(
 			userFacetPortletPreferences.getFrequencyThreshold());
 		userFacetBuilder.setMaxTerms(userFacetPortletPreferences.getMaxTerms());
@@ -71,6 +75,10 @@ public class UserFacetPortletSharedSearchContributor
 			userFacetBuilder::setSelectedUserNames);
 
 		return userFacetBuilder.build();
+	}
+
+	protected String getAggregationName(String portletId) {
+		return Field.ASSET_CATEGORY_IDS + StringPool.PERIOD + portletId;
 	}
 
 	@Reference


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86345
https://issues.liferay.com/browse/LPP-31759

Problem: Facets, which are instanciable, mostly had their aggregationName unset, so they used their fieldnames instead [here]( https://github.com/joshuacords/liferay-portal/blob/fe829ea5f2fba5a437e3f931b1699eef07a64072/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/FacetImpl.java#L40-L44). This caused only the last facet of that type which was put into the map [here](https://github.com/joshuacords/liferay-portal/blob/5d96f83f51c246654441520ff19f8544278270a0/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchSettingsImpl.java#L53-L57) to apply. As there is no set order to the processing of facets, this would at time result in correct and incorrect filtering.

Solution: By recommendation from Andre, I've copied the pattern used by Custom Facet to name each facet in part based on their portletId to insure uniqueness.  I applied this change to all facets that allowed their Parameter name to be changed. (This excludes only the Modified Facet).