### PR TITLE
LPS-89295 Remove empty attributes from LDAP request

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -40,6 +40,7 @@ import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -686,6 +687,8 @@ public class DefaultPortalLDAP implements PortalLDAP {
 		PropertiesUtil.merge(userMappings, contactMappings);
 
 		Collection<Object> values = userMappings.values();
+
+		values.removeAll(Arrays.asList(""));
 
 		String[] mappedUserAttributeIds = ArrayUtil.toStringArray(
 			values.toArray(new Object[userMappings.size()]));


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89295
https://issues.liferay.com/browse/LPP-32732

Problem: "" attributes can cause LDAP requests to be rejected.

Solutions: Remove all empty attributes before sending LDAP request.