### PR TITLE
LPS-90187 Check all field values for match

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/FacetBucketUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/facet/FacetBucketUtil.java
@@ -53,8 +53,10 @@ public class FacetBucketUtil {
 			return false;
 		}
 
-		if (term.equals(field.getValue())) {
-			return true;
+		for (String value : field.getValues()) {
+			if (term.equals(value)) {
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90187
https://issues.liferay.com/browse/LPP-32946

The field.getValue only returns the first array element, but there can be multiple values which need to be checked against.