### PR TITLE
LPS-88427 Fix ordering of parameters for LocalizationImpl.getLocalizationXmlFromPreferences

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
@@ -597,7 +597,7 @@ public class LocalizationImpl implements Localization {
 		String parameter, String defaultValue) {
 
 		return getLocalizationXmlFromPreferences(
-			preferences, portletRequest, parameter, defaultValue, null);
+			preferences, portletRequest, parameter, null, defaultValue);
 	}
 
 	@Override


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-88427

This was caused by this source formatting commit that failed to update the method call. https://github.com/joshuacords/liferay-portal/commit/8e5518b6669a3aa6079b235d912e932df73ba592#diff-1dc9657b6f38affe721f82bb7475b21aL499

Notes from @diana-lin 

> **Problem**:  In 6.2, [LocalizationImpl.getLocalizationXmlFromPreferences (6.2.x)](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java#L483-L517) returns the value passed in the parameter `defaultValue` if the portlet preferences are empty.  In master, the [LocalizationImpl.getLocalizationXmlFromPreferences (master)](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java#L594-L645) returns `null` if the portlet preferences are empty.
> 
> When looking at the implementation, it is apparent that the order of parameters is incorrect ([ref](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java#L594-L645)).  Notice the order of input parameters `prefix` and `defaultValue` in the method signature
> 
> ```
> public String getLocalizationXmlFromPreferences(
> 		PortletPreferences preferences, PortletRequest portletRequest,
> 		String parameter, String prefix, String defaultValue) {
>           ...
> }
> ```
> 
> in comparison to the input parameters `prefix` and `defaultValue` in the method call
> 
> ```
> @Override
> public String getLocalizationXmlFromPreferences(
> 	PortletPreferences preferences, PortletRequest portletRequest,
> 	String parameter, String defaultValue) {
> 
> 	return getLocalizationXmlFromPreferences(
> 		preferences, portletRequest, parameter, defaultValue, null);
> }
> ```
> 
> **Solution**:  Change the order of the input parameters `null` and `defaultValue` in the method call.