### PR TITLE
LPS-91094

### DIFF
--- a/app.server.properties
+++ b/app.server.properties
@@ -176,7 +176,7 @@
 ## Tomcat
 ##
 
-    app.server.tomcat.legacy.versions=9.0.6
+    app.server.tomcat.legacy.versions=9.0.6,9.0.10
     app.server.tomcat.version=9.0.17
     app.server.tomcat.dir=${app.server.parent.dir}/tomcat-${app.server.tomcat.version}
     app.server.tomcat.bin.dir=${app.server.tomcat.dir}/bin

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageConfiguration.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageConfiguration.java
@@ -54,7 +54,10 @@ public interface AMImageConfiguration {
 	 * than this value will not generate adaptive media images. A value of -1
 	 * indicates that all images will generate adaptive media images. A value of
 	 * 0 indicates that no adaptive media images will be generated.
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link DLFileEntryConfiguration#previewableProcessorMaxSize()}
 	 */
+	@Deprecated
 	@Meta.AD(
 		deflt = "104857600", description = "max-image-size-key-description",
 		name = "max-image-size", required = false

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageConfiguration.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageConfiguration.java
@@ -56,7 +56,7 @@ public interface AMImageConfiguration {
 	 * 0 indicates that no adaptive media images will be generated.
 	 */
 	@Meta.AD(
-		deflt = "10485760", description = "max-image-size-key-description",
+		deflt = "104857600", description = "max-image-size-key-description",
 		name = "max-image-size", required = false
 	)
 	public int imageMaxSize();

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/validator/AMImageValidatorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/validator/AMImageValidatorImpl.java
@@ -17,6 +17,7 @@ package com.liferay.adaptive.media.image.internal.validator;
 import com.liferay.adaptive.media.image.internal.configuration.AMImageConfiguration;
 import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
 import com.liferay.adaptive.media.image.validator.AMImageValidator;
+import com.liferay.document.library.kernel.util.DLProcessorRegistryUtil;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 
@@ -38,6 +39,10 @@ public class AMImageValidatorImpl implements AMImageValidator {
 
 	@Override
 	public boolean isValid(FileVersion fileVersion) {
+		if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
+			return false;
+		}
+
 		long imageMaxSize = _amImageConfiguration.imageMaxSize();
 
 		if ((imageMaxSize != -1) &&

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/SelectAssetDisplayPageDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/SelectAssetDisplayPageDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.item.selector.criterion.AssetDisplayPageSelectorCriterion;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalServiceUtil;
+import com.liferay.asset.display.page.util.AssetDisplayPageHelper;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
@@ -302,7 +303,31 @@ public class SelectAssetDisplayPageDisplayContext {
 	}
 
 	public boolean isShowViewInContextLink() {
-		return _showViewInContextLink;
+		if (!_showViewInContextLink) {
+			return false;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		AssetRendererFactory assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.
+				getAssetRendererFactoryByClassNameId(_classNameId);
+
+		try {
+			AssetEntry assetEntry = assetRendererFactory.getAssetEntry(
+				PortalUtil.getClassName(_classNameId), _classPK);
+
+			if (!AssetDisplayPageHelper.hasAssetDisplayPage(
+					themeDisplay.getScopeGroupId(), assetEntry)) {
+
+				return false;
+			}
+		}
+		catch (Exception e) {
+		}
+
+		return true;
 	}
 
 	public boolean isURLViewInContext() throws Exception {

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -128,7 +128,7 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Response.class);
+			return outputObjectMapper.readValue(string, Response.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -178,7 +178,7 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Response.class);
+			return outputObjectMapper.readValue(string, Response.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -227,7 +227,7 @@ public abstract class BaseKeywordResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Keyword>>() {
 			});

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseMessageSelectionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseMessageSelectionResourceTestCase.java
@@ -140,8 +140,7 @@ public abstract class BaseMessageSelectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, MessageSelection.class);
+			return outputObjectMapper.readValue(string, MessageSelection.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -120,7 +120,7 @@ public abstract class BaseStatusResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Status.class);
+			return outputObjectMapper.readValue(string, Status.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -126,7 +126,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Response.class);
+			return outputObjectMapper.readValue(string, Response.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -176,7 +176,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Response.class);
+			return outputObjectMapper.readValue(string, Response.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -134,7 +134,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<TaxonomyVocabulary>>() {
 			});

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataDefinitionResourceTestCase.java
@@ -300,7 +300,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DataDefinition>>() {
 			});
@@ -358,7 +358,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataDefinition),
+			inputObjectMapper.writeValueAsString(dataDefinition),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -378,7 +378,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataDefinition.class);
+			return outputObjectMapper.readValue(string, DataDefinition.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -394,7 +394,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataDefinition),
+			inputObjectMapper.writeValueAsString(dataDefinition),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -510,7 +510,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataDefinition.class);
+			return outputObjectMapper.readValue(string, DataDefinition.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -571,7 +571,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataDefinition),
+			inputObjectMapper.writeValueAsString(dataDefinition),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -590,7 +590,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataDefinition.class);
+			return outputObjectMapper.readValue(string, DataDefinition.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -606,7 +606,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataDefinition),
+			inputObjectMapper.writeValueAsString(dataDefinition),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataLayoutResourceTestCase.java
@@ -240,7 +240,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DataLayout>>() {
 			});
@@ -347,7 +347,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataLayout),
+			inputObjectMapper.writeValueAsString(dataLayout),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -367,7 +367,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataLayout.class);
+			return outputObjectMapper.readValue(string, DataLayout.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -383,7 +383,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataLayout),
+			inputObjectMapper.writeValueAsString(dataLayout),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -537,7 +537,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataLayout.class);
+			return outputObjectMapper.readValue(string, DataLayout.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -592,7 +592,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataLayout),
+			inputObjectMapper.writeValueAsString(dataLayout),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -610,7 +610,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataLayout.class);
+			return outputObjectMapper.readValue(string, DataLayout.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -626,7 +626,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataLayout),
+			inputObjectMapper.writeValueAsString(dataLayout),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -312,7 +312,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DataRecordCollection>>() {
 			});
@@ -496,7 +496,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DataRecordCollection>>() {
 			});
@@ -556,7 +556,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecordCollection),
+			inputObjectMapper.writeValueAsString(dataRecordCollection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -576,7 +576,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, DataRecordCollection.class);
 		}
 		catch (Exception e) {
@@ -595,7 +595,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecordCollection),
+			inputObjectMapper.writeValueAsString(dataRecordCollection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -721,7 +721,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, DataRecordCollection.class);
 		}
 		catch (Exception e) {
@@ -788,7 +788,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecordCollection),
+			inputObjectMapper.writeValueAsString(dataRecordCollection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -808,7 +808,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, DataRecordCollection.class);
 		}
 		catch (Exception e) {
@@ -826,7 +826,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecordCollection),
+			inputObjectMapper.writeValueAsString(dataRecordCollection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/BaseDataRecordResourceTestCase.java
@@ -244,7 +244,7 @@ public abstract class BaseDataRecordResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DataRecord>>() {
 			});
@@ -302,7 +302,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecord),
+			inputObjectMapper.writeValueAsString(dataRecord),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -322,7 +322,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataRecord.class);
+			return outputObjectMapper.readValue(string, DataRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -338,7 +338,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecord),
+			inputObjectMapper.writeValueAsString(dataRecord),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -489,7 +489,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataRecord.class);
+			return outputObjectMapper.readValue(string, DataRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -544,7 +544,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecord),
+			inputObjectMapper.writeValueAsString(dataRecord),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -562,7 +562,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DataRecord.class);
+			return outputObjectMapper.readValue(string, DataRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -578,7 +578,7 @@ public abstract class BaseDataRecordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(dataRecord),
+			inputObjectMapper.writeValueAsString(dataRecord),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/preview/DLPreviewRenderer.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/preview/DLPreviewRenderer.java
@@ -32,14 +32,16 @@ public interface DLPreviewRenderer {
 	/**
 	 * Renders content to the response.
 	 *
-	 * @param request the request
-	 * @param response the response
+	 * @param httpServletRequest the request
+	 * @param httpServletResponse the response
 	 * @see   DLPreviewRendererProvider#getPreviewDLPreviewRendererOptional(
 	 *        FileVersion)
 	 * @see   DLPreviewRendererProvider#getThumbnailDLPreviewRendererOptional(
 	 *        FileVersion)
 	 */
-	public void render(HttpServletRequest request, HttpServletResponse response)
+	public void render(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
 		throws IOException, PortalException, ServletException;
 
 }

--- a/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
@@ -52,7 +52,7 @@ public class ImageDLPreviewRendererProvider
 
 		if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
 			return Optional.of(
-				(request, response) -> {
+				(httpServletRequest, httpServletResponse) -> {
 					throw new DLPreviewSizeException();
 				});
 		}

--- a/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
@@ -50,6 +50,13 @@ public class ImageDLPreviewRendererProvider
 	public Optional<DLPreviewRenderer> getPreviewDLPreviewRendererOptional(
 		FileVersion fileVersion) {
 
+		if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
+			return Optional.of(
+				(request, response) -> {
+					throw new DLPreviewSizeException();
+				});
+		}
+
 		if (!ImageProcessorUtil.isImageSupported(fileVersion)) {
 			return Optional.empty();
 		}
@@ -86,10 +93,6 @@ public class ImageDLPreviewRendererProvider
 		}
 
 		if (!ImageProcessorUtil.hasImages(fileVersion)) {
-			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
-				throw new DLPreviewSizeException();
-			}
-
 			throw new DLPreviewGenerationInProcessException();
 		}
 	}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -103,6 +103,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 								<liferay-frontend:icon-vertical-card
 									actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/image_gallery_display/image_action.jsp" : StringPool.BLANK %>'
 									actionJspServletContext="<%= application %>"
+									cardCssClass="card-interactive card-interactive-secondary"
 									cssClass="entry-display-style"
 									icon="documents-and-media"
 									resultRow="<%= row %>"
@@ -113,6 +114,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 								<liferay-frontend:vertical-card
 									actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/image_gallery_display/image_action.jsp" : StringPool.BLANK %>'
 									actionJspServletContext="<%= application %>"
+									cardCssClass="card-interactive card-interactive-secondary"
 									cssClass="entry-display-style"
 									imageUrl="<%= imagePreviewURL %>"
 									resultRow="<%= row %>"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.babelrc
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.babelrc
@@ -1,1 +1,5 @@
-{"ignore":["**/js/*.js"],"plugins":[],"presets":["@babel/preset-env"]}
+{
+	"ignore": ["**/js/*.js"],
+	"plugins" :[],
+	"presets" :["@babel/preset-env"]
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.babelrc
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.babelrc
@@ -1,5 +1,1 @@
-{
-    "ignore": [
-		"**/js/*.js"
-	]
-}
+{"ignore":["**/js/*.js"],"plugins":[],"presets":["@babel/preset-env"]}

--- a/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServlet.java
+++ b/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServlet.java
@@ -180,7 +180,6 @@ public class RTLServlet extends HttpServlet {
 		response.setContentLength(urlConnection.getContentLength());
 
 		response.setContentType(ContentTypes.TEXT_CSS);
-
 		response.setStatus(HttpServletResponse.SC_OK);
 
 		StreamUtil.transfer(url.openStream(), response.getOutputStream());

--- a/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServlet.java
+++ b/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServlet.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.RequestDispatcherUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
@@ -177,6 +178,8 @@ public class RTLServlet extends HttpServlet {
 		URLConnection urlConnection = url.openConnection();
 
 		response.setContentLength(urlConnection.getContentLength());
+
+		response.setContentType(ContentTypes.TEXT_CSS);
 
 		response.setStatus(HttpServletResponse.SC_OK);
 

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/_portal.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/_portal.scss
@@ -5,6 +5,7 @@
 @import "portal/edit_layout";
 @import "portal/editor_alloy";
 @import "portal/editor_lfr_source";
+@import "portal/dropdown";
 @import "portal/forms";
 @import "portal/generic_portal";
 @import "portal/generic_portlet";

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_dropdown.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_dropdown.scss
@@ -1,0 +1,4 @@
+html.rtl .dropdown-menu {
+	left: auto;
+	right: 0;
+}

--- a/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/JSPortletExtender.java
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/JSPortletExtender.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.js.portlet.extender;
 
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
 import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.frontend.js.portlet.extender.internal.portlet.JSPortlet;
 import com.liferay.frontend.js.portlet.extender.internal.portlet.action.PortletExtenderConfigurationAction;
@@ -180,7 +181,7 @@ public class JSPortletExtender {
 		try {
 			ConfigurationAction configurationAction =
 				new PortletExtenderConfigurationAction(
-					_ddm, portletPreferencesJSONObject);
+					_ddm, _ddmFormRenderer, portletPreferencesJSONObject);
 
 			Dictionary<String, Object> properties = new Hashtable<>();
 
@@ -282,6 +283,9 @@ public class JSPortletExtender {
 
 	@Reference
 	private DDM _ddm;
+
+	@Reference
+	private DDMFormRenderer _ddmFormRenderer;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/action/PortletExtenderConfigurationAction.java
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/action/PortletExtenderConfigurationAction.java
@@ -14,11 +14,12 @@
 
 package com.liferay.frontend.js.portlet.extender.internal.portlet.action;
 
+import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
-import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
-import com.liferay.dynamic.data.mapping.render.DDMFormRendererUtil;
 import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -36,6 +37,7 @@ import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -43,6 +45,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -64,8 +67,11 @@ public class PortletExtenderConfigurationAction
 	extends DefaultConfigurationAction {
 
 	public PortletExtenderConfigurationAction(
-			DDM ddm, JSONObject preferencesJSONObject)
+			DDM ddm, DDMFormRenderer ddmFormRenderer,
+			JSONObject preferencesJSONObject)
 		throws PortalException {
+
+		_ddmFormRenderer = ddmFormRenderer;
 
 		_ddmForm = ddm.getDDMForm(preferencesJSONObject.toJSONString());
 		_preferencesJSONObject = preferencesJSONObject;
@@ -104,10 +110,9 @@ public class PortletExtenderConfigurationAction
 					_getActionURL(request, portletDisplay), Constants.CMD,
 					Constants.UPDATE,
 					String.valueOf(System.currentTimeMillis()),
-					DDMFormRendererUtil.render(
+					_ddmFormRenderer.render(
 						_ddmForm,
-						_getDDMFormFieldRenderingContext(
-							request, response, themeDisplay, portletDisplay)),
+						_createDDMFormRenderingContext(request, response)),
 					fieldsJSONArray.toString(), portletDisplay.getNamespace(),
 					LanguageUtil.get(themeDisplay.getLocale(), "save")
 				}));
@@ -152,6 +157,38 @@ public class PortletExtenderConfigurationAction
 		return StringPool.BLANK;
 	}
 
+	private DDMFormRenderingContext _createDDMFormRenderingContext(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		DDMFormRenderingContext ddmFormRenderingContext =
+			new DDMFormRenderingContext();
+
+		ddmFormRenderingContext.setHttpServletRequest(httpServletRequest);
+		ddmFormRenderingContext.setHttpServletResponse(httpServletResponse);
+
+		Set<Locale> availableLocales = _ddmForm.getAvailableLocales();
+
+		Locale locale = _ddmForm.getDefaultLocale();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (availableLocales.contains(themeDisplay.getLocale())) {
+			locale = themeDisplay.getLocale();
+		}
+
+		ddmFormRenderingContext.setLocale(locale);
+
+		ddmFormRenderingContext.setPortletNamespace(
+			PortalUtil.getPortletNamespace(
+				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN));
+		ddmFormRenderingContext.setReadOnly(false);
+
+		return ddmFormRenderingContext;
+	}
+
 	private String _getActionURL(
 			HttpServletRequest request, PortletDisplay portletDisplay)
 		throws Exception {
@@ -173,26 +210,6 @@ public class PortletExtenderConfigurationAction
 		actionURL.setWindowState(LiferayWindowState.POP_UP);
 
 		return actionURL.toString();
-	}
-
-	private DDMFormFieldRenderingContext _getDDMFormFieldRenderingContext(
-		HttpServletRequest request, HttpServletResponse response,
-		ThemeDisplay themeDisplay, PortletDisplay portletDisplay) {
-
-		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
-			new DDMFormFieldRenderingContext();
-
-		ddmFormFieldRenderingContext.setHttpServletRequest(request);
-		ddmFormFieldRenderingContext.setHttpServletResponse(response);
-		ddmFormFieldRenderingContext.setLocale(themeDisplay.getLocale());
-		ddmFormFieldRenderingContext.setMode("edit");
-		ddmFormFieldRenderingContext.setPortletNamespace(
-			portletDisplay.getNamespace());
-		ddmFormFieldRenderingContext.setReadOnly(false);
-		ddmFormFieldRenderingContext.setShowEmptyFieldLabel(true);
-		ddmFormFieldRenderingContext.setViewMode(true);
-
-		return ddmFormFieldRenderingContext;
 	}
 
 	private void _populateFieldNames() {
@@ -260,6 +277,7 @@ public class PortletExtenderConfigurationAction
 	}
 
 	private final DDMForm _ddmForm;
+	private final DDMFormRenderer _ddmFormRenderer;
 	private final Set<String> _fieldNames = new HashSet<>();
 	private final JSONObject _preferencesJSONObject;
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
@@ -154,9 +154,7 @@ public class ContentSetElementResourceImpl
 			pagination, assetListEntry.getAssetEntriesCount(segmentsEntryIds));
 	}
 
-	private ContentSetElement _toContentSetElement(AssetEntry assetEntry)
-		throws Exception {
-
+	private ContentSetElement _toContentSetElement(AssetEntry assetEntry) {
 		DTOConverter dtoConverter = _dtoConverterRegistry.getDTOConverter(
 			assetEntry.getClassName());
 
@@ -180,7 +178,7 @@ public class ContentSetElementResourceImpl
 				setContentType(
 					() -> {
 						if (dtoConverter == null) {
-							return "Unknown";
+							return assetEntry.getClassName();
 						}
 
 						return dtoConverter.getContentType();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -215,8 +215,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, BlogPostingImage.class);
+			return outputObjectMapper.readValue(string, BlogPostingImage.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -583,7 +582,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<BlogPostingImage>>() {
 			});
@@ -640,7 +639,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 		options.addPart(
 			"blogPostingImage",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -666,8 +665,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, BlogPostingImage.class);
+			return outputObjectMapper.readValue(string, BlogPostingImage.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -202,7 +202,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, BlogPosting.class);
+			return outputObjectMapper.readValue(string, BlogPosting.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -263,7 +263,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(blogPosting),
+			inputObjectMapper.writeValueAsString(blogPosting),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -281,7 +281,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, BlogPosting.class);
+			return outputObjectMapper.readValue(string, BlogPosting.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -297,7 +297,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(blogPosting),
+			inputObjectMapper.writeValueAsString(blogPosting),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -344,7 +344,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(blogPosting),
+			inputObjectMapper.writeValueAsString(blogPosting),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -362,7 +362,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, BlogPosting.class);
+			return outputObjectMapper.readValue(string, BlogPosting.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -378,7 +378,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(blogPosting),
+			inputObjectMapper.writeValueAsString(blogPosting),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -478,7 +478,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -532,7 +532,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -588,7 +588,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -931,7 +931,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<BlogPosting>>() {
 			});
@@ -992,7 +992,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(blogPosting),
+			inputObjectMapper.writeValueAsString(blogPosting),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1012,7 +1012,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, BlogPosting.class);
+			return outputObjectMapper.readValue(string, BlogPosting.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1028,7 +1028,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(blogPosting),
+			inputObjectMapper.writeValueAsString(blogPosting),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -409,7 +409,7 @@ public abstract class BaseCommentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Comment>>() {
 			});
@@ -468,7 +468,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -487,7 +487,7 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Comment.class);
+			return outputObjectMapper.readValue(string, Comment.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -503,7 +503,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -598,7 +598,7 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Comment.class);
+			return outputObjectMapper.readValue(string, Comment.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -651,7 +651,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -668,7 +668,7 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Comment.class);
+			return outputObjectMapper.readValue(string, Comment.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -684,7 +684,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -991,7 +991,7 @@ public abstract class BaseCommentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Comment>>() {
 			});
@@ -1049,7 +1049,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1068,7 +1068,7 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Comment.class);
+			return outputObjectMapper.readValue(string, Comment.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1084,7 +1084,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1383,7 +1383,7 @@ public abstract class BaseCommentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Comment>>() {
 			});
@@ -1440,7 +1440,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1458,7 +1458,7 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Comment.class);
+			return outputObjectMapper.readValue(string, Comment.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1474,7 +1474,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1797,7 +1797,7 @@ public abstract class BaseCommentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Comment>>() {
 			});
@@ -1858,7 +1858,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1878,7 +1878,7 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Comment.class);
+			return outputObjectMapper.readValue(string, Comment.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1894,7 +1894,7 @@ public abstract class BaseCommentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(comment),
+			inputObjectMapper.writeValueAsString(comment),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -250,7 +250,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<ContentSetElement>>() {
 			});
@@ -451,7 +451,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<ContentSetElement>>() {
 			});
@@ -653,7 +653,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<ContentSetElement>>() {
 			});

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -448,7 +448,7 @@ public abstract class BaseContentStructureResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<ContentStructure>>() {
 			});
@@ -523,8 +523,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, ContentStructure.class);
+			return outputObjectMapper.readValue(string, ContentStructure.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -445,7 +445,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DocumentFolder>>() {
 			});
@@ -508,7 +508,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -528,7 +528,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DocumentFolder.class);
+			return outputObjectMapper.readValue(string, DocumentFolder.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -544,7 +544,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -660,7 +660,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DocumentFolder.class);
+			return outputObjectMapper.readValue(string, DocumentFolder.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -724,7 +724,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -743,7 +743,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DocumentFolder.class);
+			return outputObjectMapper.readValue(string, DocumentFolder.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -759,7 +759,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -810,7 +810,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -829,7 +829,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DocumentFolder.class);
+			return outputObjectMapper.readValue(string, DocumentFolder.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -845,7 +845,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1199,7 +1199,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<DocumentFolder>>() {
 			});
@@ -1262,7 +1262,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1282,7 +1282,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, DocumentFolder.class);
+			return outputObjectMapper.readValue(string, DocumentFolder.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1298,7 +1298,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(documentFolder),
+			inputObjectMapper.writeValueAsString(documentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -420,7 +420,7 @@ public abstract class BaseDocumentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Document>>() {
 			});
@@ -476,7 +476,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		options.addPart(
 			"document",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -502,7 +502,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Document.class);
+			return outputObjectMapper.readValue(string, Document.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -840,7 +840,7 @@ public abstract class BaseDocumentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Document>>() {
 			});
@@ -896,7 +896,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		options.addPart(
 			"document",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -922,7 +922,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Document.class);
+			return outputObjectMapper.readValue(string, Document.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1030,7 +1030,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Document.class);
+			return outputObjectMapper.readValue(string, Document.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1072,7 +1072,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		options.addPart(
 			"document",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -1095,7 +1095,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Document.class);
+			return outputObjectMapper.readValue(string, Document.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1140,7 +1140,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 		options.addPart(
 			"document",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -1163,7 +1163,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Document.class);
+			return outputObjectMapper.readValue(string, Document.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1270,7 +1270,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1320,7 +1320,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1373,7 +1373,7 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -464,7 +464,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<KnowledgeBaseArticle>>() {
 			});
@@ -529,7 +529,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -549,7 +549,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseArticle.class);
 		}
 		catch (Exception e) {
@@ -566,7 +566,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -692,7 +692,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseArticle.class);
 		}
 		catch (Exception e) {
@@ -764,7 +764,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -784,7 +784,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseArticle.class);
 		}
 		catch (Exception e) {
@@ -802,7 +802,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -858,7 +858,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -878,7 +878,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseArticle.class);
 		}
 		catch (Exception e) {
@@ -896,7 +896,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1008,7 +1008,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1064,7 +1064,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1122,7 +1122,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1509,7 +1509,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<KnowledgeBaseArticle>>() {
 			});
@@ -1578,7 +1578,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1598,7 +1598,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseArticle.class);
 		}
 		catch (Exception e) {
@@ -1617,7 +1617,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1992,7 +1992,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<KnowledgeBaseArticle>>() {
 			});
@@ -2061,7 +2061,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -2081,7 +2081,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseArticle.class);
 		}
 		catch (Exception e) {
@@ -2100,7 +2100,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
+			inputObjectMapper.writeValueAsString(knowledgeBaseArticle),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -200,7 +200,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<KnowledgeBaseAttachment>>() {
 			});
@@ -251,7 +251,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 
 		options.addPart(
 			"knowledgeBaseAttachment",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -277,7 +277,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseAttachment.class);
 		}
 		catch (Exception e) {
@@ -419,7 +419,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseAttachment.class);
 		}
 		catch (Exception e) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -255,7 +255,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<KnowledgeBaseFolder>>() {
 			});
@@ -315,7 +315,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -335,7 +335,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseFolder.class);
 		}
 		catch (Exception e) {
@@ -352,7 +352,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -477,7 +477,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseFolder.class);
 		}
 		catch (Exception e) {
@@ -547,7 +547,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -567,7 +567,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseFolder.class);
 		}
 		catch (Exception e) {
@@ -584,7 +584,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -639,7 +639,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -659,7 +659,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseFolder.class);
 		}
 		catch (Exception e) {
@@ -676,7 +676,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -845,7 +845,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<KnowledgeBaseFolder>>() {
 			});
@@ -909,7 +909,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -929,7 +929,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, KnowledgeBaseFolder.class);
 		}
 		catch (Exception e) {
@@ -948,7 +948,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
+			inputObjectMapper.writeValueAsString(knowledgeBaseFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -216,7 +216,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardAttachment.class);
 		}
 		catch (Exception e) {
@@ -338,7 +338,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardAttachment>>() {
 			});
@@ -389,7 +389,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 
 		options.addPart(
 			"messageBoardAttachment",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -415,7 +415,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardAttachment.class);
 		}
 		catch (Exception e) {
@@ -540,7 +540,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardAttachment>>() {
 			});
@@ -591,7 +591,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 
 		options.addPart(
 			"messageBoardAttachment",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -617,7 +617,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardAttachment.class);
 		}
 		catch (Exception e) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -219,7 +219,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardMessage.class);
 		}
 		catch (Exception e) {
@@ -289,7 +289,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -309,7 +309,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardMessage.class);
 		}
 		catch (Exception e) {
@@ -326,7 +326,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -381,7 +381,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -401,7 +401,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardMessage.class);
 		}
 		catch (Exception e) {
@@ -418,7 +418,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -530,7 +530,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -586,7 +586,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -644,7 +644,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1023,7 +1023,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardMessage>>() {
 			});
@@ -1092,7 +1092,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1112,7 +1112,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardMessage.class);
 		}
 		catch (Exception e) {
@@ -1131,7 +1131,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1495,7 +1495,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardMessage>>() {
 			});
@@ -1564,7 +1564,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1584,7 +1584,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardMessage.class);
 		}
 		catch (Exception e) {
@@ -1603,7 +1603,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardMessage),
+			inputObjectMapper.writeValueAsString(messageBoardMessage),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -453,7 +453,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardSection>>() {
 			});
@@ -518,7 +518,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -538,7 +538,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardSection.class);
 		}
 		catch (Exception e) {
@@ -555,7 +555,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -680,7 +680,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardSection.class);
 		}
 		catch (Exception e) {
@@ -750,7 +750,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -770,7 +770,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardSection.class);
 		}
 		catch (Exception e) {
@@ -787,7 +787,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -842,7 +842,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -862,7 +862,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardSection.class);
 		}
 		catch (Exception e) {
@@ -879,7 +879,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1246,7 +1246,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardSection>>() {
 			});
@@ -1315,7 +1315,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1335,7 +1335,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardSection.class);
 		}
 		catch (Exception e) {
@@ -1354,7 +1354,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardSection),
+			inputObjectMapper.writeValueAsString(messageBoardSection),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -453,7 +453,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardThread>>() {
 			});
@@ -518,7 +518,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -538,7 +538,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardThread.class);
 		}
 		catch (Exception e) {
@@ -555,7 +555,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -918,7 +918,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<MessageBoardThread>>() {
 			});
@@ -987,7 +987,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1007,7 +1007,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardThread.class);
 		}
 		catch (Exception e) {
@@ -1026,7 +1026,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1150,7 +1150,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardThread.class);
 		}
 		catch (Exception e) {
@@ -1219,7 +1219,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1239,7 +1239,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardThread.class);
 		}
 		catch (Exception e) {
@@ -1256,7 +1256,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1310,7 +1310,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1330,7 +1330,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, MessageBoardThread.class);
 		}
 		catch (Exception e) {
@@ -1347,7 +1347,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(messageBoardThread),
+			inputObjectMapper.writeValueAsString(messageBoardThread),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1459,7 +1459,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1515,7 +1515,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1573,7 +1573,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -470,7 +470,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<StructuredContentFolder>>() {
 			});
@@ -538,7 +538,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -558,7 +558,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContentFolder.class);
 		}
 		catch (Exception e) {
@@ -577,7 +577,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -965,7 +965,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<StructuredContentFolder>>() {
 			});
@@ -1035,7 +1035,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1055,7 +1055,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContentFolder.class);
 		}
 		catch (Exception e) {
@@ -1074,7 +1074,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1202,7 +1202,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContentFolder.class);
 		}
 		catch (Exception e) {
@@ -1277,7 +1277,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1297,7 +1297,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContentFolder.class);
 		}
 		catch (Exception e) {
@@ -1315,7 +1315,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1373,7 +1373,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1393,7 +1393,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContentFolder.class);
 		}
 		catch (Exception e) {
@@ -1411,7 +1411,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContentFolder),
+			inputObjectMapper.writeValueAsString(structuredContentFolder),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -452,7 +452,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<StructuredContent>>() {
 			});
@@ -515,7 +515,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -535,7 +535,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -552,7 +552,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -613,7 +613,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -685,7 +685,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -1059,7 +1059,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<StructuredContent>>() {
 			});
@@ -1443,7 +1443,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<StructuredContent>>() {
 			});
@@ -1511,7 +1511,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1531,7 +1531,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -1550,7 +1550,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1672,7 +1672,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -1740,7 +1740,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1760,7 +1760,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -1777,7 +1777,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1829,7 +1829,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1849,7 +1849,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, StructuredContent.class);
 		}
 		catch (Exception e) {
@@ -1866,7 +1866,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(structuredContent),
+			inputObjectMapper.writeValueAsString(structuredContent),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1978,7 +1978,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -2034,7 +2034,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -2092,7 +2092,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Rating.class);
+			return outputObjectMapper.readValue(string, Rating.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
@@ -178,7 +178,7 @@ public class MessageBoardAttachmentResourceTest
 				new ByteArrayInputStream(randomString.getBytes()), 0));
 
 		return MultipartBody.of(
-			binaryFileMap, __ -> _inputObjectMapper,
+			binaryFileMap, __ -> inputObjectMapper,
 			inputObjectMapper.convertValue(
 				messageBoardAttachment, HashMap.class));
 	}

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -194,7 +194,7 @@ public abstract class BaseFormDocumentResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormDocument.class);
+			return outputObjectMapper.readValue(string, FormDocument.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordFormResourceTestCase.java
@@ -116,7 +116,7 @@ public abstract class BaseFormRecordFormResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(formRecordForm),
+			inputObjectMapper.writeValueAsString(formRecordForm),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -134,7 +134,7 @@ public abstract class BaseFormRecordFormResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormRecord.class);
+			return outputObjectMapper.readValue(string, FormRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -150,7 +150,7 @@ public abstract class BaseFormRecordFormResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(formRecordForm),
+			inputObjectMapper.writeValueAsString(formRecordForm),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -138,7 +138,7 @@ public abstract class BaseFormRecordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormRecord.class);
+			return outputObjectMapper.readValue(string, FormRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -199,7 +199,7 @@ public abstract class BaseFormRecordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormRecord.class);
+			return outputObjectMapper.readValue(string, FormRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -343,7 +343,7 @@ public abstract class BaseFormRecordResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<FormRecord>>() {
 			});
@@ -409,7 +409,7 @@ public abstract class BaseFormRecordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormRecord.class);
+			return outputObjectMapper.readValue(string, FormRecord.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -229,7 +229,7 @@ public abstract class BaseFormResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Form>>() {
 			});
@@ -287,7 +287,7 @@ public abstract class BaseFormResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Form.class);
+			return outputObjectMapper.readValue(string, Form.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -333,7 +333,7 @@ public abstract class BaseFormResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(form),
+			inputObjectMapper.writeValueAsString(form),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -350,7 +350,7 @@ public abstract class BaseFormResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Form.class);
+			return outputObjectMapper.readValue(string, Form.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -366,7 +366,7 @@ public abstract class BaseFormResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(form),
+			inputObjectMapper.writeValueAsString(form),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -394,7 +394,7 @@ public abstract class BaseFormResourceTestCase {
 
 		options.addPart(
 			"form",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -417,7 +417,7 @@ public abstract class BaseFormResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormDocument.class);
+			return outputObjectMapper.readValue(string, FormDocument.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -242,7 +242,7 @@ public abstract class BaseFormStructureResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<FormStructure>>() {
 			});
@@ -309,7 +309,7 @@ public abstract class BaseFormStructureResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, FormStructure.class);
+			return outputObjectMapper.readValue(string, FormStructure.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseEmailResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseEmailResourceTestCase.java
@@ -133,7 +133,7 @@ public abstract class BaseEmailResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Email.class);
+			return outputObjectMapper.readValue(string, Email.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -230,7 +230,7 @@ public abstract class BaseEmailResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Email>>() {
 			});
@@ -327,7 +327,7 @@ public abstract class BaseEmailResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Email>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -416,7 +416,7 @@ public abstract class BaseKeywordResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Keyword>>() {
 			});
@@ -476,7 +476,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(keyword),
+			inputObjectMapper.writeValueAsString(keyword),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -496,7 +496,7 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Keyword.class);
+			return outputObjectMapper.readValue(string, Keyword.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -512,7 +512,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(keyword),
+			inputObjectMapper.writeValueAsString(keyword),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -608,7 +608,7 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Keyword.class);
+			return outputObjectMapper.readValue(string, Keyword.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -661,7 +661,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(keyword),
+			inputObjectMapper.writeValueAsString(keyword),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -678,7 +678,7 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Keyword.class);
+			return outputObjectMapper.readValue(string, Keyword.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -694,7 +694,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(keyword),
+			inputObjectMapper.writeValueAsString(keyword),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -248,7 +248,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Organization>>() {
 			});
@@ -521,7 +521,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Organization>>() {
 			});
@@ -588,7 +588,7 @@ public abstract class BaseOrganizationResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Organization.class);
+			return outputObjectMapper.readValue(string, Organization.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -936,7 +936,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Organization>>() {
 			});
@@ -1109,7 +1109,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Organization>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -178,7 +178,7 @@ public abstract class BasePhoneResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Phone>>() {
 			});
@@ -231,7 +231,7 @@ public abstract class BasePhoneResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Phone.class);
+			return outputObjectMapper.readValue(string, Phone.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -327,7 +327,7 @@ public abstract class BasePhoneResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Phone>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -189,7 +189,7 @@ public abstract class BasePostalAddressResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<PostalAddress>>() {
 			});
@@ -251,7 +251,7 @@ public abstract class BasePostalAddressResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, PostalAddress.class);
+			return outputObjectMapper.readValue(string, PostalAddress.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -361,7 +361,7 @@ public abstract class BasePostalAddressResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<PostalAddress>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -179,7 +179,7 @@ public abstract class BaseRoleResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Role>>() {
 			});
@@ -228,7 +228,7 @@ public abstract class BaseRoleResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Role>>() {
 			});
@@ -282,7 +282,7 @@ public abstract class BaseRoleResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, Role.class);
+			return outputObjectMapper.readValue(string, Role.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -378,7 +378,7 @@ public abstract class BaseRoleResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Role>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -231,7 +231,7 @@ public abstract class BaseSegmentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Segment>>() {
 			});
@@ -418,7 +418,7 @@ public abstract class BaseSegmentResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<Segment>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -234,7 +234,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<SegmentUser>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -459,7 +459,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<TaxonomyCategory>>() {
 			});
@@ -523,7 +523,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -543,8 +543,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, TaxonomyCategory.class);
+			return outputObjectMapper.readValue(string, TaxonomyCategory.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -560,7 +559,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -681,8 +680,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, TaxonomyCategory.class);
+			return outputObjectMapper.readValue(string, TaxonomyCategory.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -748,7 +746,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -768,8 +766,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, TaxonomyCategory.class);
+			return outputObjectMapper.readValue(string, TaxonomyCategory.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -785,7 +782,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -837,7 +834,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -857,8 +854,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, TaxonomyCategory.class);
+			return outputObjectMapper.readValue(string, TaxonomyCategory.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -874,7 +870,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1236,7 +1232,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<TaxonomyCategory>>() {
 			});
@@ -1300,7 +1296,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1320,8 +1316,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
-				string, TaxonomyCategory.class);
+			return outputObjectMapper.readValue(string, TaxonomyCategory.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1338,7 +1333,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyCategory),
+			inputObjectMapper.writeValueAsString(taxonomyCategory),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -452,7 +452,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<TaxonomyVocabulary>>() {
 			});
@@ -517,7 +517,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyVocabulary),
+			inputObjectMapper.writeValueAsString(taxonomyVocabulary),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -537,7 +537,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, TaxonomyVocabulary.class);
 		}
 		catch (Exception e) {
@@ -554,7 +554,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyVocabulary),
+			inputObjectMapper.writeValueAsString(taxonomyVocabulary),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -678,7 +678,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, TaxonomyVocabulary.class);
 		}
 		catch (Exception e) {
@@ -747,7 +747,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyVocabulary),
+			inputObjectMapper.writeValueAsString(taxonomyVocabulary),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -767,7 +767,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, TaxonomyVocabulary.class);
 		}
 		catch (Exception e) {
@@ -784,7 +784,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyVocabulary),
+			inputObjectMapper.writeValueAsString(taxonomyVocabulary),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -838,7 +838,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyVocabulary),
+			inputObjectMapper.writeValueAsString(taxonomyVocabulary),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -858,7 +858,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(
+			return outputObjectMapper.readValue(
 				string, TaxonomyVocabulary.class);
 		}
 		catch (Exception e) {
@@ -875,7 +875,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(taxonomyVocabulary),
+			inputObjectMapper.writeValueAsString(taxonomyVocabulary),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -150,7 +150,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, UserAccount.class);
+			return outputObjectMapper.readValue(string, UserAccount.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -490,7 +490,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<UserAccount>>() {
 			});
@@ -764,7 +764,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<UserAccount>>() {
 			});
@@ -832,7 +832,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, UserAccount.class);
+			return outputObjectMapper.readValue(string, UserAccount.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -885,7 +885,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		options.addPart(
 			"userAccount",
-			_inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+			inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -907,7 +907,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, UserAccount.class);
+			return outputObjectMapper.readValue(string, UserAccount.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1023,7 +1023,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, UserAccount.class);
+			return outputObjectMapper.readValue(string, UserAccount.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1079,7 +1079,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(userAccount),
+			inputObjectMapper.writeValueAsString(userAccount),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1097,7 +1097,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, UserAccount.class);
+			return outputObjectMapper.readValue(string, UserAccount.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -1113,7 +1113,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		Http.Options options = _createHttpOptions();
 
 		options.setBody(
-			_inputObjectMapper.writeValueAsString(userAccount),
+			inputObjectMapper.writeValueAsString(userAccount),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 
 		String location =
@@ -1434,7 +1434,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<UserAccount>>() {
 			});

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -179,7 +179,7 @@ public abstract class BaseWebUrlResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<WebUrl>>() {
 			});
@@ -277,7 +277,7 @@ public abstract class BaseWebUrlResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<WebUrl>>() {
 			});
@@ -331,7 +331,7 @@ public abstract class BaseWebUrlResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WebUrl.class);
+			return outputObjectMapper.readValue(string, WebUrl.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -139,7 +139,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WorkflowLog.class);
+			return outputObjectMapper.readValue(string, WorkflowLog.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -298,7 +298,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<WorkflowLog>>() {
 			});

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -236,7 +236,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<WorkflowTask>>() {
 			});
@@ -290,7 +290,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<WorkflowTask>>() {
 			});
@@ -344,7 +344,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 			_log.debug("HTTP response: " + string);
 		}
 
-		return _outputObjectMapper.readValue(
+		return outputObjectMapper.readValue(
 			string,
 			new TypeReference<Page<WorkflowTask>>() {
 			});
@@ -407,7 +407,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WorkflowTask.class);
+			return outputObjectMapper.readValue(string, WorkflowTask.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -474,7 +474,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WorkflowTask.class);
+			return outputObjectMapper.readValue(string, WorkflowTask.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -548,7 +548,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WorkflowTask.class);
+			return outputObjectMapper.readValue(string, WorkflowTask.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -622,7 +622,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WorkflowTask.class);
+			return outputObjectMapper.readValue(string, WorkflowTask.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);
@@ -695,7 +695,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		}
 
 		try {
-			return _outputObjectMapper.readValue(string, WorkflowTask.class);
+			return outputObjectMapper.readValue(string, WorkflowTask.class);
 		}
 		catch (Exception e) {
 			_log.error("Unable to process HTTP response: " + string, e);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java
@@ -71,6 +71,8 @@ public class PublishLayoutPageTemplateEntryMVCActionCommand
 		catch (Throwable t) {
 			throw new Exception(t);
 		}
+
+		sendRedirect(actionRequest, actionResponse);
 	}
 
 	private static final TransactionConfig _transactionConfig =

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
@@ -52,8 +52,6 @@ SearchContainer searchContainer = new SearchContainer(renderRequest, null, null,
 
 mbAdminListDisplayContext.setEntriesDelta(searchContainer);
 
-searchContainer.setId("mbEntries");
-
 mbEntriesManagementToolbarDisplayContext.populateOrder(searchContainer);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
@@ -82,7 +80,6 @@ String entriesNavigation = ParamUtil.getString(request, "entriesNavigation", "al
 	filterLabelItems="<%= mbEntriesManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= searchContainer.getTotal() %>"
 	searchActionURL="<%= mbEntriesManagementToolbarDisplayContext.getSearchActionURL() %>"
-	searchContainerId="mbEntries"
 	searchFormName="searchFm"
 	showInfoButton="<%= false %>"
 	sortingOrder="<%= mbEntriesManagementToolbarDisplayContext.getOrderByType() %>"

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -807,9 +807,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 			Http.Options options = _createHttpOptions();
 
 			<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch", "post", "put") && invokeArguments?ends_with(",${schemaVarName}")>
-				options.setBody(_inputObjectMapper.writeValueAsString(${schemaVarName}), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+				options.setBody(inputObjectMapper.writeValueAsString(${schemaVarName}), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 			<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch", "post", "put") && invokeArguments?ends_with("multipartBody")>
-				options.addPart("${schemaVarName}", _inputObjectMapper.writeValueAsString(multipartBody.getValues()));
+				options.addPart("${schemaVarName}", inputObjectMapper.writeValueAsString(multipartBody.getValues()));
 
 				BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -865,7 +865,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 			<#if stringUtil.equals(javaMethodSignature.returnType, "boolean")>
 				try {
-					return _outputObjectMapper.readValue(string, Boolean.class);
+					return outputObjectMapper.readValue(string, Boolean.class);
 				}
 				catch (Exception e) {
 					_log.error("Unable to process HTTP response: " + string, e);
@@ -873,12 +873,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					throw e;
 				}
 			<#elseif javaMethodSignature.returnType?contains("Page<")>
-				return _outputObjectMapper.readValue(string, new TypeReference<Page<${schemaName}>>() {});
+				return outputObjectMapper.readValue(string, new TypeReference<Page<${schemaName}>>() {});
 			<#elseif javaMethodSignature.returnType?ends_with("String")>
 				return string;
 			<#elseif !stringUtil.equals(javaMethodSignature.returnType, "void")>
 				try {
-					return _outputObjectMapper.readValue(string, ${javaMethodSignature.returnType}.class);
+					return outputObjectMapper.readValue(string, ${javaMethodSignature.returnType}.class);
 				}
 				catch (Exception e) {
 					_log.error("Unable to process HTTP response: " + string, e);
@@ -892,7 +892,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 			Http.Options options = _createHttpOptions();
 
 			<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch", "post", "put") && invokeArguments?ends_with(",${schemaVarName}")>
-				options.setBody(_inputObjectMapper.writeValueAsString(${schemaVarName}), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+				options.setBody(inputObjectMapper.writeValueAsString(${schemaVarName}), ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 			</#if>
 
 			<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "delete")>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Organization.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Organization.macro
@@ -91,13 +91,11 @@ definition {
 	}
 
 	macro addCommentCP {
-		Organization.gotoMiscellaneousCP();
+		AssertElementPresent(locator1 = "TextArea#COMMENTS");
 
 		Type(locator1 = "TextArea#COMMENTS", value1 = "${orgComment}");
 
 		PortletEntry.save();
-
-		Organization.gotoMiscellaneousCP();
 
 		AssertTextEquals(locator1 = "TextArea#COMMENTS", value1 = "${orgComment}");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Page.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Page.macro
@@ -364,17 +364,17 @@ definition {
 		}
 	}
 
-	macro toggleShowInPagesHierarchyMenu {
+	macro toggleHiddenFromNavigationMenuWidget {
 		if ("${toggleValue}" == "enable") {
 			Check.checkToggleSwitch(
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH",
-				key_toggleSwitchLabel = "Pages Hierarchy Menu"
+				key_toggleSwitchLabel = "Hidden from Navigation Menu Widget"
 			);
 		}
 		else if ("${toggleValue}" == "disable") {
 			Uncheck.uncheckToggleSwitch(
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH",
-				key_toggleSwitchLabel = "Pages Hierarchy Menu"
+				key_toggleSwitchLabel = "Hidden from Navigation Menu Widget"
 			);
 		}
 		else {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
@@ -309,6 +309,8 @@ definition {
 
 	@summary = "Assert that certain template attributes are present for the template '${templateName}'"
 	macro viewCP {
+		var key_ddlStructureName = "${structureName}";
+		var key_ddlTemplateDescription = "${templateDescription}";
 		var key_ddlTemplateName = "${templateName}";
 
 		AssertTextEquals(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
@@ -313,6 +313,8 @@ definition {
 		var key_ddlTemplateDescription = "${templateDescription}";
 		var key_ddlTemplateName = "${templateName}";
 
+		LexiconEntry.changeDisplayStyle(displayStyle = "table");
+
 		AssertTextEquals(
 			locator1 = "DDMSelectTemplate#TEMPLATE_TABLE_NAME",
 			value1 = "${templateName}"

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -415,7 +415,7 @@
 </tr>
 <tr>
 	<td>PUBLISH</td>
-	<td>//button[span[contains(.,'Publish')]] | //button[contains(text(),'Publish')]</td>
+	<td>//button[span[contains(.,'Publish')]] | //div[contains(@class,'button-holder')]//button[contains(text(),'Publish')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditTemplate.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditTemplate.path
@@ -15,7 +15,7 @@
 </tr>
 <tr>
 	<td>SCRIPT_FIELD</td>
-	<td>//div[contains(@class,'palette-section') and contains(@id,'fields')]//ul/li/span[contains(.,'${key_fieldName}')]</td>
+	<td>//fieldset[contains(@class,'palette-section') and contains(@id,'fields')]//ul/li/span[contains(.,'${key_fieldName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -56,7 +56,7 @@
 <!--DETAILS-->
 <tr>
 	<td>DETAILS_SELECT_STRUCTURE</td>
-	<td>//a[contains(@href,'openDDMStructureSelector')]/span</td>
+	<td>//button[contains(@id,'selectDDMStructure')]/span</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectTemplate.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectTemplate.path
@@ -31,7 +31,7 @@
 </tr>
 <tr>
 	<td>TEMPLATE_TABLE_NAME</td>
-	<td>xpath=(//div[contains(@id,'ddmTemplatesSearchContainer')]//tr[contains(.,'${key_ddlTemplateName}')]/td[3])[1]</td>
+	<td>//div[contains(@id,'ddmTemplatesSearchContainer')]//td[3]/a[contains(.,'${key_ddlTemplateName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -46,7 +46,7 @@
 </tr>
 <tr>
 	<td>TEMPLATE_TABLE_DESCRIPTION</td>
-	<td>xpath=(//div[contains(@id,'ddmTemplatesSearchContainer')]//tr[contains(.,'${key_ddlTemplateName}')]/td[4])[1]</td>
+	<td>xpath=(//div[contains(@id,'ddmTemplatesSearchContainer')]//td[4])[contains(.,'${key_ddlTemplateDescription}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -56,12 +56,12 @@
 </tr>
 <tr>
 	<td>TEMPLATE_TABLE_MODE</td>
-	<td>xpath=(//div[contains(@id,'ddmTemplatesSearchContainer')]//tr[contains(.,'${key_ddlTemplateName}')]/td[5])[1]</td>
+	<td>xpath=(//div[contains(@id,'ddmTemplatesSearchContainer')]//td[5])[contains(.,'${key_ddlStructureName}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TEMPLATE_TABLE_LANGUAGE</td>
-	<td>xpath=(//div[contains(@id,'ddmTemplatesSearchContainer')]//tr[contains(.,'${key_ddlTemplateName}')]/td[6])[1]</td>
+	<td>//div[contains(@id,'ddmTemplatesSearchContainer')]//td[6]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -1602,10 +1602,8 @@ definition {
 			portlet = "Pages"
 		);
 
-		SitePages.addPublicPage(pageName = "Web Content Staging Page");
-
 		Navigator.gotoSitePage(
-			pageName = "Web Content Staging Page",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 
@@ -1626,7 +1624,7 @@ definition {
 		AssertElementNotPresent(locator1 = "Staging#STAGING_PUBLISH_TO_LIVE_BUTTON");
 
 		Navigator.gotoSitePage(
-			pageName = "Web Content Staging Page",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 
@@ -1635,7 +1633,7 @@ definition {
 		Staging.publishToLive();
 
 		Navigator.gotoSitePage(
-			pageName = "Web Content Staging Page",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 
@@ -1645,14 +1643,14 @@ definition {
 		);
 
 		Navigator.gotoSitePage(
-			pageName = "Web Content Staging Page",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 
 		Staging.publishToLiveNowViaPortletPG();
 
 		Navigator.gotoSitePage(
-			pageName = "Web Content Staging Page",
+			pageName = "Staging Test Page",
 			siteName = "Remote Site"
 		);
 
@@ -1937,17 +1935,15 @@ definition {
 			portlet = "Pages"
 		);
 
-		SitePages.addPublicPage(pageName = "Test Page Name");
-
 		Navigator.gotoStagedSitePage(
-			pageName = "Test Page Name",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 
 		Staging.addPageVariationPG(pageVariationName = "Test Page Variation Name");
 
 		Navigator.gotoStagedSitePage(
-			pageName = "Test Page Name",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 
@@ -1977,7 +1973,7 @@ definition {
 		User.deleteCP();
 
 		Navigator.gotoStagedSitePage(
-			pageName = "Test Page Name",
+			pageName = "Staging Test Page",
 			siteName = "Site Name"
 		);
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/navigationmenus/NavigationMenuWidgetUsingPageHierarchy.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/navigationmenus/NavigationMenuWidgetUsingPageHierarchy.testcase
@@ -27,7 +27,7 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-87134. Assert we can navigate to a child page in the Navigation Menu widget using pages hierarchy menu."
+	@description = "This is a test for LPS-87134. Assert we can navigate to a child page in the Navigation Menu widget."
 	@priority = "5"
 	test AddChildPage {
 		task ("Add a page and child page to the site") {
@@ -50,7 +50,7 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-87134. Assert we can navigate to different pages in the Navigation Menu widget using pages hierarchy menu."
+	@description = "This is a test for LPS-87134. Assert we can navigate to different pages in the Navigation Menu widget."
 	@priority = "5"
 	test AddMultiplePages {
 		task ("Add three pages to the site") {
@@ -120,7 +120,7 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-87134. Assert we can hide pages in the Navigation Menu widget using pages hierarchy menu."
+	@description = "This is a test for LPS-87134. Assert we can hide pages in the Navigation Menu widget."
 	@priority = "4"
 	test HidePages {
 		task ("Add a page to the site") {
@@ -145,7 +145,7 @@ definition {
 				pageName = "Site Page Visible"
 			);
 
-			Page.toggleShowInPagesHierarchyMenu(toggleValue = "enable");
+			Page.toggleHiddenFromNavigationMenuWidget(toggleValue = "disable");
 
 			Button.clickSave();
 		}
@@ -158,7 +158,7 @@ definition {
 				pageName = "Site Page Hidden"
 			);
 
-			Page.toggleShowInPagesHierarchyMenu(toggleValue = "disable");
+			Page.toggleHiddenFromNavigationMenuWidget(toggleValue = "enable");
 
 			Button.clickSave();
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91094

Notes from @matthewchan123:
> This PR addresses an issue affecting the messageboard toolbar. When a user tries to filter by thread and subsequently by categories, the number of results is not updated, showing only the number results for threads.
> 
> According to a comment made by eduardolundgren in this issue discussion, senna.js has a default behavior to paint the first page load contents when a surface object cannot be found. The object in question was found to be searchContainer through testing.
> 
> A proposed fix implemented in this PR is to remove the searchContainerId parameter from messageBoard toolbar altogether. This solution was inspired by edit_permissions.jsp in portlet-configuration-web whose toolbar is written without a searchContainerId field. By removing this field, Senna no longer looks for searchContainer, avoiding the check for a surface that it cannot find.
> 
> After applying this fix, the messageboard toolbar updates as expected the number of filter results, with no noticeable effect on the portlet's search capabilities.