### PR TITLE
LPS-87175 Keep old nameMap from failing validateName during staging

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/model/listener/DDMStructureModelListener.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/model/listener/DDMStructureModelListener.java
@@ -17,6 +17,7 @@ package com.liferay.dynamic.data.lists.internal.model.listener;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
@@ -26,6 +27,10 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -79,10 +84,25 @@ public class DDMStructureModelListener extends BaseModelListener<DDMStructure> {
 
 				serviceContext.setUserId(defaultUserId);
 
+				Locale siteLocale = null;
+
+				if (ExportImportThreadLocal.isImportInProcess()) {
+					siteLocale = LocaleThreadLocal.getSiteDefaultLocale();
+
+					Locale stagingLocale = LocaleUtil.fromLanguageId(
+						ddmStructure.getDefaultLanguageId());
+
+					LocaleThreadLocal.setSiteDefaultLocale(stagingLocale);
+				}
+
 				_ddlRecordSetLocalService.updateRecordSet(
 					recordSet.getRecordSetId(), ddmStructure.getStructureId(),
 					recordSet.getNameMap(), recordSet.getDescriptionMap(),
 					recordSet.getMinDisplayRows(), serviceContext);
+
+				if (ExportImportThreadLocal.isImportInProcess()) {
+					LocaleThreadLocal.setSiteDefaultLocale(siteLocale);
+				}
 			});
 
 		return actionableDynamicQuery;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-32053
https://issues.liferay.com/browse/LPS-87175

This issue is masked in master by [this code](https://github.com/joshuacords/liferay-portal/blob/bf7bf545ccaa53be6ce44af2da75f49caac72722/portal-kernel/src/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerUtil.java#L530-L537) from [LPS-77336](https://issues.liferay.com/browse/LPS-77336) which catches an exception.

This exception is thrown because of this chain of events:
During the Import of a DDLRecordSet, a import starts for the referenced model of DDMStructure. The update on the DDMStructure triggers the onAfterUpdate method of the DDMStructureModelListener and the does a dynamicQuery in order to [update the DDLRecordSet](https://github.com/joshuacords/liferay-portal/blob/6c715baa8057be213d9754eddf9f7dc55e438568/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/model/listener/DDMStructureModelListener.java#L82-L85) associated with the DDMStructure. The update method is called and passes in the old record set's nameMap which in this case doesn't contain a locale for France, returns null, and will throw an exception in the Validate method [here](https://github.com/joshuacords/liferay-portal/blob/7e70020e7cf31704656bcd09b96485cbc32797ee/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetLocalServiceImpl.java#L966-L971). Note that the imported DDLRecord which has yet to be updated will contain to proper Locale because it is updated during the import process.

My fix is to change the locale to the import's default locale during the staging process to side step the Exception.

I've also considered the following 2 options but found them inferior:
1. Create a new method for DDLRecord that only updates the StructureID in the modelListener - the downside is we would need to change the API. It would look like [this](https://github.com/joshuacords/liferay-portal-ee/commits/JCords-LPS-87175).
2. Make a dynamic query inside the modelListener to update the DDLRecord directly