### PR TITLE
LPS-86440

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
@@ -33,6 +33,7 @@ import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -70,7 +71,7 @@ public class DDMFormFieldTemplateContextFactory {
 		_locale = ddmFormRenderingContext.getLocale();
 	}
 
-	public List<Object> create() {
+	public List<Object> create() throws PortalException {
 		return createDDMFormFieldTemplateContexts(
 			_ddmFormFieldValues, StringPool.BLANK);
 	}
@@ -132,9 +133,10 @@ public class DDMFormFieldTemplateContextFactory {
 	}
 
 	protected Map<String, Object> createDDMFormFieldTemplateContext(
-		DDMFormFieldValue ddmFormFieldValue,
-		Map<String, Object> changedProperties, int index,
-		String parentDDMFormFieldParameterName) {
+			DDMFormFieldValue ddmFormFieldValue,
+			Map<String, Object> changedProperties, int index,
+			String parentDDMFormFieldParameterName)
+		throws PortalException {
 
 		DDMFormField ddmFormField = _ddmFormFieldsMap.get(
 			ddmFormFieldValue.getName());
@@ -171,8 +173,9 @@ public class DDMFormFieldTemplateContextFactory {
 	}
 
 	protected List<Object> createDDMFormFieldTemplateContexts(
-		List<DDMFormFieldValue> ddmFormFieldValues,
-		String parentDDMFormFieldParameterName) {
+			List<DDMFormFieldValue> ddmFormFieldValues,
+			String parentDDMFormFieldParameterName)
+		throws PortalException {
 
 		List<Object> ddmFormFieldTemplateContexts = new ArrayList<>();
 
@@ -203,8 +206,9 @@ public class DDMFormFieldTemplateContextFactory {
 	}
 
 	protected Map<String, Object> createNestedDDMFormFieldTemplateContext(
-		DDMFormFieldValue parentDDMFormFieldValue,
-		String parentDDMFormFieldParameterName) {
+			DDMFormFieldValue parentDDMFormFieldValue,
+			String parentDDMFormFieldParameterName)
+		throws PortalException {
 
 		Map<String, Object> nestedDDMFormFieldTemplateContext = new HashMap<>();
 
@@ -283,7 +287,8 @@ public class DDMFormFieldTemplateContextFactory {
 	}
 
 	protected Map<String, Object> getChangedProperties(
-		DDMFormFieldValue ddmFormFieldValue) {
+			DDMFormFieldValue ddmFormFieldValue)
+		throws PortalException {
 
 		Map<String, Object> changedProperties =
 			_ddmFormFieldsPropertyChanges.get(
@@ -758,6 +763,7 @@ public class DDMFormFieldTemplateContextFactory {
 		_ddmFormFieldsPropertyChanges;
 	private DDMFormFieldTypeServicesTracker _ddmFormFieldTypeServicesTracker;
 	private final List<DDMFormFieldValue> _ddmFormFieldValues;
+	private DDMFormInstanceLocalServiceUtil _ddmFormInstanceLocalServiceUtil;
 	private final DDMFormRenderingContext _ddmFormRenderingContext;
 	private final Locale _locale;
 	private final boolean _pageEnabled;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
@@ -24,9 +24,12 @@ import com.liferay.dynamic.data.mapping.form.renderer.internal.util.DDMFormTempl
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidation;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -37,6 +40,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -291,9 +295,8 @@ public class DDMFormFieldTemplateContextFactory {
 			changedProperties = new HashMap<>();
 		}
 
-		if (!_pageEnabled) {
-			changedProperties.put("required", false);
-		}
+		setDDMFormFieldChangedPropertyRequired(
+			changedProperties, ddmFormFieldValue.getDDMFormField());
 
 		if (_ddmFormRenderingContext.isReadOnly()) {
 			changedProperties.put("readOnly", true);
@@ -320,6 +323,53 @@ public class DDMFormFieldTemplateContextFactory {
 		sb.append(index);
 
 		return sb.toString();
+	}
+
+	protected void setDDMFormFieldChangedPropertyRequired(
+			Map<String, Object> changedProperties,
+			DDMFormField currentDDMFormField)
+		throws PortalException {
+
+		long formInstanceId = ParamUtil.getLong(
+			_ddmFormRenderingContext.getHttpServletRequest(), "formInstanceId");
+
+		try {
+			if (!_pageEnabled) {
+				changedProperties.put("required", false);
+			}
+			else if (formInstanceId > 0) {
+				DDMFormInstance ddmFormInstance =
+					_ddmFormInstanceLocalServiceUtil.fetchDDMFormInstance(
+						formInstanceId);
+
+				if (ddmFormInstance != null) {
+					DDMStructure ddmStructure = ddmFormInstance.getStructure();
+
+					String ddmFormFieldName = currentDDMFormField.getName();
+
+					if (ddmStructure.hasField(ddmFormFieldName)) {
+						DDMFormField ddmFormField =
+							ddmStructure.getDDMFormField(ddmFormFieldName);
+
+						if (currentDDMFormField.isRequired() !=
+								ddmFormField.isRequired()) {
+
+							changedProperties.put(
+								"required", ddmFormField.isRequired());
+						}
+					}
+				}
+			}
+		}
+		catch (PortalException pe) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append("Unable to get DDM form instance or structure with ");
+			sb.append("form instance id ");
+			sb.append(formInstanceId);
+
+			throw new PortalException(sb.toString(), pe);
+		}
 	}
 
 	protected void setDDMFormFieldTemplateContextContributedParameters(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactory.java
@@ -28,6 +28,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -81,7 +82,7 @@ public class DDMFormPagesTemplateContextFactory {
 		_locale = ddmFormRenderingContext.getLocale();
 	}
 
-	public List<Object> create() {
+	public List<Object> create() throws PortalException {
 		_evaluate();
 
 		return createPagesTemplateContext(
@@ -111,7 +112,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected List<Object> createColumnsTemplateContext(
-		List<DDMFormLayoutColumn> ddmFormLayoutColumns) {
+			List<DDMFormLayoutColumn> ddmFormLayoutColumns)
+		throws PortalException {
 
 		List<Object> columnsTemplateContext = new ArrayList<>();
 
@@ -124,7 +126,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected Map<String, Object> createColumnTemplateContext(
-		DDMFormLayoutColumn ddmFormLayoutColumn) {
+			DDMFormLayoutColumn ddmFormLayoutColumn)
+		throws PortalException {
 
 		Map<String, Object> columnTemplateContext = new HashMap<>();
 
@@ -138,7 +141,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected List<Object> createFieldsTemplateContext(
-		List<String> ddmFormFieldNames) {
+			List<String> ddmFormFieldNames)
+		throws PortalException {
 
 		List<Object> fieldsTemplateContext = new ArrayList<>();
 
@@ -154,7 +158,9 @@ public class DDMFormPagesTemplateContextFactory {
 		return fieldsTemplateContext;
 	}
 
-	protected List<Object> createFieldTemplateContext(String ddmFormFieldName) {
+	protected List<Object> createFieldTemplateContext(String ddmFormFieldName)
+		throws PortalException {
+
 		DDMFormFieldTemplateContextFactory ddmFormFieldTemplateContextFactory =
 			new DDMFormFieldTemplateContextFactory(
 				_ddmFormFieldsMap,
@@ -170,7 +176,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected List<Object> createPagesTemplateContext(
-		List<DDMFormLayoutPage> ddmFormLayoutPages) {
+			List<DDMFormLayoutPage> ddmFormLayoutPages)
+		throws PortalException {
 
 		List<Object> pagesTemplateContext = new ArrayList<>();
 
@@ -185,7 +192,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected Map<String, Object> createPageTemplateContext(
-		DDMFormLayoutPage ddmFormLayoutPage, int pageIndex) {
+			DDMFormLayoutPage ddmFormLayoutPage, int pageIndex)
+		throws PortalException {
 
 		Map<String, Object> pageTemplateContext = new HashMap<>();
 
@@ -228,7 +236,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected List<Object> createRowsTemplateContext(
-		List<DDMFormLayoutRow> ddmFormLayoutRows) {
+			List<DDMFormLayoutRow> ddmFormLayoutRows)
+		throws PortalException {
 
 		List<Object> rowsTemplateContext = new ArrayList<>();
 
@@ -240,7 +249,8 @@ public class DDMFormPagesTemplateContextFactory {
 	}
 
 	protected Map<String, Object> createRowTemplateContext(
-		DDMFormLayoutRow ddmFormLayoutRow) {
+			DDMFormLayoutRow ddmFormLayoutRow)
+		throws PortalException {
 
 		Map<String, Object> rowTemplateContext = new HashMap<>();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
@@ -209,8 +209,9 @@ public class DDMFormTemplateContextFactoryImpl
 	}
 
 	protected List<Object> getPages(
-		DDMForm ddmForm, DDMFormLayout ddmFormLayout,
-		DDMFormRenderingContext ddmFormRenderingContext) {
+			DDMForm ddmForm, DDMFormLayout ddmFormLayout,
+			DDMFormRenderingContext ddmFormRenderingContext)
+		throws PortalException {
 
 		DDMFormPagesTemplateContextFactory ddmFormPagesTemplateContextFactory =
 			new DDMFormPagesTemplateContextFactory(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/form.js
@@ -97,7 +97,12 @@ AUI.add(
 
 						var languageId = instance.get('editingLanguageId');
 
+						var form = A.one('#' + portletNamespace + 'fm');
+
+						var formInstanceId = form.getAttribute('data-ddmforminstanceid');
+
 						return {
+							formInstanceId: formInstanceId,
 							languageId: languageId,
 							p_auth: Liferay.authToken,
 							portletNamespace: portletNamespace,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactoryTest.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.petra.string.StringPool;
@@ -34,8 +35,10 @@ import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsImpl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,6 +50,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.mockito.Matchers;
@@ -56,6 +60,11 @@ import org.mockito.Mockito;
  * @author Marcellus Tavares
  */
 public class DDMFormFieldTemplateContextFactoryTest {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	@Before
 	public void setUp() {
@@ -97,15 +106,8 @@ public class DDMFormFieldTemplateContextFactoryTest {
 
 		// Dynamic data mapping form values
 
-		List<DDMFormFieldValue> ddmFormFieldValues = new ArrayList<>();
-
-		DDMFormFieldValue ddmFormFieldValue =
-			DDMFormValuesTestUtil.createUnlocalizedDDMFormFieldValue(
-				"Field1", "Value 1");
-
-		ddmFormFieldValue.setInstanceId(instanceId);
-
-		ddmFormFieldValues.add(ddmFormFieldValue);
+		List<DDMFormFieldValue> ddmFormFieldValues = createDDMFormFieldValues(
+			instanceId, ddmForm);
 
 		DDMFormFieldTemplateContextFactory ddmFormFieldTemplateContextFactory =
 			createDDMFormFieldTemplateContextFactory(
@@ -158,15 +160,8 @@ public class DDMFormFieldTemplateContextFactoryTest {
 
 		// Dynamic data mapping form values
 
-		List<DDMFormFieldValue> ddmFormFieldValues = new ArrayList<>();
-
-		DDMFormFieldValue ddmFormFieldValue =
-			DDMFormValuesTestUtil.createUnlocalizedDDMFormFieldValue(
-				"Field1", "Value 1");
-
-		ddmFormFieldValue.setInstanceId(instanceId);
-
-		ddmFormFieldValues.add(ddmFormFieldValue);
+		List<DDMFormFieldValue> ddmFormFieldValues = createDDMFormFieldValues(
+			instanceId, ddmForm);
 
 		DDMFormFieldTemplateContextFactory ddmFormFieldTemplateContextFactory =
 			createDDMFormFieldTemplateContextFactory(
@@ -227,15 +222,8 @@ public class DDMFormFieldTemplateContextFactoryTest {
 
 		// Dynamic data mapping form values
 
-		List<DDMFormFieldValue> ddmFormFieldValues = new ArrayList<>();
-
-		DDMFormFieldValue ddmFormFieldValue =
-			DDMFormValuesTestUtil.createUnlocalizedDDMFormFieldValue(
-				"Field1", "Value 1");
-
-		ddmFormFieldValue.setInstanceId(instanceId);
-
-		ddmFormFieldValues.add(ddmFormFieldValue);
+		List<DDMFormFieldValue> ddmFormFieldValues = createDDMFormFieldValues(
+			instanceId, ddmForm);
 
 		DDMFormFieldTemplateContextFactory ddmFormFieldTemplateContextFactory =
 			createDDMFormFieldTemplateContextFactory(
@@ -311,6 +299,27 @@ public class DDMFormFieldTemplateContextFactoryTest {
 			ddmFormFieldTypeServicesTracker);
 
 		return ddmFormFieldTemplateContextFactory;
+	}
+
+	protected List<DDMFormFieldValue> createDDMFormFieldValues(
+		String instanceId, DDMForm ddmForm) {
+
+		List<DDMFormFieldValue> ddmFormFieldValues = new ArrayList<>();
+
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createUnlocalizedDDMFormFieldValue(
+				"Field1", "Value 1");
+
+		ddmFormFieldValue.setInstanceId(instanceId);
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		ddmFormFieldValue.setDDMFormValues(ddmFormValues);
+
+		ddmFormFieldValues.add(ddmFormFieldValue);
+
+		return ddmFormFieldValues;
 	}
 
 	protected DDMFormFieldRenderer getTextDDMFormFieldRenderer() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactoryTest.java
@@ -64,7 +64,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testNotReadOnlyTextFieldAndReadOnlyForm() {
+	public void testNotReadOnlyTextFieldAndReadOnlyForm() throws Exception {
 
 		// Dynamic data mapping form
 
@@ -125,7 +125,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testReadOnlyTextFieldAndNotReadOnlyForm() {
+	public void testReadOnlyTextFieldAndNotReadOnlyForm() throws Exception {
 
 		// Dynamic data mapping form
 
@@ -186,7 +186,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testTextField() {
+	public void testTextField() throws Exception {
 
 		// Dynamic data mapping form
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormPagesTemplateContextFactoryTest.java
@@ -47,12 +47,14 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.HtmlImpl;
+import com.liferay.portal.util.PropsImpl;
 import com.liferay.registry.BasicRegistryImpl;
 import com.liferay.registry.RegistryUtil;
 
@@ -70,6 +72,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -91,6 +94,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 	"com.liferay.portal.kernel.util.ResourceBundleLoaderUtil"
 )
 public class DDMFormPagesTemplateContextFactoryTest extends PowerMockito {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		PropsUtil.setProps(new PropsImpl());
+	}
 
 	@Before
 	public void setUp() {


### PR DESCRIPTION
### Explanation of changes in https://github.com/SamZiemer/liferay-portal/commit/368005853c1f0da830be65f7674435a9f71b3ddb

Since these are unit tests the portal does not need to be running like when performing integration tests. Due to that we need to make sure the classes we are utilizing are initialized properly. In https://github.com/SamZiemer/liferay-portal/commit/550bdcac5185ec330433d98e33f9bf240354e28e#diff-1fbfbd36b8c7387a347b33c5ad2c1c19R333 a dependency on `ParamUtil` was introduced. `ParamUtil` contains a [static block](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/util/ParamUtil.java#L2507-L2526) that relies on `PropsUtil`. When the portal is running normally, `PropsUtil` will have it's `_props` set correctly but since this is a unit test this does not occur.

In this case what we need to do is manually initialize `PropsUtil` with a value to avoid the NullPointerException.

This was discovered by the cause of the initial exception thrown for the first test run:

```
Caused by:
        java.lang.NullPointerException
            at com.liferay.portal.kernel.util.PropsUtil.get(PropsUtil.java:31)
            at com.liferay.portal.kernel.util.ParamUtil.<clinit>(ParamUtil.java:2508)
            ... 65 more
```

### Explanation of changes in https://github.com/SamZiemer/liferay-portal/commit/93f0f6a1291c83f177fdba2c21ac50bc433f0a4a

For this test, the following error was logged:

```
java.lang.NullPointerException
        at com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue.getDDMFormField(DDMFormFieldValue.java:71)
```

The call to `ddmFormFieldValue.getDDMFormField()` in https://github.com/SamZiemer/liferay-portal/commit/550bdcac5185ec330433d98e33f9bf240354e28e#diff-1fbfbd36b8c7387a347b33c5ad2c1c19R299 causes this exception to be raised since the `_ddmFormValues` have not been initialized.

If you guys have any questions please let me know.

/cc @diana-lin @joshuacords