### PR TITLE
Ricky pan lps 86161

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.dao.orm.hibernate;
 
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONSerializer;
 import com.liferay.portal.kernel.model.BaseModel;
 
 import org.hibernate.Session;
@@ -43,8 +45,14 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
+			JSONSerializer jsonSerializer =
+				JSONFactoryUtil.createJSONSerializer();
+
+			String objStr = jsonSerializer.serialize(object);
+			String currObjStr = jsonSerializer.serialize(currentObject);
+
 			return new ORMException(
-				object + " is stale in comparison to " + currentObject, e);
+				objStr + " is stale in comparison to " + currObjStr, e);
 		}
 
 		return new ORMException(e);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86161
https://issues.liferay.com/browse/LPP-31875

We've gone with a different approach. Since JSONWS already sensors some sensitive data, we're using that serializer to produce the desired output. 

See @ricky-pan notes [here](https://issues.liferay.com/browse/LPS-86161?focusedCommentId=1616423&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1616423)

An important detail is that the json serializer acts differently when an Admin user is accessing it versus when a default user is. In the later case, 5 more fields are blanked out in the output. In this PR, Ricky is using an Admin user to allow visibility of those fields. Alternately we could not set a permission checker at all and leave all the field blank, or we could base it on the User initializing the task which could be gotten by using `PrincipalThreadLocal.getUserId()` but this last option would result in inconsistent logging. I'm not to clear on how these permission issues should play out so I'll leave that to higher reviews.

NOTE: This needs to go through the Security Team and the customer is looking for a fix soon.