### PR TITLE
LPS-89236 Control search filter hidden with attribute

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu_filter.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu_filter.js
@@ -59,11 +59,11 @@ AUI.add(
 					_filterMenu: function(event) {
 						var instance = this;
 
-						instance._menuItems.addClass(CSS_HIDDEN);
+						instance._menuItems.setAttribute('hidden', true);
 
 						event.results.forEach(
 							function(result) {
-								result.raw.node.removeClass(CSS_HIDDEN);
+								result.raw.node.removeAttribute('hidden');
 							}
 						);
 					},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89236
https://issues.liferay.com/browse/LPP-32673

Problem: 'hidden' class had no effect on the menu's items.

Solution: Use the 'hidden' attribute instead which is not reliant on CSS.