### PR TITLE
[TECHNICAL-SUPPORT] LPS-89295

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -40,7 +40,6 @@ import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -688,7 +687,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 
 		Collection<Object> values = userMappings.values();
 
-		values.removeAll(Arrays.asList(""));
+		values.removeIf(o -> Validator.isNull(o));
 
 		String[] mappedUserAttributeIds = ArrayUtil.toStringArray(
 			values.toArray(new Object[userMappings.size()]));

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -40,6 +40,7 @@ import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -686,6 +687,8 @@ public class DefaultPortalLDAP implements PortalLDAP {
 		PropertiesUtil.merge(userMappings, contactMappings);
 
 		Collection<Object> values = userMappings.values();
+
+		values.removeAll(Arrays.asList(""));
 
 		String[] mappedUserAttributeIds = ArrayUtil.toStringArray(
 			values.toArray(new Object[userMappings.size()]));


### PR DESCRIPTION
Hi Sam. I don't have a Red Hat Directory LDAP server available to test with but I suspect that it will also have trouble with values only containing whitespace? Assuming this is the case I feel we should filter those values at the point you identified as well.

Note: As it stands the DefaultLDAPSettings service will filter these values out earlier on. But there is a chance customers will implement their own LDAPSettings which does not.

If you are happy with the change then please send to Brian.

/cc @joshuacords @topolik


Notes from Josh:

> https://issues.liferay.com/browse/LPS-89295
> https://issues.liferay.com/browse/LPP-32732
> 
> Problem: "" attributes can cause LDAP requests to be rejected.
> 
> Solutions: Remove all empty attributes before sending LDAP request.