### PR TITLE
LPS-94869

### DIFF
--- a/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/resources/META-INF/resources/details.jsp
+++ b/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/resources/META-INF/resources/details.jsp
@@ -22,7 +22,7 @@ CTCollection ctCollection = (CTCollection)request.getAttribute(CTWebKeys.CT_COLL
 SearchContainer<CTEntry> ctEntrySearchContainer = changeListsHistoryDisplayContext.getCTCollectionDetailsSearchContainer(ctCollection);
 
 if (ctCollection != null) {
-	String title = HtmlUtil.escapeJS(ctCollection.getName());
+	String title = HtmlUtil.escape(ctCollection.getName());
 
 	portletDisplay.setTitle(title);
 

--- a/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/action/PortletExtenderConfigurationAction.java
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/portlet/action/PortletExtenderConfigurationAction.java
@@ -14,7 +14,6 @@
 
 package com.liferay.frontend.js.portlet.extender.internal.portlet.action;
 
-import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
@@ -37,7 +36,6 @@ import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -131,7 +129,17 @@ public class PortletExtenderConfigurationAction
 		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
 			String key = entry.getKey();
 
-			String name = key.split("_INSTANCE")[0];
+			if (!key.startsWith("ddm$$")) {
+				continue;
+			}
+
+			String[] names = key.split("\\$");
+
+			if (names.length < 3) {
+				continue;
+			}
+
+			String name = names[2];
 
 			if (!_fieldNames.contains(name)) {
 				continue;
@@ -183,9 +191,11 @@ public class PortletExtenderConfigurationAction
 
 		ddmFormRenderingContext.setLocale(locale);
 
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
 		ddmFormRenderingContext.setPortletNamespace(
-			PortalUtil.getPortletNamespace(
-				DDMPortletKeys.DYNAMIC_DATA_MAPPING_FORM_ADMIN));
+			portletDisplay.getNamespace());
+
 		ddmFormRenderingContext.setReadOnly(false);
 
 		return ddmFormRenderingContext;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -69,13 +69,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		UserLocalServiceUtil.deleteGroupUser(
 			testGroup.getGroupId(), _testUser.getUserId());
 
-		Indexer<User> indexer = IndexerRegistryUtil.getIndexer(
+		List<User> users = UserLocalServiceUtil.getUsers(
+			PortalUtil.getDefaultCompanyId(), false,
+			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			_testUser.getModelClassName());
 
-		if (indexer != null) {
-			indexer.reindex(
-				_testUser.getModelClassName(), _testUser.getUserId());
-		}
+		indexer.reindex(users);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -69,13 +69,13 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		UserLocalServiceUtil.deleteGroupUser(
 			testGroup.getGroupId(), _testUser.getUserId());
 
+		Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			_testUser.getModelClassName());
+
 		List<User> users = UserLocalServiceUtil.getUsers(
 			PortalUtil.getDefaultCompanyId(), false,
 			WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
-
-		Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
-			_testUser.getModelClassName());
 
 		indexer.reindex(users);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/spi/scope/finder/OAuth2ProviderShortcutScopeFinder.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/spi/scope/finder/OAuth2ProviderShortcutScopeFinder.java
@@ -19,7 +19,6 @@ import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandler;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
-import com.liferay.oauth2.provider.shortcut.internal.constants.OAuth2ProviderShortcutConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
@@ -31,22 +30,9 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * @author Shinn Lok
  */
-@Component(
-	immediate = true,
-	property = {
-		"osgi.jaxrs.name=" + OAuth2ProviderShortcutConstants.APPLICATION_NAME,
-		"sap.scope.finder=true"
-	},
-	service = {
-		ApplicationDescriptor.class, PrefixHandlerFactory.class,
-		ScopeFinder.class, ScopeMapper.class
-	}
-)
 public class OAuth2ProviderShortcutScopeFinder
 	implements ApplicationDescriptor, PrefixHandlerFactory, ScopeFinder,
 			   ScopeMapper {

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/servlet/taglib/ProductNavigationControlMenuTopHeadDynamicInclude.java
@@ -14,7 +14,6 @@
 
 package com.liferay.product.navigation.control.menu.theme.contributor.internal.servlet.taglib;
 
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -53,12 +52,6 @@ public class ProductNavigationControlMenuTopHeadDynamicInclude
 				WebKeys.THEME_DISPLAY);
 
 		if (!themeDisplay.isSignedIn()) {
-			return;
-		}
-
-		Layout layout = themeDisplay.getLayout();
-
-		if (layout.isTypeControlPanel()) {
 			return;
 		}
 

--- a/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/servlet/taglib/SocialBookmarkTag.java
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/servlet/taglib/SocialBookmarkTag.java
@@ -17,12 +17,12 @@ package com.liferay.social.bookmarks.taglib.servlet.taglib;
 import com.liferay.social.bookmarks.SocialBookmark;
 import com.liferay.social.bookmarks.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.social.bookmarks.taglib.internal.util.SocialBookmarksRegistryUtil;
+import com.liferay.taglib.servlet.PipingServletResponse;
 import com.liferay.taglib.util.AttributesTagSupport;
 
 import java.io.IOException;
 
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 
@@ -56,7 +56,8 @@ public class SocialBookmarkTag extends AttributesTagSupport {
 
 				socialBookmark.render(
 					_target, _title, _url, request,
-					(HttpServletResponse)pageContext.getResponse());
+					PipingServletResponse.createPipingServletResponse(
+						pageContext));
 			}
 
 			return EVAL_PAGE;

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -1489,6 +1489,8 @@ definition {
 			permissionDefinitionKey = "CONFIGURATION_PERMISSIONS_VIEW_CHECKBOX",
 			roleTitle = "Site Member");
 
+		IFrame.closeFrame();
+
 		SearchPortlets.configureDestination(destinationPage = "Search Page");
 
 		User.logoutPG();
@@ -1565,6 +1567,8 @@ definition {
 		PermissionsInline.viewPermissionsChecked(
 			permissionDefinitionKey = "CONFIGURATION_PERMISSIONS_VIEW_CHECKBOX",
 			roleTitle = "Site Member");
+
+		IFrame.closeFrame();
 
 		User.logoutPG();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SolrSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SolrSearch.testcase
@@ -1242,6 +1242,8 @@ definition {
 			permissionDefinitionKey = "CONFIGURATION_PERMISSIONS_VIEW_CHECKBOX",
 			roleTitle = "Site Member");
 
+		IFrame.closeFrame();
+
 		SearchPortlets.configureDestination(destinationPage = "Search Page");
 
 		User.logoutPG();
@@ -1318,6 +1320,8 @@ definition {
 		PermissionsInline.viewPermissionsChecked(
 			permissionDefinitionKey = "CONFIGURATION_PERMISSIONS_VIEW_CHECKBOX",
 			roleTitle = "Site Member");
+
+		IFrame.closeFrame();
 
 		User.logoutPG();
 


### PR DESCRIPTION
Hello @SamZiemer ,

https://issues.liferay.com/browse/LPS-94869

Notes from @matthewchan123:
> Issue:
> The change list history title is being displayed as an escaped string and is not human-readable.
> 
> Cause:
> The portletDisplay title is set to an escaped string for use in a javascript context by HTMLUtil's escapeJS() function, however the portletDisplay context is actually html.
> 
> Fix:
> The two uses of title here are to set the renderResponse title for a searchContainer in ChangeListHistoryDisplayContext.java and also the portletDisplay title, which is seen in this issue. Since Javascript is never involved in these instances, we can safely modify this function call to the html version HTMLUtil.escape(), which removes the displayed escape characters in change list history.

CI Result: https://github.com/brianikim/liferay-portal/pull/22#issuecomment-490562334