### PR TITLE
LPS-92354 Template JS is stripped with a syntax error

### DIFF
--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/frontend/js/minifier/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/frontend/js/minifier/GoogleJavaScriptMinifier.java
@@ -70,6 +70,10 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 				SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
 				compilerOptions);
 
+			if (compiler.hasErrors()) {
+				return content;
+			}
+
 			return compiler.toSource();
 		}
 		finally {

--- a/modules/apps/frontend-js/frontend-js-minifier/src/test/java/com/frontend/js/minifier/GoogleJavascriptMinifierTest.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/test/java/com/frontend/js/minifier/GoogleJavascriptMinifierTest.java
@@ -34,7 +34,7 @@ public class GoogleJavascriptMinifierTest {
 		GoogleJavaScriptMinifier googleJavaScriptMinifier =
 			new GoogleJavaScriptMinifier();
 
-		String code = "function(){ var abcd; var efgh; }";
+		String code = "function(){ var invalidFunctionExpression; }";
 
 		try (CaptureHandler captureHandler =
 				JDKLoggerTestUtil.configureJDKLogger(
@@ -42,7 +42,7 @@ public class GoogleJavascriptMinifierTest {
 
 			String minifiedJS = googleJavaScriptMinifier.compress("test", code);
 
-			Assert.assertEquals(0, minifiedJS.length());
+			Assert.assertEquals(44, minifiedJS.length());
 
 			List<LogRecord> logRecords = captureHandler.getLogRecords();
 


### PR DESCRIPTION
Previous pr: https://github.com/SamZiemer/liferay-portal/pull/582

https://issues.liferay.com/browse/LPS-92354

Second commit changes are to reflect the customer's requests that bad code would be reflected in the DOM and not stripped. 

I have opened a [PTR-823](https://issues.liferay.com/browse/PTR-823) to get clarification on the fix and the written test that I have changed. 
