### PR TITLE
LPS-87348

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -10,6 +10,16 @@ AUI.add(
 
 		var UA = A.UA;
 
+		window.addEventListener('dragover', function(event) {
+			event.preventDefault();
+		}, false);
+		window.addEventListener('drop', function(event) {
+			if (!event.target.isContentEditable &&
+				!confirm(Liferay.Language.get('this-page-is-asking-you-to-confirm-that-you-want-to-leave'))) {
+				event.preventDefault();
+			}
+		}, false);
+
 		var LiferayAlloyEditor = A.Component.create(
 			{
 				ATTRS: {

--- a/modules/apps/frontend-editor/frontend-editor-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/frontend-editor/frontend-editor-lang/src/main/resources/content/Language.properties
@@ -10,4 +10,5 @@ preformatted-text=Preformatted Text
 rich-text-editor=Rich Text Editor
 sorry,-this-platform-is-not-supported=Sorry, this platform is not supported.
 text-view=Text View
+this-page-is-asking-you-to-confirm-that-you-want-to-leave=This page is asking you to confirm that you want to leave. Any unsaved changes will be lost.
 video-playback-is-disabled-during-edit-mode=Video playback is disabled during edit mode.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87348

Hello @SamZiemer ,

The issue here is that, browsers will by default try to download or open files.

This default behavior of browsers become an issue when a user is creating content or editing existing content through Liferay's AlloyEditor. If a user drops a media file, for ex. an image or a video, but accidentally drops the said file into non-editable areas where AlloyEditor's drag&drop listeners are not triggered, the default browser behavior will be triggered and the file will be opened in the browser.

The problem with this is that users will lose all unsaved progress.

My fix is an implementation of the suggestion made here: liferay/alloy-editor#903 (comment). If a file is dropped in non-editable areas, an alert will ask the user whether they would like to proceed and warn that unsaved changes will be lost.

For the language key message itself, we have to implictly tell users that the default browser behavior will be triggered if the content is dropped on non-editable areas. The current iteration of the message was an attempt to minimize the potential wordiness and still retain the clarity.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim