### PR TITLE
LPS-90444 Use of .includes not supported in IE11, replace with .indexOf

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/alloy/js/form_builder_action_calculate.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/alloy/js/form_builder_action_calculate.js
@@ -250,10 +250,10 @@ AUI.add(
 					_removeRepeatedOperatorKey: function(key) {
 						var instance = this;
 
-						if (OPERATORS_MAP.includes(key) && instance._getCalculateKeyActions().length >= 1) {
+						if (OPERATORS_MAP.indexOf(key) > -1 && instance._getCalculateKeyActions().length >= 1) {
 							var lastKey = instance._getCalculateKeyActions()[instance._getCalculateKeyActions().length - 1];
 
-							if (OPERATORS_MAP.includes(lastKey)) {
+							if (OPERATORS_MAP.indexOf(lastKey) > -1) {
 								instance._getCalculateKeyActions().pop();
 							}
 						}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90444
Tested here: https://github.com/joshuacords/liferay-portal/pull/54#issuecomment-462932389

Notes from @diana-lin 
**Problem**: Unable to add a mathematical expression for the Calculate action in Form Rules.  Clicking on integers or operators in the calculator UI does not produce any results in IE11.  This is because IE does not support the Javascript method `.includes`.  [See documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility).

**Solution**:  Replace `.includes` with `.indexOf`.