### PR TITLE
LPS-97660

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8296,7 +8296,7 @@ public class PortalImpl implements Portal {
 			languageId = siteDefaultLocale.getLanguage();
 		}
 
-		return StringPool.SLASH.concat(languageId);
+		return StringPool.SLASH.concat(LocaleUtil.toW3cLanguageId(languageId));
 	}
 
 	private Map<Locale, String> _getAlternateURLs(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97660

Hello @SamZiemer ,

After the introduction of LPS-78738,  use of "_"  has been replaced with "-" in the locale of the URLs as part of SEO improvement. However, this change was not reflected in how we generate the URLs in the [head element](https://github.com/liferay/liferay-portal/blob/5bad9b73b6e3431b71543e8d5ce1d46afe8347b2/portal-web/docroot/html/common/themes/top_head.jsp#L34-L53). As a result, our SEO performance is poor.

The fix is to ensure we apply the precedent set in LPS-78738 to our creation of [alternateURLs](https://github.com/liferay/liferay-portal/blob/5bad9b73b6e3431b71543e8d5ce1d46afe8347b2/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L8302-L8339).

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim