### PR TITLE
LPS-95138 Wiki content out of range in portlet

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/css/main.scss
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/css/main.scss
@@ -20,6 +20,8 @@
 	}
 
 	.wiki-body, .wiki-page-editor {
+		word-wrap: break-word;
+
 		img {
 			max-width: 100%;
 		}


### PR DESCRIPTION
Previous pr: https://github.com/SamZiemer/liferay-portal/pull/589

Was replaced by LPS-95135 due to mislabeling ticket LPS-95135.

https://issues.liferay.com/browse/LPS-95138