### PR TITLE
LPS-87782

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
@@ -20,6 +20,10 @@ AUI.add(
 			}
 		);
 
+		var isString = function(val) {
+			return typeof val == 'string';
+		};
+
 		var toInt = function(value) {
 			return Lang.toInt(value, 10, 0);
 		};
@@ -83,7 +87,12 @@ AUI.add(
 							var content = val;
 
 							if (val) {
-								content = LString.unescapeHTML(val);
+								if (isString(val)) {
+									content = LString.escapeHTML(val);
+								}
+								else {
+									content = LString.escapeHTML(val.toString());
+								}
 							}
 
 							return content;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87782

Hello @SamZiemer ,

The issue here is that, when a user tries to create a calendar event using the simple pop-up window (rather than using the detailed view that appears when you click edit) **and** the user inputs non-string values for the title, the event fails to be saved.

The reason for this issue is that, the simple event creation is being handled by scheduler_models.js in which the content attribute will be set to the value of the input title. However, an error will be thrown when the setter function is called because we always expect the title to be of type string.

The fix here is simple in that we need to check if the value of the title is a string, and if not, we need to convert it to a string before we allow the value to be passed onto the sanitization method.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim