### PR TITLE
LPS-82213 Portlet title is not saved after change from site

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdatePortletTitleAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdatePortletTitleAction.java
@@ -16,7 +16,6 @@ package com.liferay.portal.action;
 
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
@@ -65,8 +64,7 @@ public class UpdatePortletTitleAction extends JSONAction {
 		String title = ParamUtil.getString(request, "title");
 
 		PortletPreferences portletSetup =
-			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-				layout, portletId);
+			themeDisplay.getStrictLayoutPortletSetup(layout, portletId);
 
 		portletSetup.setValue("portletSetupTitle_" + languageId, title);
 		portletSetup.setValue("portletSetupUseCustomTitle", "true");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82213

Header portlets could not save the changed portlet's display name. The name is saved in the database under a new field, but when fetching for the data it would search for the root data since the portlet is in the header. Portlets that are under the section of the page is saved correctly since it's created as a new instance.

The fix is to fetch the correct data setup. If it was a header portlet, it would fetch the original field/preferences in the database. Section portlets still store in the same field/preferences that was created for that instance in the database. The change is that header portlets are saving into their original preference because the page refresh fetches the original preference of the header portlets.