### PR TITLE
LPS-82471 email link to form entries page

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/notification/DDMFormEmailNotificationSender.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/notification/DDMFormEmailNotificationSender.java
@@ -445,7 +445,7 @@ public class DDMFormEmailNotificationSender {
 
 		params.put(
 			portletNamespace.concat("mvcPath"),
-			new String[] {"/admin/view_form_instance_record.jsp"});
+			new String[] {"/admin/view_form_instance_records.jsp"});
 		params.put(
 			portletNamespace.concat("formInstanceId"),
 			new String[] {String.valueOf(ddmFormInstance.getFormInstanceId())});


### PR DESCRIPTION
Hello @SamZiemer ,

Notes from @matthewchan123:

> https://issues.liferay.com/browse/LPS-82471
> 
> Issue:
> In email notifications of form submissions, a link to form entries list is broken and leads to a page displaying "Forms is temporarily unavailable."
> 
> Fix:
> There was a typo in the jsp path, most likely due to copying the params Map in [getViewFormURL()](https://github.com/liferay/liferay-portal/blob/1d525179384f1f55586c9012c83cee3504b63bbb/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/notification/DDMFormEmailNotificationSender.java#L469-L471) which provides the page for single form entry. The path should point to  "view_form_instance_records.jsp", redirecting to the intended page - the list of all entries for a form - without any error.

Sincerely,
Brian Kim