### PR TITLE
LPS-90297 Use of .includes not supported in IE11, replace with .indexOf

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/checkbox-multiple/checkbox_multiple_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/checkbox-multiple/checkbox_multiple_field.js
@@ -87,7 +87,7 @@ AUI.add(
 						for (var i = 0; i < checkboxNodeList.size(); i++) {
 							var node = checkboxNodeList.item(i);
 
-							if (value.includes(checkboxNodeList.item(i).val())) {
+							if (value.indexOf(checkboxNodeList.item(i).val()) > -1) {
 								node.setAttribute('checked', true);
 
 								data = value;


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-90297

Tested here: https://github.com/joshuacords/liferay-portal/pull/53#issuecomment-462602305

Notes from @diana-lin:
**Problem**: Unable to execute [checkbox_multiple_field.js#L90-L94](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/checkbox-multiple/checkbox_multiple_field.js#L90-L94) in IE11 because IE does not support the Javascript method `.includes`.  [See documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility).

**Solution**:  Replace `.includes` with `.indexOf`.