### PR TITLE
LPS-96987 Move the upgrade to the Core since the modified tables are defined there

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.internal.upgrade;
 
 import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayoutPermissions;
+import com.liferay.layout.internal.upgrade.v1_0_1.UpgradeLayoutParentPlid;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,6 +29,7 @@ public class LayoutImplUpgrade implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register("0.0.0", "1.0.0", new UpgradeLayoutPermissions());
+		registry.register("1.0.0", "1.0.1", new UpgradeLayoutParentPlid());
 	}
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
@@ -15,7 +15,7 @@
 package com.liferay.layout.internal.upgrade;
 
 import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayoutPermissions;
-import com.liferay.layout.internal.upgrade.v1_0_1.UpgradeLayoutParentPlid;
+import com.liferay.portal.upgrade.v7_2_x.UpgradeLayoutParentPlid;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -29,7 +29,6 @@ public class LayoutImplUpgrade implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register("0.0.0", "1.0.0", new UpgradeLayoutPermissions());
-		registry.register("1.0.0", "1.0.1", new UpgradeLayoutParentPlid());
 	}
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.upgrade.v1_0_1;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Matthew Chan
+ */
+public class UpgradeLayoutParentPlid extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		String sql = StringBundler.concat(
+			"create table TEMP (select l1.plid as plid, l2.plid as parentPlid ",
+			"from Layout l1 left join Layout l2 on l1.groupId = l2.groupId ",
+			"and l1.privateLayout = l2.privateLayout and l1.parentLayoutId = ",
+			"l2.layoutId)");
+
+		runSQL(sql);
+
+		runSQL("create unique index IX_TEMP on TEMP (plid)");
+
+		runSQL(
+			"update Layout set parentPlid = (select parentPlid from TEMP " +
+				"where Layout.plid = TEMP.plid)");
+
+		runSQL("drop table TEMP");
+
+		runSQL("update Layout set parentPlid = 0 where parentPlid is null");
+	}
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
@@ -25,10 +25,10 @@ public class UpgradeLayoutParentPlid extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		String sql = StringBundler.concat(
-			"create table TEMP (select l1.plid as plid, l2.plid as parentPlid ",
-			"from Layout l1 left join Layout l2 on l1.groupId = l2.groupId ",
-			"and l1.privateLayout = l2.privateLayout and l1.parentLayoutId = ",
-			"l2.layoutId)");
+			"create table TEMP as (select l1.plid as plid, l2.plid as ",
+			"parentPlid from Layout l1 left join Layout l2 on l1.groupId = ",
+			"l2.groupId and l1.privateLayout = l2.privateLayout and ",
+			"l1.parentLayoutId = l2.layoutId)");
 
 		runSQL(sql);
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_1/UpgradeLayoutParentPlid.java
@@ -35,12 +35,10 @@ public class UpgradeLayoutParentPlid extends UpgradeProcess {
 		runSQL("create unique index IX_TEMP on TEMP (plid)");
 
 		runSQL(
-			"update Layout set parentPlid = (select parentPlid from TEMP " +
-				"where Layout.plid = TEMP.plid)");
+			"update Layout set parentPlid = (select coalesce(parentPlid, 0) " +
+				"from TEMP where Layout.plid = TEMP.plid)");
 
 		runSQL("drop table TEMP");
-
-		runSQL("update Layout set parentPlid = 0 where parentPlid is null");
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/PortalUpgradeProcessRegistryImpl.java
@@ -40,6 +40,8 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeProcesses.put(new Version(5, 0, 1), new UpgradePersonalMenu());
 
 		upgradeProcesses.put(new Version(5, 0, 2), new UpgradeCountry());
+
+		upgradeProcesses.put(new Version(5, 0, 3), new UpgradeLayoutParentPlid());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/UpgradeLayoutParentPlid.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/UpgradeLayoutParentPlid.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.layout.internal.upgrade.v1_0_1;
+package com.liferay.portal.upgrade.v7_2_x;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;


### PR DESCRIPTION
Hey @SamZiemer, @matthewchan123,

I have moved the upgrade to the Core since the Layout table belongs there so we have to keep the upgrade processes which manipulates it where the table is defined:
https://github.com/liferay/liferay-portal/blob/master/sql/portal-tables.sql#L546

Apart from this, I think that the syntax CREATE TABLE AS SELECT doesn't work in DB2 (only with the clause WITH NO DATA) or SQLServer.

If the customer is in a rush, we can create a SDH but let's discuss the final solution first.

Thanks.