### PR TITLE
LPS-86805

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/WorkflowDefinitionLinkLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/WorkflowDefinitionLinkLocalServiceImpl.java
@@ -217,6 +217,7 @@ public class WorkflowDefinitionLinkLocalServiceImpl
 			throw new NoSuchWorkflowDefinitionLinkException();
 		}
 
+		groupId = StagingUtil.getLiveGroupId(groupId);
 		long classNameId = classNameLocalService.getClassNameId(className);
 
 		return workflowDefinitionLinkPersistence.findByG_C_C_C(
@@ -240,6 +241,8 @@ public class WorkflowDefinitionLinkLocalServiceImpl
 	@Override
 	public int getWorkflowDefinitionLinksCount(
 		long companyId, long groupId, String className) {
+
+		groupId = StagingUtil.getLiveGroupId(groupId);
 
 		return workflowDefinitionLinkPersistence.countByG_C_C(
 			groupId, companyId,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86805

Resolves an issue caused by my earlier fix LPS-85726 which causes the "submit for publication" button to not be visible, and instead a "ready for publication" slider to appear.  This is because when retrieving the workflowDefinitionLink, we search by the staging groupId, when in fact, workflows are only stored by the live groupIds, so nothing is returned.

You can see in other methods of the WorkflowDefinitionLinkLocalServiceImpl class, the groupId is transformed into the live groupId before fetching, deleting, updating, etc.

Let me know if you have any questions.  Thanks!