### PR TITLE
J cords lps 80996 2

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -1,3 +1,5 @@
+<%@ page import="com.liferay.portal.util.HtmlImpl" %>
+
 <%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
@@ -91,7 +93,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 				<h1>
 					<liferay-ui:input-editor
 						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escape(HtmlUtil.unescape(ddmFormAdminDisplayContext.getFormName())) %>"
+						contents="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormName(), HtmlImpl.ESCAPE_MODE_ATTRIBUTE) %>"
 						cssClass="ddm-form-name"
 						editorName="alloyeditor"
 						name="nameEditor"
@@ -105,7 +107,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 				<h5>
 					<liferay-ui:input-editor
 						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escape(HtmlUtil.unescape(ddmFormAdminDisplayContext.getFormDescription())) %>"
+						contents="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormDescription(), HtmlImpl.ESCAPE_MODE_ATTRIBUTE) %>"
 						cssClass="ddm-form-description h5"
 						editorName="alloyeditor"
 						name="descriptionEditor"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -64,6 +64,7 @@ page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.portal.util.HtmlImpl" %><%@
 page import="com.liferay.taglib.search.DateSearchEntry" %><%@
 page import="com.liferay.taglib.search.ResultRow" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/form_portlet.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/form_portlet.js
@@ -452,6 +452,14 @@ AUI.add(
 
 						var state = instance.getState();
 
+						Object.keys(state.description).forEach(function(key) {
+							state.description[key] = Liferay.Util.unescape(state.description[key]);
+						});
+
+						Object.keys(state.name).forEach(function(key) {
+							state.name[key] = Liferay.Util.unescape(state.name[key]);
+						});
+
 						instance.one('#description').val(JSON.stringify(state.description));
 						instance.one('#name').val(JSON.stringify(state.name));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/metal/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/metal/edit_form_instance.jsp
@@ -109,7 +109,7 @@ if (!isFormPublished && isFormSaved) {
 				<h1>
 					<liferay-ui:input-editor
 						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escape(HtmlUtil.unescape(ddmFormAdminDisplayContext.getFormName())) %>"
+						contents="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormName(), HtmlImpl.ESCAPE_MODE_ATTRIBUTE) %>"
 						cssClass="ddm-form-name"
 						editorName="alloyeditor"
 						name="nameEditor"
@@ -121,7 +121,7 @@ if (!isFormPublished && isFormSaved) {
 				<h5>
 					<liferay-ui:input-editor
 						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escape(HtmlUtil.unescape(ddmFormAdminDisplayContext.getFormDescription())) %>"
+						contents="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormDescription(), HtmlImpl.ESCAPE_MODE_ATTRIBUTE) %>"
 						cssClass="ddm-form-description h5"
 						editorName="alloyeditor"
 						name="descriptionEditor"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80996
https://issues.liferay.com/browse/LPS-84637

The original fix for this ticket https://github.com/brianchandotcom/liferay-portal/pull/59300 was reverted because based on this [comment](https://issues.liferay.com/browse/LPS-80996?focusedCommentId=1513899&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1513899) stating the correct fix is [LPS-84637](https://issues.liferay.com/browse/LPS-84637). 

Looking at this [comment](https://issues.liferay.com/browse/LPS-84637?focusedCommentId=1508794&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1508794) on LPS-84637, I approached things a little differently. Samuel stated that both the Html.Util escape and unescape should be removed. However, doing so will remove all tags from the editor. Also, Escape is commonly used with the input-editor as you can see in these references:
https://github.com/liferay/liferay-portal/blob/5fc3f891ddf27fb6e6d1de1ccebaf0efa0e5aa99/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp#L85
https://github.com/liferay/liferay-portal/blob/b248a2d11e5157a51381f3f1486234cb89e30058/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp#L190
https://github.com/liferay/liferay-portal/blob/b248a2d11e5157a51381f3f1486234cb89e30058/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp#L203
https://github.com/liferay/liferay-portal/blob/8bad1164b047f43e632418bf350963810c805372/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp#L87
https://github.com/liferay/liferay-portal/blob/8bad1164b047f43e632418bf350963810c805372/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp#L101
https://github.com/liferay/liferay-portal/blob/674f27fe641489527c2ea6b52c2a28f0bb1b2324/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/metal/edit_form_instance.jsp#L112
https://github.com/liferay/liferay-portal/blob/674f27fe641489527c2ea6b52c2a28f0bb1b2324/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/metal/edit_form_instance.jsp#L124
https://github.com/liferay/liferay-portal/blob/fe9dfcc0275660a0fe9aafb50ae6b169236f67cf/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp#L150
https://github.com/liferay/liferay-portal/blob/bdba3a1f8a8b2608904146c486c666d7e30f16c2/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp#L204
So I don't see an issue with using escape.

Since the text is escaped, it needs to be unescaped before being sent to the  updateForm(). The only unescape in javascript is Liferay.Util.unescape - however this method is not the inverse of HtmlUtil.escape(String). The important difference is that HtmlUtil.escape translates " as `&#34;` which is not changed back by the Liferay.Util.unescape which is looking for `&quot;`. So instead I used HtmlUtil.escape(String, int mode) which does return `&quot;`.

I also believe that text than resembles Html tags such as "<a href="http://www.amazon.com">Click to go to Amazon</a>" should be visible and not removed, but obviously non-functional. Disagreeing with this [comment](https://issues.liferay.com/browse/LPS-77693?focusedCommentId=1302319&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1302319).

At this point everything seems to be working perfectly and the ' and " characters are stored normally in the database.