### PR TITLE
LPS-88316

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/DisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/portlet/DisplayPageFriendlyURLResolver.java
@@ -97,8 +97,15 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 			FriendlyURLNormalizerUtil.normalizeWithEncoding(decodedUrlTitle);
 
 		JournalArticle journalArticle =
-			_journalArticleLocalService.getLatestArticleByUrlTitle(
+			_journalArticleLocalService.fetchLatestArticleByUrlTitle(
 				groupId, normalizedUrlTitle, WorkflowConstants.STATUS_APPROVED);
+
+		if (journalArticle == null) {
+			journalArticle =
+				_journalArticleLocalService.getLatestArticleByUrlTitle(
+					groupId, normalizedUrlTitle,
+					WorkflowConstants.STATUS_PENDING);
+		}
 
 		Map<Locale, String> friendlyURLMap = journalArticle.getFriendlyURLMap();
 
@@ -157,8 +164,15 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 			FriendlyURLNormalizerUtil.normalizeWithEncoding(decodedUrlTitle);
 
 		JournalArticle journalArticle =
-			_journalArticleLocalService.getLatestArticleByUrlTitle(
+			_journalArticleLocalService.fetchLatestArticleByUrlTitle(
 				groupId, normalizedUrlTitle, WorkflowConstants.STATUS_APPROVED);
+
+		if (journalArticle == null) {
+			journalArticle =
+				_journalArticleLocalService.getLatestArticleByUrlTitle(
+					groupId, normalizedUrlTitle,
+					WorkflowConstants.STATUS_PENDING);
+		}
 
 		Map<Locale, String> friendlyURLMap = journalArticle.getFriendlyURLMap();
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-32287
https://issues.liferay.com/browse/LPS-88316

Using the "View in Context" link under My Workflow Tasks for a pending article (with a configured display page) does not work if there are no approved versions of that article.

This is due to changes to both the `getActualURL()` and `getJournalArticleLayout()` methods in two previous changes:

https://github.com/liferay/liferay-portal/commit/ffc21d1ab6e48cae397f1581bf154e1d533473dc#diff-88404608066b298ac8f681687363f86b
https://github.com/liferay/liferay-portal/commit/f418247eb9212e7338c0b2b2bade439306428475#diff-88404608066b298ac8f681687363f86b

With these changes, only approved versions can be viewed in context this way. However, we believe this is not correct, as it renders the "View in Context" link for workflow tasks non-functional unless there are already previously approved versions.

An alternative fix could be to simply disable this feature for articles that do not have an approved version. However, from my own understanding it should work for any pending content, so we are going with this.

To prevent making content accessible through the friendlyURL that should not be (i.e., trashed or expired articles), I only added an extra case for pending articles, but not other statuses.

Please let me know if this can be improved, or if there are any problems or misunderstandings with this fix. Thank you.