### PR TITLE
LPS-90724

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -620,6 +620,17 @@ AUI.add(
 								field.addLocaleToLocalizationMap(displayLocale);
 								field.set('displayLocale', displayLocale);
 
+								if (instance.originalField) {
+									field.originalField = instance.originalField;
+								}
+								else {
+									field.originalField = instance;
+								}
+
+								var form = field.getForm();
+
+								form.newRepeatableInstances.push(field);
+
 								field.renderUI();
 
 								instance._addFieldValidation(field, instance);
@@ -3086,6 +3097,7 @@ AUI.add(
 						var instance = this;
 
 						instance.eventHandlers = [];
+						instance.newRepeatableInstances = [];
 						instance.repeatableInstances = {};
 
 						instance.bindUI();
@@ -3166,6 +3178,46 @@ AUI.add(
 								}
 							}
 						);
+					},
+
+					finalizeRepeatableFieldLocalizations: function() {
+						var instance = this;
+
+						var defaultLocale = instance.getDefaultLocale();
+
+						for (x in instance.newRepeatableInstances) {
+							var field = instance.newRepeatableInstances[x];
+
+							if (!field.get('localizable')) {
+								continue;
+							}
+
+							var currentLocale = field.get('displayLocale');
+							var originalField = field.originalField;
+
+							var newFieldLocalizations = field.get('localizationMap');
+							var totalLocalizations = originalField.get('localizationMap');
+
+							for (var localization in totalLocalizations) {
+								if (localization == currentLocale) {
+									continue;
+								}
+
+								if (!newFieldLocalizations[localization]) {
+									if (newFieldLocalizations[defaultLocale]) {
+										newFieldLocalizations[localization] = newFieldLocalizations[defaultLocale];
+									}
+									else if (defaultLocale == field.get('displayLocale') && field.getValue()) {
+										newFieldLocalizations[localization] = field.getValue();
+									}
+									else {
+										newFieldLocalizations[localization] = '';
+									}
+								}
+							}
+
+							field.set('localizationMap', newFieldLocalizations);
+						}
 					},
 
 					moveField: function(parentField, oldIndex, newIndex) {
@@ -3395,6 +3447,8 @@ AUI.add(
 
 					_onSubmitForm: function(event) {
 						var instance = this;
+
+						instance.finalizeRepeatableFieldLocalizations();
 
 						instance.updateDDMFormInputValue();
 					},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -615,6 +615,11 @@ AUI.add(
 							function(fieldTemplate) {
 								var field = instance.createField(fieldTemplate);
 
+								var displayLocale = instance.get('displayLocale');
+
+								field.addLocaleToLocalizationMap(displayLocale);
+								field.set('displayLocale', displayLocale);
+
 								field.renderUI();
 
 								instance._addFieldValidation(field, instance);


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-33032
https://issues.liferay.com/browse/LPS-90724

When adding an instance of a repeatable field for Web Content, if values are not added for some locales before publishing, then when viewing those locales, the new repeatable field will lose its position (ending up as the last one) and it will have "null" as a value.

This happens because not every currently supported localization is initialized when creating a new repeatable field -- and when the fields are processed after publishing, there is no information (instanceIds, etc.) identifying each individual instance of a repeatable field; only the number of fields is known. So when some repeatable fields have a different number of initialized localizations, in the code it is processed as there being fewer instances of that localization, which messes up processing the number of the repeated fields (this happens in [JournalConverterImpl.getContent()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java#L153)).

Thus, to prevent the fields having different numbers of localizations, this fix initializes every known supported localization when the form is submitted. It is necessary to do when the form is submitted, rather than when the new fields are created (as it is done for other fields), because for these fields specifically, the ordering of localizations and fields being added is not the same. Because the fields may be created after multiple localizations have already been added, attempting to do it at a different time will cause initialization of other localizations that does not occur for other types of fields (setting them all to blank, for instance, when the normal expectation would be for them to remain uninitialized so that they can be copied over if the user switches to that locale).

The two commits here do as follows:

- https://github.com/SamZiemer/liferay-portal/commit/7143b310ce2cda692ec154de164a7f7a0d085893: fixes an issue in which the `displayLocale` for a field is not properly set (nor the `localizationMap` initialized, for that matter) for newly created repeatable fields. This causes a separate issue in which, if the user begins by viewing a non-default locale and then creating a new instance of a repeatable field, it will be treated as a different locale than the one currently displayed. It is necessary to fix this issue as well.

- https://github.com/SamZiemer/liferay-portal/commit/26b3525453b5a1933f678843a41f49132686812a: forces initialization of all known supported localizations for all newly added repeatable field instances when the form is submitted. This is done by:
-- Keeping track of all newly created repeatable fields since the form was loaded
-- For each of these, keeping track of the original field they were 'repeated' from so that it can be used as a reference for how many localizations are supported
-- Finally, calling the new `finalizeRepeatableFieldLocalizations()` on form submit, which goes through all new repeatable fields and initializes any missing localizations (based on the ones present in their "original" fields) so that they do not have an unexpected number of them when they are later processed by `JournalConverterImpl`; if a value is known for the default locale, then, keeping in line with the current pattern, that value is copied instead of an empty string.
** Note: `finalizeRepeatableFieldLocalizations()` has to handle the `localizationMap` directly. While there are functions present in `ddm_form.js` ([updateLocalizationMap()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L758), as well as [addLocaleToLocalizationMap()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L403)) that can add localizations themselves instead, they do not work for this purpose, because they operate on assumptions about the field's current "value" which are not necessarily true at the time of form submission. For example, `addLocaleToLocalizationMap()` would not account for a value for the default locale that has not yet been saved (if the user is still viewing the default locale, for instance).

It is a fair bit of code added for a relatively simple fix, so if there is a better way to do so that I have not considered, please let me know. I found this to be the easiest fix that keeps the behavior of repeatable fields in line with that of other fields (defaulting to the default locale for uninitialized locales, which are uninitialized until the user views or submits the form so there is no empty value overriding it), but if I am wrong about that being the correct way to do so, then the potential fix could be much simpler.