### PR TITLE
LPS-95208 Check needs to be stricter because friendlyURLs will be checked initially.

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -478,8 +478,10 @@ public class FriendlyURLServlet extends HttpServlet {
 		public boolean isValidForward() {
 			String path = getPath();
 
-			if (!path.startsWith(Portal.PATH_MAIN)) {
-				return false;
+			if (!path.equals(Portal.PATH_MAIN)) {
+				if (!path.startsWith("/c/")) {
+					return false;
+				}
 			}
 
 			if (isForce()) {

--- a/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
@@ -544,8 +544,10 @@ public class FriendlyURLServlet extends HttpServlet {
 		public boolean isValidForward() {
 			String path = getPath();
 
-			if (!path.startsWith(Portal.PATH_MAIN)) {
-				return false;
+			if (!path.equals(Portal.PATH_MAIN)) {
+				if (!path.startsWith("/c/")) {
+					return false;
+				}
 			}
 
 			if (isForce()) {


### PR DESCRIPTION
Hello @SamZiemer ,

https://issues.liferay.com/browse/LPS-95208

There is an edge case from LPS-93973 that needs to be resolved in this ticket.

The edge case is described here: https://issues.liferay.com/browse/LPS-95208

The fix is to make the check introduced here: https://github.com/liferay/liferay-portal/commit/f78a1a825da5c28eba6fd8523c39b30828296241 to be stricter.

We essentially want forwarding to occur only if the path is equal to Portal.PATH_MAIN ("/c") or if it starts with ("/c/"), for ex. /c/portal/layout. 

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim