### PR TITLE
LPS-88577 Use index-based searching in site memberships for organizations

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsDisplayContext.java
@@ -26,6 +26,11 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -33,6 +38,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.sitesadmin.search.OrganizationSiteMembershipChecker;
 import com.liferay.portlet.usersadmin.search.OrganizationSearch;
 import com.liferay.portlet.usersadmin.search.OrganizationSearchTerms;
@@ -165,13 +171,16 @@ public class SelectOrganizationsDisplayContext {
 		return _orderByType;
 	}
 
-	public SearchContainer getOrganizationSearchContainer() {
+	public SearchContainer getOrganizationSearchContainer() throws Exception {
 		if (_organizationSearch != null) {
 			return _organizationSearch;
 		}
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
 			WebKeys.THEME_DISPLAY);
+
+		long parentOrganizationId =
+			OrganizationConstants.ANY_PARENT_ORGANIZATION_ID;
 
 		OrganizationSearch organizationSearch = new OrganizationSearch(
 			_renderRequest, getPortletURL());
@@ -187,25 +196,48 @@ public class SelectOrganizationsDisplayContext {
 		LinkedHashMap<String, Object> organizationParams =
 			new LinkedHashMap<>();
 
-		int organizationsCount = OrganizationLocalServiceUtil.searchCount(
-			themeDisplay.getCompanyId(),
-			OrganizationConstants.ANY_PARENT_ORGANIZATION_ID,
-			searchTerms.getKeywords(), searchTerms.getType(),
-			searchTerms.getRegionIdObj(), searchTerms.getCountryIdObj(),
-			organizationParams);
+		String keywords = searchTerms.getKeywords();
+		
+		List<Organization> results = null;
+		int total = 0;
 
-		organizationSearch.setTotal(organizationsCount);
+		Indexer<?> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			Organization.class);
 
-		List<Organization> organizations = OrganizationLocalServiceUtil.search(
-			themeDisplay.getCompanyId(),
-			OrganizationConstants.ANY_PARENT_ORGANIZATION_ID,
-			searchTerms.getKeywords(), searchTerms.getType(),
-			searchTerms.getRegionIdObj(), searchTerms.getCountryIdObj(),
-			organizationParams, organizationSearch.getStart(),
-			organizationSearch.getEnd(),
-			organizationSearch.getOrderByComparator());
+		if (indexer.isIndexerEnabled() &&
+			PropsValues.ORGANIZATIONS_SEARCH_WITH_INDEX) {
 
-		organizationSearch.setResults(organizations);
+			organizationParams.put("expandoAttributes", keywords);
+
+			Sort sort = SortFactoryUtil.getSort(
+				Organization.class, organizationSearch.getOrderByCol(),
+				organizationSearch.getOrderByType());
+
+			BaseModelSearchResult<Organization> baseModelSearchResult =
+				OrganizationLocalServiceUtil.searchOrganizations(
+					themeDisplay.getCompanyId(), parentOrganizationId, keywords,
+					organizationParams, organizationSearch.getStart(),
+					organizationSearch.getEnd(), sort);
+
+			results = baseModelSearchResult.getBaseModels();
+			total = baseModelSearchResult.getLength();
+		}
+		else {
+			total = OrganizationLocalServiceUtil.searchCount(
+				themeDisplay.getCompanyId(), parentOrganizationId, keywords,
+				searchTerms.getType(), searchTerms.getRegionIdObj(),
+				searchTerms.getCountryIdObj(), organizationParams);
+
+			results = OrganizationLocalServiceUtil.search(
+				themeDisplay.getCompanyId(), parentOrganizationId, keywords,
+				searchTerms.getType(), searchTerms.getRegionIdObj(),
+				searchTerms.getCountryIdObj(), organizationParams,
+				organizationSearch.getStart(), organizationSearch.getEnd(),
+				organizationSearch.getOrderByComparator());
+		}
+
+		organizationSearch.setResults(results);
+		organizationSearch.setTotal(total);
 
 		_organizationSearch = organizationSearch;
 
@@ -262,7 +294,7 @@ public class SelectOrganizationsDisplayContext {
 		return sortingURL.toString();
 	}
 
-	public int getTotalItems() {
+	public int getTotalItems() throws Exception {
 		SearchContainer organizationSearchContainer =
 			getOrganizationSearchContainer();
 
@@ -285,7 +317,7 @@ public class SelectOrganizationsDisplayContext {
 		};
 	}
 
-	public boolean isDisabledManagementBar() {
+	public boolean isDisabledManagementBar() throws Exception {
 		if (getTotalItems() <= 0) {
 			return true;
 		}
@@ -293,7 +325,7 @@ public class SelectOrganizationsDisplayContext {
 		return false;
 	}
 
-	public boolean isShowSearch() {
+	public boolean isShowSearch() throws Exception {
 		if (getTotalItems() > 0) {
 			return true;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88577

Hello @SamZiemer ,

The issue here is that when a user searches using a keyword for an organization in Site Memberships, the behavior is inconsistent with how a user searches using a keyword for an organization in Users and Organizations. 

The reason for this issue is that [getOrganizationSearchContainer()](https://github.com/liferay/liferay-portal/blob/6d0744b64c2125ee99eaecb71bfe4f5db8b46a4e/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsDisplayContext.java#L168) for Site Memberships is not using index-based searching (the implementation is completely missing from the method) when the portal property [organizations.search.with.index](https://github.com/liferay/liferay-portal/blob/6d0744b64c2125ee99eaecb71bfe4f5db8b46a4e/portal-impl/src/portal.properties#L2627) is set to True (It is set to True by default).

The fix is straightforward in that index-based searching needs to be implemented.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim