### PR TITLE
LPS-94690 Async status monitoring for remote staging

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -29,14 +29,10 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.application.list.PanelAppRegistry" %><%@
 page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.application.list.constants.ApplicationListWebKeys" %><%@
-page import="com.liferay.exportimport.kernel.exception.RemoteExportException" %><%@
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.ItemSelectorCriterion" %><%@
 page import="com.liferay.item.selector.criteria.URLItemSelectorReturnType" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.exception.SystemException" %><%@
-page import="com.liferay.portal.kernel.log.Log" %><%@
-page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil" %><%@

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -90,7 +90,3 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 		/>
 	</c:if>
 </c:if>
-
-<%!
-private static Log _log = LogFactoryUtil.getLog("com_liferay_product_navigation_site_administration.sites.site_administration_body_jsp");
-%>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -20,9 +20,11 @@
 PanelCategory panelCategory = (PanelCategory)request.getAttribute(ApplicationListWebKeys.PANEL_CATEGORY);
 
 SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDisplayContext = new SiteAdministrationPanelCategoryDisplayContext(liferayPortletRequest, liferayPortletResponse, null);
+
+Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 %>
 
-<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getGroup() != null %>">
+<c:if test="<%= group != null %>">
 	<div class="row">
 		<div class="col-md-12">
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() %>">
@@ -42,8 +44,8 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 					<%
 					data.put("qa-id", "live");
 
-					try {
-						String liveGroupURL = siteAdministrationPanelCategoryDisplayContext.getLiveGroupURL();
+					if (group.getTypeSettingsProperty("remoteURL") != null) {
+						String liveGroupURL = group.getTypeSettingsProperty("remoteURL");
 					%>
 
 						<span class="<%= Validator.isNull(liveGroupURL) ? "active" : StringPool.BLANK %>">
@@ -52,10 +54,7 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 
 					<%
 					}
-					catch (RemoteExportException | SystemException e) {
-						if (e instanceof SystemException) {
-							_log.error(e, e);
-						}
+					else {
 					%>
 
 						<aui:a data="<%= data %>" href="" id="remoteLiveLink" label="<%= siteAdministrationPanelCategoryDisplayContext.getLiveGroupLabel() %>" />

--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/messaging/StagingMessageListener.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/messaging/StagingMessageListener.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
+import com.liferay.portal.kernel.scheduler.SchedulerEntry;
+import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
+import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.scheduler.Trigger;
+import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.util.PropsValues;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Kimberly Chau
+ */
+@Component(immediate = true, service = StagingMessageListener.class)
+public class StagingMessageListener extends BaseMessageListener {
+
+	@Activate
+	protected void activate() {
+		Class<?> clazz = getClass();
+
+		int connectTimeout = GetterUtil.getInteger(
+			PropsValues.TUNNELING_SERVLET_TIMEOUT);
+
+		String className = clazz.getName();
+
+		Trigger trigger = _triggerFactory.createTrigger(
+			className, className, null, null, connectTimeout,
+			TimeUnit.MILLISECOND);
+
+		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
+			className, trigger);
+
+		_schedulerEngineHelper.register(
+			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_schedulerEngineHelper.unregister(this);
+	}
+
+	@Override
+	protected void doReceive(Message message) throws Exception {
+	}
+
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	protected void setModuleServiceLifecycle(
+		ModuleServiceLifecycle moduleServiceLifecycle) {
+	}
+
+	@Reference(unbind = "-")
+	protected void setSchedulerEngineHelper(
+		SchedulerEngineHelper schedulerEngineHelper) {
+
+		_schedulerEngineHelper = schedulerEngineHelper;
+	}
+
+	private SchedulerEngineHelper _schedulerEngineHelper;
+
+	@Reference
+	private TriggerFactory _triggerFactory;
+
+}

--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/messaging/StagingMessageListener.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/messaging/StagingMessageListener.java
@@ -39,9 +39,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.util.PropsValues;
 
 import java.net.ConnectException;
 
@@ -62,14 +60,10 @@ public class StagingMessageListener extends BaseMessageListener {
 	protected void activate() {
 		Class<?> clazz = getClass();
 
-		int connectTimeout = GetterUtil.getInteger(
-			PropsValues.TUNNELING_SERVLET_TIMEOUT);
-
 		String className = clazz.getName();
 
 		Trigger trigger = _triggerFactory.createTrigger(
-			className, className, null, null, connectTimeout,
-			TimeUnit.MILLISECOND);
+			className, className, null, null, 1, TimeUnit.HOUR);
 
 		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
 			className, trigger);

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.security.auth.RemoteAuthException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -438,6 +439,21 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			userId, stagingGroup, branchingPublic, branchingPrivate, true,
 			serviceContext);
 
+		String groupDisplayURL = null;
+
+		if ((serviceContext != null) &&
+			(serviceContext.getThemeDisplay() != null)) {
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			Layout layout = themeDisplay.getLayout();
+
+			boolean privateLayout = layout.isPrivateLayout();
+
+			groupDisplayURL = GroupServiceHttp.getGroupDisplayURL(
+				httpPrincipal, remoteGroupId, privateLayout, secureConnection);
+		}
+
 		typeSettingsProperties.setProperty(
 			"branchingPrivate", String.valueOf(branchingPrivate));
 		typeSettingsProperties.setProperty(
@@ -451,6 +467,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			"remotePathContext", remotePathContext);
 		typeSettingsProperties.setProperty(
 			"remotePort", String.valueOf(remotePort));
+		typeSettingsProperties.setProperty("remoteURL", groupDisplayURL);
 		typeSettingsProperties.setProperty(
 			"secureConnection", String.valueOf(secureConnection));
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94690

Previous pr: https://github.com/moltam89/liferay-portal/pull/502
Changes due to this https://github.com/moltam89/liferay-portal/pull/502#issuecomment-504002295

The issue is when the site is staging. At every page load of the Control Panel, the local server would send a request to the remote server. This can cause the site to hang because the request is sent in [SiteAdministrationPanelCategroyDisplayContext.getLiveGroupURL](https://github.com/SamZiemer/liferay-portal/compare/master...knchau:LPS-94690_1?expand=1#diff-2db79331dcd02f15d22749213538877fL46). The timeout can take 30 seconds.

My changes move the logic to the backend in a thread using the quartz scheduler. The quartz scheduler monitors the remote server's connection and updates the remote display URL. The listener would periodically ping the remote server and update its remote URL every hour. It initially caches the remote URL when remote staging is enabled -- https://github.com/SamZiemer/liferay-portal/commit/57f4925b957ad34854bb9497d824c927c203d79f. The remote URL value is cached in the group's type settings. 

https://github.com/SamZiemer/liferay-portal/commit/d8c88e4d967963a15d0f01f274a27111c95c52e8 -- It dynamically fetches all groups, then checks for those that are remotely staging and updates their remote display URL with GroupServiceHttp.getGroupDisplayURL that is in Staging.getRemoteSiteURL. It updates the group's type settings. It is not only updating the remote URL, but also monitoring the connection because it's pinging the server (in the backend).

The remote URL for the 'Remote Site' button on the Control Panel was originally updated by pinging the remote server, which can cause the site to hang because it was called on the jsp. https://github.com/SamZiemer/liferay-portal/commit/f4bde57eadb9e6785933bfe1ccba47e9987f2f35 changes it to fetch the remote URL from the group's type settings. 