### PR TITLE
J cords lps 88490 3

### DIFF
--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksEntryStagedModelDataHandler.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/data/handler/BookmarksEntryStagedModelDataHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.bookmarks.internal.exportimport.data.handler;
 
+import com.liferay.bookmarks.internal.exportimport.staged.model.repository.BookmarksEntryStagedModelRepository;
 import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.model.BookmarksFolder;
 import com.liferay.bookmarks.model.BookmarksFolderConstants;
@@ -107,20 +108,21 @@ public class BookmarksEntryStagedModelDataHandler
 		importedEntry.setFolderId(folderId);
 
 		BookmarksEntry existingEntry =
-			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(
-				entry.getUuid(), portletDataContext.getScopeGroupId());
+			_bookmarksEntryStagedModelRepository.
+				fetchStagedModelByUuidAndGroupId(
+					entry.getUuid(), portletDataContext.getScopeGroupId());
 
 		if ((existingEntry == null) ||
 			!portletDataContext.isDataStrategyMirror()) {
 
-			importedEntry = _stagedModelRepository.addStagedModel(
+			importedEntry = _bookmarksEntryStagedModelRepository.addStagedModel(
 				portletDataContext, importedEntry);
 		}
 		else {
-			importedEntry.setEntryId(existingEntry.getEntryId());
-
-			importedEntry = _stagedModelRepository.updateStagedModel(
-				portletDataContext, importedEntry);
+			importedEntry =
+				_bookmarksEntryStagedModelRepository.updateStagedModel(
+					portletDataContext, importedEntry,
+					existingEntry.getEntryId());
 		}
 
 		portletDataContext.importClassedModel(entry, importedEntry);
@@ -128,19 +130,23 @@ public class BookmarksEntryStagedModelDataHandler
 
 	@Override
 	protected StagedModelRepository<BookmarksEntry> getStagedModelRepository() {
-		return _stagedModelRepository;
+		return _bookmarksEntryStagedModelRepository;
 	}
 
 	@Reference(
+		service = BookmarksEntryStagedModelRepository.class,
 		target = "(model.class.name=com.liferay.bookmarks.model.BookmarksEntry)",
 		unbind = "-"
 	)
 	protected void setStagedModelRepository(
-		StagedModelRepository<BookmarksEntry> stagedModelRepository) {
+		BookmarksEntryStagedModelRepository
+			bookmarksEntryStagedModelRepository) {
 
-		_stagedModelRepository = stagedModelRepository;
+		_bookmarksEntryStagedModelRepository =
+			bookmarksEntryStagedModelRepository;
 	}
 
-	private StagedModelRepository<BookmarksEntry> _stagedModelRepository;
+	private BookmarksEntryStagedModelRepository
+		_bookmarksEntryStagedModelRepository;
 
 }

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/staged/model/repository/BookmarksEntryStagedModelRepository.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/staged/model/repository/BookmarksEntryStagedModelRepository.java
@@ -181,6 +181,14 @@ public class BookmarksEntryStagedModelRepository
 			BookmarksEntry bookmarksEntry)
 		throws PortalException {
 
+		throw new UnsupportedOperationException();
+	}
+
+	public BookmarksEntry updateStagedModel(
+		PortletDataContext portletDataContext,
+		BookmarksEntry bookmarksEntry, long existingEntityId)
+		throws PortalException {
+
 		long userId = portletDataContext.getUserId(
 			bookmarksEntry.getUserUuid());
 
@@ -188,7 +196,7 @@ public class BookmarksEntryStagedModelRepository
 			bookmarksEntry);
 
 		return _bookmarksEntryLocalService.updateEntry(
-			userId, bookmarksEntry.getEntryId(), bookmarksEntry.getGroupId(),
+			userId, existingEntityId, bookmarksEntry.getGroupId(),
 			bookmarksEntry.getFolderId(), bookmarksEntry.getName(),
 			bookmarksEntry.getUrl(), bookmarksEntry.getDescription(),
 			serviceContext);

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/staged/model/repository/BookmarksEntryStagedModelRepository.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/exportimport/staged/model/repository/BookmarksEntryStagedModelRepository.java
@@ -41,7 +41,10 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = "model.class.name=com.liferay.bookmarks.model.BookmarksEntry",
-	service = StagedModelRepository.class
+	service = {
+		BookmarksEntryStagedModelRepository.class,
+		StagedModelRepository.class
+	}
 )
 public class BookmarksEntryStagedModelRepository
 	implements StagedModelRepository<BookmarksEntry> {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88490
https://issues.liferay.com/browse/LPP-32496

Revised from https://github.com/matethurzo/liferay-portal/pull/2343, resending.

**Problem**: Overwriting the EntryId before the updateStagedModel() makes the serviceContext will cause the [assetCategory](https://github.com/joshuacords/liferay-portal/blob/0397da87d4353a608b65e82ad2527873ea5df9c5/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java#L737-L744) and assetTag maps to try looking up by the wrong BookmarkEntry id. 

**Solution**: Instead, initialize the serviceContext beforehand using custom updateStagedModel method based on Mate's suggestion here: https://github.com/matethurzo/liferay-portal/pull/2343#issuecomment-454366304