### PR TITLE
LPS-86452 Mobile view needs to be accounted for width

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_search_iterator.scss
@@ -68,7 +68,7 @@
 				> a {
 					line-height: 20px;
 					padding: 11px 19px;
-					width: 50%;
+					width: 65%;
 				}
 			}
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86452

Hello @SamZiemer,

The issue here is that the "previous" button for page iterators is not displayed consistently with its counterpart "next" button. The "previous" button is split into two lines because the value of the width property is set too small.

The fix is to increase the width to 65% as it was prior to the introduction of this SF commit: https://github.com/liferay/liferay-portal/commit/a3c710871d07a2f6783fe3523bc58124a8c1c8ac

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim