### PR TITLE
LPS-88305 Skip check for FileEntry on import since it does not yet exist

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.dynamic.data.mapping.util.DDMFieldsCounter;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.journal.exception.ArticleContentException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -561,10 +562,13 @@ public class JournalConverterImpl implements JournalConverter {
 				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 					dynamicContentElement.getText());
 
-				String uuid = jsonObject.getString("uuid");
-				long groupId = jsonObject.getLong("groupId");
+				if (!ExportImportThreadLocal.isImportInProcess()) {
+					String uuid = jsonObject.getString("uuid");
+					long groupId = jsonObject.getLong("groupId");
 
-				_dlAppLocalService.getFileEntryByUuidAndGroupId(uuid, groupId);
+					_dlAppLocalService.getFileEntryByUuidAndGroupId(
+						uuid, groupId);
+				}
 
 				serializable = jsonObject.toString();
 			}


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-88305

Notes from @diana-lin:

> **Problem**: LPS-88305 was previously resolved and closed here https://github.com/brianchandotcom/liferay-portal/pull/65919.  However, the method call `_dlAppLocalService.getFileEntryByUuidAndGroupId(uuid, groupId);` does not account for situations in which we are importing a `FileEntry`.  When this method is called during an import, it will throw an exception since the `FileEntry` that it is attempting to retrieve does not yet exist.
> 
> **Solution**:  Only check for existence of the `FileEntry` when performing operations other than import.

Further conversation here: https://github.com/joshuacords/liferay-portal/pull/47#issuecomment-453294522