### PR TITLE
LPS-92362 Take into account portalContext for OpenId URI

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectServiceHandlerImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectServiceHandlerImpl.java
@@ -294,9 +294,10 @@ public class OpenIdConnectServiceHandlerImpl
 
 	protected URI getLoginRedirectURI(HttpServletRequest httpServletRequest) {
 		try {
-			StringBundler sb = new StringBundler(2);
+			StringBundler sb = new StringBundler(3);
 
 			sb.append(_portal.getPortalURL(httpServletRequest));
+			sb.append(_portal.getPathContext());
 			sb.append(OpenIdConnectConstants.REDIRECT_URL_PATTERN);
 
 			return new URI(sb.toString());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92362
https://issues.liferay.com/browse/LPP-33333

Problem: The URI created for OpenId Connect doesn't add the Path Context, but other parts of the portal handle a different path context appropriately.

Solution: Add the path context, which will normally be blank unless the tomcat bundle is modified.