### PR TITLE
LPS-97647 Run the updates in parallel to reduce the time needed to upgrade

### DIFF
--- a/modules/apps/asset/source-formatter-suppressions.xml
+++ b/modules/apps/asset/source-formatter-suppressions.xml
@@ -5,6 +5,7 @@
 		<suppress checks="PersistenceCallCheck" files="modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext\.java" />
 	</checkstyle>
 	<source-check>
+		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/internal/upgrade/v1_0_0/UpgradeAssetEntryAssetCategoryRel.java" />
 		<suppress checks="XMLServiceEntityNameCheck" files="modules/apps/asset/asset-category-property-service/service\.xml" />
 		<suppress checks="XMLServiceEntityNameCheck" files="modules/apps/asset/asset-tag-stats-service/service\.xml" />
 	</source-check>


### PR DESCRIPTION
@SamZiemer,

Let me know if there's a better way to re-write the original SQL so we can do the update in one transaction. I don't think there is because we need to generate a new PK for each row but I might be missing some way around that.

The callable format is used in `UpgradeImageTypeContent` and `UpgradeAssetDisplayPageEntry` so there is precedence for it.

Let me know if you have any questions.