### PR TITLE
LPS-96657 Include JSTL Core taglib for asset_categories_error so it can actually be used.

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_error/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_error/init.jsp
@@ -14,6 +14,8 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-96657

Hello @SamZiemer ,

The issue here is that JSTL Core Taglib usage in [page.jsp](https://github.com/liferay/liferay-portal/blob/c8f78609353d6a83a0b755b0bbf93764959821ee/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_error/page.jsp#L33-L40) does not work because the taglib is not actually being included as it was never provided.

This causes both error messages to appear because the checks never occur.

The fix is to include the taglib.

Sincerely,
Brian Kim