### PR TITLE
Ricky pan lps 86161

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.dao.orm.hibernate;
 
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONSerializer;
 import com.liferay.portal.kernel.model.BaseModel;
 
 import org.hibernate.Session;
@@ -43,8 +45,14 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
+			JSONSerializer jsonSerializer =
+				JSONFactoryUtil.createJSONSerializer();
+
+			String objStr = jsonSerializer.serialize(object);
+			String currObjStr = jsonSerializer.serialize(currentObject);
+
 			return new ORMException(
-				object + " is stale in comparison to " + currentObject, e);
+				objStr + " is stale in comparison to " + currObjStr, e);
 		}
 
 		return new ORMException(e);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86161
https://issues.liferay.com/browse/LPP-31681

This takes code modification to reproduce in master if you don't have a newer version of Intellij.

Notes from @ricky-pan:
> Issue: When Liferay encounters database-related exceptions regarding the User model, the entire model is stored into the logs, including the hashed password and the plaintext security question answer, as well as personal information such as name, birthday, and email. According to OWASP (Open Web Application Security Project), it is [good practice](https://www.owasp.org/index.php/Logging_Cheat_Sheet) to not ever log sensitive information, as is currently done in handling StaleObject exceptions.

> Solution: In the case of a StaleObject exception, I added a check that the logging level must be set to Debug for the model to be recorded. Specifically for stale User objects, I also obscure fields that may contain personal information. 