### PR TITLE
LPS-88636 Implement search for site role selection

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -16,6 +16,7 @@
 
 <%
 String p_u_i_d = ParamUtil.getString(request, "p_u_i_d");
+String keywords = ParamUtil.getString(request, "keywords");
 int step = ParamUtil.getInteger(request, "step", 1);
 String displayStyle = ParamUtil.getString(request, "displayStyle", "list");
 String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectSiteRole");
@@ -40,6 +41,14 @@ if (step == 1) {
 		uniqueGroupId = groups.get(0).getGroupId();
 	}
 }
+
+LinkedHashMap<String, Object> groupParams = new LinkedHashMap<>();
+
+groupParams.put("inherit", Boolean.FALSE);
+groupParams.put("site", Boolean.TRUE);
+groupParams.put("usersGroups", selUser.getUserId());
+
+groups = GroupLocalServiceUtil.search(user.getCompanyId(), keywords, groupParams, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 SelectRoleManagementToolbarDisplayContext SelectRoleManagementToolbarDisplayContext = new SelectRoleManagementToolbarDisplayContext(request, renderRequest, renderResponse, eventName);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88636

Hello @SamZiemer ,

The issue is that search does not work when a user tries to filter sites in site role selection using keywords.

The reason for this issue is that we did not implement search functionality even though we provide a search bar for site role selection.

The solution is to provide search functionality similar to the ones that we can see working during a regular role selection and organization role selection.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim