### PR TITLE
LPS-92995 subtypeSelectionId default null for database

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -84,12 +84,18 @@ public class AssetBrowserDisplayContext {
 
 			assetBrowserSearch.setTotal(total);
 
+			long[] subtypeSelectionId = null;
+
+			if (getSubtypeSelectionId() > 0) {
+				subtypeSelectionId = new long[] {getSubtypeSelectionId()};
+			}
+
 			List<AssetEntry> assetEntries =
 				AssetEntryLocalServiceUtil.getEntries(
 					_getFilterGroupIds(), _getClassNameIds(),
-					new long[] {getSubtypeSelectionId()}, _getKeywords(),
-					_getKeywords(), _getKeywords(), _getKeywords(),
-					_getListable(), false, false, assetBrowserSearch.getStart(),
+					subtypeSelectionId, _getKeywords(), _getKeywords(),
+					_getKeywords(), _getKeywords(), _getListable(), false,
+					false, assetBrowserSearch.getStart(),
 					assetBrowserSearch.getEnd(), "modifiedDate",
 					StringPool.BLANK, getOrderByType(), StringPool.BLANK);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92995

> https://issues.liferay.com/browse/LPS-90245 added support to search asset entry by class ids but caused regressions. For the default search we set subtypeSelectionId to null.

Forwarded from https://github.com/jonathanmccann/liferay-portal/pull/1791 because was told high priority and he's out today

tests: https://github.com/jonathanmccann/liferay-portal/pull/1791#issuecomment-477846178