### PR TITLE
J cords lps 88424

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7113,49 +7113,71 @@ public class JournalArticleLocalServiceImpl
 
 		List<JournalArticle> latestArticles = new ArrayList<>();
 
-		List<JournalArticle> articles = journalArticleFinder.findByReviewDate(
-			JournalArticleConstants.CLASSNAME_ID_DEFAULT, reviewDate,
-			_previousCheckDate);
+		final ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (JournalArticle article : articles) {
-			if (article.isInTrash()) {
-				continue;
-			}
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property classNameIdProperty = PropertyFactoryUtil.forName(
+					"classNameId");
 
-			long groupId = article.getGroupId();
-			String articleId = article.getArticleId();
-			double version = article.getVersion();
+				dynamicQuery.add(
+					classNameIdProperty.eq(
+						JournalArticleConstants.CLASSNAME_ID_DEFAULT));
 
-			if (!journalArticleLocalService.isLatestVersion(
-					groupId, articleId, version)) {
+				Property reviewDateProperty = PropertyFactoryUtil.forName(
+					"reviewDate");
 
-				article = journalArticleLocalService.getLatestArticle(
-					groupId, articleId);
-			}
+				dynamicQuery.add(reviewDateProperty.le(reviewDate));
 
-			if (!latestArticles.contains(article)) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Sending review notification for article " +
-							article.getId());
+				dynamicQuery.add(reviewDateProperty.ge(_previousCheckDate));
+			});
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle article) -> {
+				if (!article.isInTrash()) {
+					long groupId = article.getGroupId();
+					String articleId = article.getArticleId();
+					double version = article.getVersion();
+
+					if (!journalArticleLocalService.isLatestVersion(
+							groupId, articleId, version)) {
+
+						article = journalArticleLocalService.getLatestArticle(
+							groupId, articleId);
+					}
+
+					if (!latestArticles.contains(article)) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(
+								"Sending review notification for article " +
+									article.getId());
+						}
+
+						latestArticles.add(article);
+
+						String portletId = PortletProviderUtil.getPortletId(
+							JournalArticle.class.getName(),
+							PortletProvider.Action.EDIT);
+
+						String articleURL = PortalUtil.getControlPanelFullURL(
+							article.getGroupId(), portletId, null);
+
+						articleURL = buildArticleURL(
+							articleURL, article.getGroupId(),
+							article.getFolderId(), article.getArticleId());
+
+						sendEmail(
+							article, articleURL, "review",
+							new ServiceContext());
+					}
 				}
+			});
 
-				latestArticles.add(article);
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
-				String portletId = PortletProviderUtil.getPortletId(
-					JournalArticle.class.getName(),
-					PortletProvider.Action.EDIT);
-
-				String articleURL = PortalUtil.getControlPanelFullURL(
-					article.getGroupId(), portletId, null);
-
-				articleURL = buildArticleURL(
-					articleURL, article.getGroupId(), article.getFolderId(),
-					article.getArticleId());
-
-				sendEmail(article, articleURL, "review", new ServiceContext());
-			}
-		}
+		actionableDynamicQuery.performActions();
 	}
 
 	protected void checkStructure(Document contentDocument, DDMForm ddmForm)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6978,28 +6978,47 @@ public class JournalArticleLocalServiceImpl
 		String portletId = PortletProviderUtil.getPortletId(
 			JournalArticle.class.getName(), PortletProvider.Action.EDIT);
 
-		List<JournalArticle> articles = journalArticlePersistence.findByLtD_S(
-			displayDate, WorkflowConstants.STATUS_SCHEDULED);
+		final ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (JournalArticle article : articles) {
-			long userId = PortalUtil.getValidUserId(
-				article.getCompanyId(), article.getUserId());
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property statusProperty = PropertyFactoryUtil.forName("status");
 
-			ServiceContext serviceContext = new ServiceContext();
+				dynamicQuery.add(
+					statusProperty.eq(WorkflowConstants.STATUS_SCHEDULED));
 
-			serviceContext.setCommand(Constants.UPDATE);
+				Property displayDateProperty = PropertyFactoryUtil.forName(
+					"displayDate");
 
-			String layoutFullURL = PortalUtil.getLayoutFullURL(
-				article.getGroupId(), portletId);
+				dynamicQuery.add(displayDateProperty.lt(displayDate));
+			});
 
-			serviceContext.setLayoutFullURL(layoutFullURL);
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle article) -> {
+				long userId = PortalUtil.getValidUserId(
+					article.getCompanyId(), article.getUserId());
 
-			serviceContext.setScopeGroupId(article.getGroupId());
+				ServiceContext serviceContext = new ServiceContext();
 
-			journalArticleLocalService.updateStatus(
-				userId, article, WorkflowConstants.STATUS_APPROVED, null,
-				serviceContext, new HashMap<String, Serializable>());
-		}
+				serviceContext.setCommand(Constants.UPDATE);
+
+				String layoutFullURL = PortalUtil.getLayoutFullURL(
+					article.getGroupId(), portletId);
+
+				serviceContext.setLayoutFullURL(layoutFullURL);
+
+				serviceContext.setScopeGroupId(article.getGroupId());
+
+				journalArticleLocalService.updateStatus(
+					userId, article, WorkflowConstants.STATUS_APPROVED, null,
+					serviceContext, new HashMap<String, Serializable>());
+			});
+
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.performActions();
 	}
 
 	protected void checkArticlesByExpirationDate(Date expirationDate)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7098,6 +7098,8 @@ public class JournalArticleLocalServiceImpl
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
+		actionableDynamicQuery.setInterval(1000);
+
 		actionableDynamicQuery.performActions();
 
 		if (_previousCheckDate == null) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7018,7 +7018,7 @@ public class JournalArticleLocalServiceImpl
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
-		actionableDynamicQuery.setInterval(1000);
+		actionableDynamicQuery.setInterval(_INTERVAL);
 
 		actionableDynamicQuery.performActions();
 	}
@@ -7119,7 +7119,7 @@ public class JournalArticleLocalServiceImpl
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
-		actionableDynamicQuery.setInterval(1000);
+		actionableDynamicQuery.setInterval(_INTERVAL);
 
 		actionableDynamicQuery.performActions();
 
@@ -7182,7 +7182,7 @@ public class JournalArticleLocalServiceImpl
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
-		actionableDynamicQuery.setInterval(1000);
+		actionableDynamicQuery.setInterval(_INTERVAL);
 
 		actionableDynamicQuery.performActions();
 
@@ -8980,6 +8980,8 @@ public class JournalArticleLocalServiceImpl
 		return journalArticleLocalizationPersistence.update(
 			journalArticleLocalization);
 	}
+
+	private static final int _INTERVAL = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleLocalServiceImpl.class);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7130,47 +7130,31 @@ public class JournalArticleLocalServiceImpl
 
 				dynamicQuery.add(reviewDateProperty.le(reviewDate));
 
-				dynamicQuery.add(reviewDateProperty.ge(_previousCheckDate));
+				if (_previousCheckDate != null) {
+					dynamicQuery.add(reviewDateProperty.ge(_previousCheckDate));
+				}
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				dynamicQuery.add(
+					statusProperty.ne(WorkflowConstants.STATUS_IN_TRASH));
 			});
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
-				if (!article.isInTrash()) {
-					long groupId = article.getGroupId();
-					String articleId = article.getArticleId();
-					double version = article.getVersion();
+				long groupId = article.getGroupId();
+				String articleId = article.getArticleId();
+				double version = article.getVersion();
 
-					if (!journalArticleLocalService.isLatestVersion(
-							groupId, articleId, version)) {
+				if (!journalArticleLocalService.isLatestVersion(
+						groupId, articleId, version)) {
 
-						article = journalArticleLocalService.getLatestArticle(
-							groupId, articleId);
-					}
+					article = journalArticleLocalService.getLatestArticle(
+						groupId, articleId);
+				}
 
-					if (!latestArticles.contains(article)) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(
-								"Sending review notification for article " +
-									article.getId());
-						}
-
-						latestArticles.add(article);
-
-						String portletId = PortletProviderUtil.getPortletId(
-							JournalArticle.class.getName(),
-							PortletProvider.Action.EDIT);
-
-						String articleURL = PortalUtil.getControlPanelFullURL(
-							article.getGroupId(), portletId, null);
-
-						articleURL = buildArticleURL(
-							articleURL, article.getGroupId(),
-							article.getFolderId(), article.getArticleId());
-
-						sendEmail(
-							article, articleURL, "review",
-							new ServiceContext());
-					}
+				if (!latestArticles.contains(article)) {
+					latestArticles.add(article);
 				}
 			});
 
@@ -7178,6 +7162,27 @@ public class JournalArticleLocalServiceImpl
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
 		actionableDynamicQuery.performActions();
+
+		for (JournalArticle journalArticle : latestArticles) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Sending review notification for article " +
+						journalArticle.getId());
+			}
+
+			String portletId = PortletProviderUtil.getPortletId(
+				JournalArticle.class.getName(), PortletProvider.Action.EDIT);
+
+			String articleURL = PortalUtil.getControlPanelFullURL(
+				journalArticle.getGroupId(), portletId, null);
+
+			articleURL = buildArticleURL(
+				articleURL, journalArticle.getGroupId(),
+				journalArticle.getFolderId(), journalArticle.getArticleId());
+
+			sendEmail(
+				journalArticle, articleURL, "review", new ServiceContext());
+		}
 	}
 
 	protected void checkStructure(Document contentDocument, DDMForm ddmForm)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -71,7 +71,11 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.xml.XMLUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.comment.CommentManager;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Order;
+import com.liferay.portal.kernel.dao.orm.OrderFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
@@ -7001,52 +7005,100 @@ public class JournalArticleLocalServiceImpl
 	protected void checkArticlesByExpirationDate(Date expirationDate)
 		throws PortalException {
 
-		List<JournalArticle> articles =
-			journalArticleFinder.findByExpirationDate(
-				JournalArticleConstants.CLASSNAME_ID_DEFAULT,
-				new Date(expirationDate.getTime() + getArticleCheckInterval()),
-				new QueryDefinition<JournalArticle>(
-					WorkflowConstants.STATUS_APPROVED));
+		long checkInterval = getArticleCheckInterval();
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("Expiring " + articles.size() + " articles");
-		}
+		final ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (JournalArticle article : articles) {
-			if (isExpireAllArticleVersions(article.getCompanyId())) {
-				List<JournalArticle> currentArticles =
-					journalArticlePersistence.findByG_A(
-						article.getGroupId(), article.getArticleId(),
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-						new ArticleVersionComparator(true));
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property classNameIdProperty = PropertyFactoryUtil.forName(
+					"classNameId");
 
-				for (JournalArticle currentArticle : currentArticles) {
-					if ((currentArticle.getExpirationDate() == null) ||
-						(currentArticle.getVersion() > article.getVersion())) {
+				dynamicQuery.add(
+					classNameIdProperty.eq(
+						JournalArticleConstants.CLASSNAME_ID_DEFAULT));
 
-						continue;
-					}
+				Property statusProperty = PropertyFactoryUtil.forName("status");
 
-					currentArticle.setExpirationDate(
-						article.getExpirationDate());
-					currentArticle.setStatus(WorkflowConstants.STATUS_EXPIRED);
+				dynamicQuery.add(
+					statusProperty.eq(WorkflowConstants.STATUS_APPROVED));
 
-					journalArticlePersistence.update(currentArticle);
+				Property expirationDateProperty = PropertyFactoryUtil.forName(
+					"expirationDate");
+
+				dynamicQuery.add(
+					expirationDateProperty.le(
+						new Date(expirationDate.getTime() + checkInterval)));
+			});
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle article) -> {
+				if (isExpireAllArticleVersions(article.getCompanyId())) {
+					final ActionableDynamicQuery actionableDynamicQueryByG_A =
+						getActionableDynamicQuery();
+
+					actionableDynamicQueryByG_A.setAddCriteriaMethod(
+						dynamicQuery -> {
+							Property groupIdProperty =
+								PropertyFactoryUtil.forName("groupId");
+
+							dynamicQuery.add(
+								groupIdProperty.eq(article.getGroupId()));
+
+							Property articleIdProperty =
+								PropertyFactoryUtil.forName("articleId");
+
+							dynamicQuery.add(
+								articleIdProperty.eq(article.getArticleId()));
+
+							Property expirationDateProperty =
+								PropertyFactoryUtil.forName("expirationDate");
+
+							dynamicQuery.add(
+								expirationDateProperty.isNotNull());
+
+							Property versionProperty =
+								PropertyFactoryUtil.forName("version");
+
+							dynamicQuery.add(
+								versionProperty.lt(article.getVersion()));
+
+							Order order = OrderFactoryUtil.asc("modifiedDate");
+
+							dynamicQuery.addOrder(order);
+						});
+
+					actionableDynamicQueryByG_A.setPerformActionMethod(
+						(JournalArticle currentArticle) -> {
+							currentArticle.setExpirationDate(
+								article.getExpirationDate());
+							currentArticle.setStatus(
+								WorkflowConstants.STATUS_EXPIRED);
+
+							journalArticlePersistence.update(currentArticle);
+						});
+
+					actionableDynamicQueryByG_A.performActions();
 				}
-			}
-			else {
+
 				article.setStatus(WorkflowConstants.STATUS_EXPIRED);
 
 				journalArticlePersistence.update(article);
-			}
 
-			updatePreviousApprovedArticle(article);
+				updatePreviousApprovedArticle(article);
 
-			Indexer<JournalArticle> indexer =
-				IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class);
+				Indexer<JournalArticle> indexer =
+					IndexerRegistryUtil.nullSafeGetIndexer(
+						JournalArticle.class);
 
-			indexer.reindex(article);
-		}
+				indexer.reindex(article);
+			});
+
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.performActions();
 
 		if (_previousCheckDate == null) {
 			_previousCheckDate = new Date(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7018,6 +7018,8 @@ public class JournalArticleLocalServiceImpl
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
+		actionableDynamicQuery.setInterval(1000);
+
 		actionableDynamicQuery.performActions();
 	}
 
@@ -7179,6 +7181,8 @@ public class JournalArticleLocalServiceImpl
 
 		actionableDynamicQuery.setTransactionConfig(
 			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.setInterval(1000);
 
 		actionableDynamicQuery.performActions();
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
@@ -78,7 +78,16 @@ public class CheckArticleMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		_journalArticleLocalService.checkArticles();
+		if (!_checkingArticles) {
+			_checkingArticles = true;
+
+			try {
+				_journalArticleLocalService.checkArticles();
+			}
+			finally {
+				_checkingArticles = false;
+			}
+		}
 	}
 
 	@Reference(unbind = "-")
@@ -100,6 +109,7 @@ public class CheckArticleMessageListener extends BaseMessageListener {
 		_schedulerEngineHelper = schedulerEngineHelper;
 	}
 
+	private boolean _checkingArticles;
 	private JournalArticleLocalService _journalArticleLocalService;
 	private SchedulerEngineHelper _schedulerEngineHelper;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88424
https://issues.liferay.com/browse/LPP-32391

Most of the changes is simply converting the methods to dynamic queries, there is some minor optimizations included. I choose 1000 as the interval because in testing a DB2 Database with logs set to:
 logprimary = 3 and logsecond = 10 (which is a default setting) was failing to complete these transactions long before the 10,000 standard interval. However, with the interval of 1000, it was passing.