### PR TITLE
LPS-91160 Use correct form. Phrase translation should be feminine.

### DIFF
--- a/portal-impl/src/content/Language_fr.properties
+++ b/portal-impl/src/content/Language_fr.properties
@@ -5692,7 +5692,7 @@ x's-commits=Les changements de {0}
 x's-commits-on-x=Les changements de {0} sur {1}.
 x-added-a-comment={0} a ajouté un <a href="{1}">commentaire</a>.
 x-added-a-new-comment-to-x={0} a ajouté un nouveau commentaire à {1}.
-x-added-a-new-x={0} a ajouté un nouveau {1}.
+x-added-a-new-x={0} a ajouté une nouvelle {1}.
 x-added-the-attachment-x={0} a ajouté la pièce jointe {1}.
 x-added-the-page-x={0} a ajouté la page {1}.
 x-ago=Il y a {0}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91160

Hello @SamZiemer ,

The issue here is very straightforward. The French translation for language key: x-added-a-new-x is incorrect as specified.

The new translation has been confirmed to be correct by the designated translation lead as specified here: https://grow.liferay.com/share/FEI+Setup+Local+Libraries

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim