### PR TITLE
LPS-91536 Only try to add 1 AssetDisplayPageEntry per index

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
@@ -17,6 +17,7 @@ package com.liferay.journal.internal.upgrade.v1_1_6;
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -25,12 +26,14 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -78,19 +81,33 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 				saveAssetDisplayPageEntryCallables = new ArrayList<>();
 
 			try (ResultSet rs = ps1.executeQuery()) {
+				StringBundler journalArticleIndexSB;
+
 				while (rs.next()) {
 					long groupId = rs.getLong("groupId");
 					long userId = rs.getLong("userId");
 					long resourcePrimKey = rs.getLong("resourcePrimKey");
 
-					SaveAssetDisplayPageEntryCallable
-						saveAssetDisplayPageEntryCallable =
-							new SaveAssetDisplayPageEntryCallable(
-								groupId, userId, journalArticleClassNameId,
-								resourcePrimKey);
+					journalArticleIndexSB = new StringBundler(5);
 
-					saveAssetDisplayPageEntryCallables.add(
-						saveAssetDisplayPageEntryCallable);
+					journalArticleIndexSB.append(groupId);
+					journalArticleIndexSB.append(StringPool.DASH);
+					journalArticleIndexSB.append(userId);
+					journalArticleIndexSB.append(StringPool.DASH);
+					journalArticleIndexSB.append(resourcePrimKey);
+
+					if (_journalArticleIndexes.add(
+							journalArticleIndexSB.toString())) {
+
+						SaveAssetDisplayPageEntryCallable
+							saveAssetDisplayPageEntryCallable =
+								new SaveAssetDisplayPageEntryCallable(
+									groupId, userId, journalArticleClassNameId,
+									resourcePrimKey);
+
+						saveAssetDisplayPageEntryCallables.add(
+							saveAssetDisplayPageEntryCallable);
+					}
 				}
 			}
 
@@ -118,6 +135,7 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 
 	private final AssetDisplayPageEntryLocalService
 		_assetDisplayPageEntryLocalService;
+	private final HashSet<String> _journalArticleIndexes = new HashSet<>();
 
 	private class SaveAssetDisplayPageEntryCallable
 		implements Callable<Boolean> {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91536
https://issues.liferay.com/browse/LPP-33125

**Problem**: The upgrade process tries to add a AssetDisplayPageEntry for each journal article version, however only one AssetDisplayPageEntry should exist for all versions of a journal article. What happens is after the first version creates an AssetDisplayPageEntry, all remain versions will through benign errors during the upgrade process.

**Solution**: Since only one AssetDisplayPageEntry is necessary for each journal article set of versions, and there is no differentiation in linkage between any of the version, I use a Set to only try adding the first version.

Note: In master, this upgrade process will also throw errors because of https://issues.liferay.com/browse/LPS-91537. This fix will remove the duplicate index errors, but not the errors documented on that ticket. In 7.1.x, those other errors don't exist and so this fix will remove all errors. 