### PR TITLE
LPS-90241 Remove unsupported org.apache.catalina.loader.WebappClassLo…

### DIFF
--- a/tools/servers/tomcat/bin/setenv.bat
+++ b/tools/servers/tomcat/bin/setenv.bat
@@ -1,1 +1,1 @@
-set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false -Duser.timezone=GMT -Xms1280m -Xmx1280m -XX:MaxNewSize=256m -XX:NewSize=256m -XX:MaxMetaspaceSize=512m -XX:MetaspaceSize=512m -XX:SurvivorRatio=7"
+set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xms1280m -Xmx1280m -XX:MaxNewSize=256m -XX:NewSize=256m -XX:MaxMetaspaceSize=512m -XX:MetaspaceSize=512m -XX:SurvivorRatio=7"

--- a/tools/servers/tomcat/bin/setenv.sh
+++ b/tools/servers/tomcat/bin/setenv.sh
@@ -1,1 +1,1 @@
-CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false -Duser.timezone=GMT -Xms2560m -Xmx2560m -XX:MaxNewSize=1536m -XX:MaxMetaspaceSize=512m -XX:MetaspaceSize=512m -XX:NewSize=1536m -XX:SurvivorRatio=7"
+CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xms2560m -Xmx2560m -XX:MaxNewSize=1536m -XX:MaxMetaspaceSize=512m -XX:MetaspaceSize=512m -XX:NewSize=1536m -XX:SurvivorRatio=7"


### PR DESCRIPTION
…ader.ENABLE_CLEAR_REFERENCES

https://issues.liferay.com/browse/LPS-90241
https://issues.liferay.com/browse/LPP-32938

Tomcat documentation referencing ENABLE_CLEAR_REFERENCES:
* [Tomcat 5.5](https://tomcat.apache.org/tomcat-5.5-doc/config/systemprops.html)
* [Tomcat 6.0](https://tomcat.apache.org/tomcat-6.0-doc/config/systemprops.html)

By Tomcat 7 documentation no longer references ENABLE_CLEAR_REFERENCES
* [Tomcat 7.0](https://tomcat.apache.org/tomcat-7.0-doc/config/systemprops.html)
* [Tomcat 8.0](https://tomcat.apache.org/tomcat-8.0-doc/config/loader.html)
* [Tomcat 9.0](https://tomcat.apache.org/tomcat-9.0-doc/config/index.html)

I have tested stopping the bundle without the ENABLE_CLEAR_REFERENCES parameter to ensure the "annoying errors" [LPS-14189](https://issues.liferay.com/browse/LPS-14189) resolved did not return.