### PR TITLE
LPS-88185

### DIFF
--- a/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
+++ b/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
@@ -305,6 +305,8 @@ public class SiteBrowserDisplayContext {
 				"p_u_i_d", String.valueOf(selUser.getUserId()));
 		}
 
+		boolean filterManageableGroups = ParamUtil.getBoolean(
+			_request, "filterManageableGroups", true);
 		boolean includeCompany = ParamUtil.getBoolean(
 			_request, "includeCompany");
 		boolean includeCurrentGroup = ParamUtil.getBoolean(
@@ -321,6 +323,8 @@ public class SiteBrowserDisplayContext {
 		portletURL.setParameter("types", _getTypes());
 		portletURL.setParameter("displayStyle", getDisplayStyle());
 		portletURL.setParameter("filter", _getFilter());
+		portletURL.setParameter(
+			"filterManageableGroups", String.valueOf(filterManageableGroups));
 		portletURL.setParameter(
 			"includeCompany", String.valueOf(includeCompany));
 		portletURL.setParameter(


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-32339
https://issues.liferay.com/browse/LPS-88185

If a user has permission to assign Site membership but is not a (regular) administrator, then when attempting to load assign a site to a user in an organization, the sites will show at first in the popup, but searching or using pagination will cause the results to no longer appear.

This is because the "filterManageableGroups" flag which is in the request for managing users in this way is not persisted in the portletURL -- so subsequent navigating or searching in the popup will filter manageable groups as it would otherwise.

I am not sure whether this might put this flag into the request for other types of actions using this popup. However, I noted that every instance of retrieving it from the request already assumes it to be true by default, so my reasoning is that this should not change any behavior unless there are also other instances where the variable is lost on subsequent requests.

Please let me know if there are any concerns about this. Thanks.