### PR TITLE
LPS-97720 Selecting an article that is expired when filtering by Expired displays the most recent version of the content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article_title.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article_title.jsp
@@ -21,11 +21,21 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 
 JournalArticle article = (JournalArticle)row.getObject();
 
+JournalArticle latestArticle = journalDisplayContext.getLatestArticle(article);
+
 String href = (String)request.getAttribute(WebKeys.SEARCH_ENTRY_HREF);
+
+String title = article.getTitle(locale);
+
+boolean latestVersion = false;
+
+if (article.equals(latestArticle)) {
+	latestVersion = true;
+}
 %>
 
-<aui:a href="<%= href %>" title="<%= HtmlUtil.escape(article.getTitle(locale)) %>">
-	<%= HtmlUtil.escape(article.getTitle(locale)) %>
+<aui:a href="<%= href %>" title='<%= latestVersion ? null : LanguageUtil.get(request, "the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it") %>'>
+	<%= HtmlUtil.escape(title) %>
 </aui:a>
 
 <c:if test="<%= article.getGroupId() != scopeGroupId %>">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -35,6 +35,7 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 
 		<%
 		JournalArticle curArticle = null;
+		JournalArticle latestArticle = null;
 		JournalFolder curFolder = null;
 
 		Object result = row.getObject();
@@ -43,7 +44,14 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 			curFolder = (JournalFolder)result;
 		}
 		else {
-			curArticle = journalDisplayContext.getLatestArticle((JournalArticle)result);
+			curArticle = (JournalArticle)result;
+			latestArticle = journalDisplayContext.getLatestArticle(curArticle);
+		}
+
+		boolean latestVersion = false;
+
+		if (curArticle.equals(latestArticle)) {
+			latestVersion = true;
 		}
 		%>
 
@@ -108,7 +116,7 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 							</span>
 
 							<p class="font-weight-bold h5">
-								<aui:a href="<%= editURL %>">
+								<aui:a href="<%= editURL %>" title='<%= !latestVersion ? LanguageUtil.get(request, "the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it") : null %>'>
 									<%= HtmlUtil.escape(title) %>
 								</aui:a>
 							</p>
@@ -146,6 +154,10 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 						%>
 
 						<liferay-ui:search-container-column-text>
+							<c:if test="<%= !latestVersion %>">
+								<span onmouseover="Liferay.Portal.ToolTip.show(this, '<liferay-ui:message key="the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it" unicode="<%= true %>" />');">
+							</c:if>
+
 							<clay:vertical-card
 								verticalCard="<%= new JournalArticleVerticalCard(curArticle, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
 							/>

--- a/modules/test/poshi-runner/.gitrepo
+++ b/modules/test/poshi-runner/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 2f586e07928e14a424edfbf3b547a3881ca193f9
+	commit = df11f50a5429fff690a3b0cad1d94ffc8b7cf41d
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 29a30902b4b55a76eff7216bb10ad8a68d66592b
+	parent = 38ed89433d9052815917d6de8b805bf662e4a9cf
 	remote = git@github.com:liferay/com-liferay-poshi-runner.git

--- a/modules/test/poshi-runner/poshi-runner/build.gradle
+++ b/modules/test/poshi-runner/poshi-runner/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	compile group: "org.apache.ivy", name: "ivy", version: "2.4.0"
 	compile group: "org.bytedeco.javacpp-presets", name: "opencv", version: "2.4.10-0.10"
 	compile group: "org.codehaus.groovy", name: "groovy", version: "2.4.5"
-	compile group: "org.jsoup", name: "jsoup", version: "1.8.3"
+	compile group: "org.jsoup", name: "jsoup", version: "1.10.2"
 	compile group: "org.seleniumhq.selenium", name: "selenium-java", version: "3.8.1"
 	compile group: "org.sikuli", name: "sikuli-api", version: "1.2.0"
 	compile group: "xml-apis", name: "xml-apis", version: "1.4.01"

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -450,10 +450,10 @@ public class PoshiRunnerContext {
 			return commandElement.attributeValue("summary");
 		}
 
-		if (classType.equals("function")) {
-			if (Validator.isNotNull(rootElement.attributeValue("summary"))) {
-				return rootElement.attributeValue("summary");
-			}
+		if (classType.equals("function") &&
+			Validator.isNotNull(rootElement.attributeValue("summary"))) {
+
+			return rootElement.attributeValue("summary");
 		}
 
 		return classCommandName;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerValidation.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerValidation.java
@@ -1657,12 +1657,12 @@ public class PoshiRunnerValidation {
 			minimumAttributeSize = 1;
 		}
 
-		if (attributes.size() <= minimumAttributeSize) {
-			if (Validator.isNull(element.getText())) {
-				_exceptions.add(
-					new ValidationException(
-						element, "Missing value attribute\n", filePath));
-			}
+		if ((attributes.size() <= minimumAttributeSize) &&
+			Validator.isNull(element.getText())) {
+
+			_exceptions.add(
+				new ValidationException(
+					element, "Missing value attribute\n", filePath));
 		}
 
 		List<String> possibleAttributeNames = new ArrayList<>();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -185,15 +185,13 @@ public abstract class PoshiElement
 
 		generatedPoshiScript = generatedPoshiScript.replaceAll("\\s+", "");
 
-		if (elements().size() == 0) {
-			if (!originalPoshiScript.equals(generatedPoshiScript)) {
-				PoshiScriptParserException pspe =
-					new PoshiScriptParserException(
-						PoshiScriptParserException.TRANSLATION_LOSS_MESSAGE,
-						this);
+		if ((elements().size() == 0) &&
+			!originalPoshiScript.equals(generatedPoshiScript)) {
 
-				throw pspe;
-			}
+			PoshiScriptParserException pspe = new PoshiScriptParserException(
+				PoshiScriptParserException.TRANSLATION_LOSS_MESSAGE, this);
+
+			throw pspe;
 		}
 
 		if (originalPoshiScript.length() != generatedPoshiScript.length()) {
@@ -298,14 +296,13 @@ public abstract class PoshiElement
 
 			String poshiScriptSnippet = poshiNode.toPoshiScript();
 
-			if ((previousPoshiNode == null) ||
-				((previousPoshiNode instanceof VarPoshiElement) &&
-				 (poshiNode instanceof VarPoshiElement))) {
+			if (((previousPoshiNode == null) ||
+				 ((previousPoshiNode instanceof VarPoshiElement) &&
+				  (poshiNode instanceof VarPoshiElement))) &&
+				poshiScriptSnippet.startsWith("\n\n")) {
 
-				if (poshiScriptSnippet.startsWith("\n\n")) {
-					poshiScriptSnippet = poshiScriptSnippet.replaceFirst(
-						"\n\n", "\n");
-				}
+				poshiScriptSnippet = poshiScriptSnippet.replaceFirst(
+					"\n\n", "\n");
 			}
 
 			sb.append(padPoshiScriptSnippet(poshiScriptSnippet));
@@ -365,12 +362,10 @@ public abstract class PoshiElement
 		StringBuilder sb = new StringBuilder();
 
 		for (char c : poshiScriptBlock.toCharArray()) {
-			if (c == '{') {
-				if (isBalancedPoshiScript(sb.toString())) {
-					String blockName = sb.toString();
+			if ((c == '{') && isBalancedPoshiScript(sb.toString())) {
+				String blockName = sb.toString();
 
-					return blockName.trim();
-				}
+				return blockName.trim();
 			}
 
 			sb.append(c);
@@ -530,16 +525,16 @@ public abstract class PoshiElement
 		for (int i = 0; i < chars.length; i++) {
 			char c = chars[i];
 
-			if (tokenIndices.contains(i)) {
-				if (isBalancedPoshiScript(sb.toString())) {
-					nestedConditions.add(sb.toString());
+			if (tokenIndices.contains(i) &&
+				isBalancedPoshiScript(sb.toString())) {
 
-					sb.setLength(0);
+				nestedConditions.add(sb.toString());
 
-					i++;
+				sb.setLength(0);
 
-					continue;
-				}
+				i++;
+
+				continue;
 			}
 
 			if (i == (chars.length - 1)) {
@@ -665,27 +660,25 @@ public abstract class PoshiElement
 			}
 
 			if (isBalancedPoshiScript(poshiScriptSnippet)) {
-				if (splitElseBlocks) {
-					if (isValidPoshiScriptBlock(
-							ElseIfPoshiElement.blockNamePattern,
-							poshiScriptSnippet) ||
-						isValidPoshiScriptBlock(
-							ElsePoshiElement.blockNamePattern,
-							poshiScriptSnippet)) {
+				if (splitElseBlocks &&
+					(isValidPoshiScriptBlock(
+						ElseIfPoshiElement.blockNamePattern,
+						poshiScriptSnippet) ||
+					 isValidPoshiScriptBlock(
+						 ElsePoshiElement.blockNamePattern,
+						 poshiScriptSnippet))) {
 
-						int lastIndex = poshiScriptSnippets.size() - 1;
+					int lastIndex = poshiScriptSnippets.size() - 1;
 
-						String lastPoshiScriptSnippet = poshiScriptSnippets.get(
-							lastIndex);
+					String lastPoshiScriptSnippet = poshiScriptSnippets.get(
+						lastIndex);
 
-						poshiScriptSnippets.set(
-							lastIndex,
-							lastPoshiScriptSnippet + poshiScriptSnippet);
+					poshiScriptSnippets.set(
+						lastIndex, lastPoshiScriptSnippet + poshiScriptSnippet);
 
-						sb.setLength(0);
+					sb.setLength(0);
 
-						continue;
-					}
+					continue;
 				}
 
 				poshiScriptSnippets.add(poshiScriptSnippet);
@@ -950,10 +943,8 @@ public abstract class PoshiElement
 
 			sb.append(line);
 
-			if (trimmedLine.startsWith("/*")) {
-				if (!stack.contains("/*")) {
-					stack.push("/*");
-				}
+			if (trimmedLine.startsWith("/*") && !stack.contains("/*")) {
+				stack.push("/*");
 			}
 
 			if ((StringUtil.count(trimmedLine, "'''") % 2) == 1) {
@@ -965,10 +956,8 @@ public abstract class PoshiElement
 				}
 			}
 
-			if (trimmedLine.endsWith("*/")) {
-				if (stackPeek.equals("/*")) {
-					stack.pop();
-				}
+			if (trimmedLine.endsWith("*/") && stackPeek.equals("/*")) {
+				stack.pop();
 			}
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
@@ -205,13 +205,11 @@ public class VarPoshiElement extends PoshiElement {
 			sb.append(" ");
 		}
 
-		if (Validator.isNotNull(valueAttributeName)) {
-			if (valueAttributeName.equals("from")) {
-				if (attribute("type") != null) {
-					sb.append(attributeValue("type"));
-					sb.append(" ");
-				}
-			}
+		if (Validator.isNotNull(valueAttributeName) &&
+			valueAttributeName.equals("from") && (attribute("type") != null)) {
+
+			sb.append(attributeValue("type"));
+			sb.append(" ");
 		}
 
 		String name = attributeValue("name");

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/SummaryLogger.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/SummaryLogger.java
@@ -626,12 +626,11 @@ public final class SummaryLogger {
 
 			String majorStepClassName = majorStepLoggerElement.getClassName();
 
-			if (lastMajorStep) {
-				if (majorStepClassName.contains("summary-failure") ||
-					majorStepClassName.contains("summary-warning")) {
+			if (lastMajorStep &&
+				(majorStepClassName.contains("summary-failure") ||
+				 majorStepClassName.contains("summary-warning"))) {
 
-					togglerClassNameSuffix = "expanded";
-				}
+				togglerClassNameSuffix = "expanded";
 			}
 
 			LoggerElement buttonLoggerElement =

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/ChromeWebDriverImpl.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/ChromeWebDriverImpl.java
@@ -146,21 +146,21 @@ public class ChromeWebDriverImpl extends BaseWebDriverImpl {
 	private void _refreshFrameWebElements() {
 		Stack<WebElement> frameWebElements = getFrameWebElements();
 
-		if (!frameWebElements.isEmpty()) {
-			if (frameWebElements.peek() instanceof RetryWebElementImpl) {
-				RetryWebElementImpl frameWebElement =
-					(RetryWebElementImpl)frameWebElements.peek();
+		if (!frameWebElements.isEmpty() &&
+			(frameWebElements.peek() instanceof RetryWebElementImpl)) {
 
-				String frameWebElementLocator = frameWebElement.getLocator();
+			RetryWebElementImpl frameWebElement =
+				(RetryWebElementImpl)frameWebElements.peek();
 
-				frameWebElements.pop();
+			String frameWebElementLocator = frameWebElement.getLocator();
 
-				frameWebElements.push(getWebElement(frameWebElementLocator));
+			frameWebElements.pop();
 
-				WebDriver.TargetLocator targetLocator = switchTo();
+			frameWebElements.push(getWebElement(frameWebElementLocator));
 
-				targetLocator.frame(frameWebElements.peek());
-			}
+			WebDriver.TargetLocator targetLocator = switchTo();
+
+			targetLocator.frame(frameWebElements.peek());
 		}
 	}
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -5052,6 +5052,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=The vacation message notifies others of your absence.
 the-value-being-validated=The value being validated
 the-verse-could-not-be-found=The verse could not be found.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it.
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later.
 the-web-content=The web content
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content

--- a/portal-impl/src/content/Language_ar.properties
+++ b/portal-impl/src/content/Language_ar.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=رسالة الإجازة تعلم الآخرين بغيابك
 the-value-being-validated=القيمة التي يتم التحقق منها
 the-verse-could-not-be-found=لم يتم العثور على الترنيمة.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=معاينة الفيديو ليست جاهزة بعد. يُرجى المحاولة مرة أخرى لاحقاً.
 the-web-content=محتوى الصفحة
 the-web-content-compared-with-the-previous-version-web-content=محتوى الصفحة مقارنة بمحتوى صفحة سابقة

--- a/portal-impl/src/content/Language_bg.properties
+++ b/portal-impl/src/content/Language_bg.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Съобщението за ваканция информира другите за вашето отсъствие.
 the-value-being-validated=Валидираната стойност
 the-verse-could-not-be-found=Стихът не може да бъде намерен.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Преглед на видео все още не е готова. Моля, опитайте отново по-късно. (Automatic Translation)
 the-web-content=Съдържанието на страницата
 the-web-content-compared-with-the-previous-version-web-content=На уеб съдържание, в сравнение с предишната версия уеб съдържание (Automatic Translation)

--- a/portal-impl/src/content/Language_ca.properties
+++ b/portal-impl/src/content/Language_ca.properties
@@ -5051,6 +5051,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=El missatge de vacances notifica la vostra absència als altres.
 the-value-being-validated=S'està validant el valor
 the-verse-could-not-be-found=No s'ha trobat el versicle.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=La vista prèvia del vídeo no està llesta. Intenteu-ho de nou més tard.
 the-web-content=El contingut de la pàgina
 the-web-content-compared-with-the-previous-version-web-content=El contingut de la pàgina comparat amb la versió anterior del mateix

--- a/portal-impl/src/content/Language_cs.properties
+++ b/portal-impl/src/content/Language_cs.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Dovolenková zpráva ostatní upozorňuje na Vaši nepřítomnost.
 the-value-being-validated=Hodnota byla ověřena
 the-verse-could-not-be-found=Citát nebyl nalezen.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Náhled videa není ještě připraven. Prosím zkuste to později.
 the-web-content=Obsah stránky
 the-web-content-compared-with-the-previous-version-web-content=Porovnání obsahu stránky s její předchozí verzí

--- a/portal-impl/src/content/Language_da.properties
+++ b/portal-impl/src/content/Language_da.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=The vacation message notifies others of your absence. (Automatic Copy)
 the-value-being-validated=The value being validated (Automatic Copy)
 the-verse-could-not-be-found=The webindhold could not be found.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)

--- a/portal-impl/src/content/Language_de.properties
+++ b/portal-impl/src/content/Language_de.properties
@@ -5051,6 +5051,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Die Abwesenheitsbenachrichtigung informiert andere über Ihre Abwesenheit.
 the-value-being-validated=Der Wert, der validiert wird
 the-verse-could-not-be-found=Der Vers konnte nicht gefunden werden.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Die Videovorschau ist noch nicht verfügbar. Bitte versuchen Sie es später erneut.
 the-web-content=Seiteninhalt
 the-web-content-compared-with-the-previous-version-web-content=Vergleich des Seiteninhalt mit dem Seiteninhalt der vorhergehenden Version

--- a/portal-impl/src/content/Language_el.properties
+++ b/portal-impl/src/content/Language_el.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Το μήνυμα διακοπών δηλώνει τους άλλους σχετικά με την απουσία σας.
 the-value-being-validated=Η τιμή που επικυρώνεται
 the-verse-could-not-be-found=Το εδάφιο δεν βρέθηκε.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Η προεπισκόπηση βίντεο δεν είναι ακόμη έτοιμη. Παρακαλώ προσπαθήστε ξανά αργότερα. (Automatic Translation)
 the-web-content=Το περιεχόμενο της σελίδας
 the-web-content-compared-with-the-previous-version-web-content=Το περιεχόμενο της σελίδας συγκρινόμενο με το περιεχόμενο των προηγούμενων εκδόσεων της σελίδας

--- a/portal-impl/src/content/Language_en.properties
+++ b/portal-impl/src/content/Language_en.properties
@@ -5052,6 +5052,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=The vacation message notifies others of your absence.
 the-value-being-validated=The value being validated
 the-verse-could-not-be-found=The verse could not be found.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it.
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later.
 the-web-content=The web content
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content

--- a/portal-impl/src/content/Language_es.properties
+++ b/portal-impl/src/content/Language_es.properties
@@ -5051,6 +5051,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=El mensaje de las vacaciones notifica otras de su ausencia.
 the-value-being-validated=El valor siendo validado
 the-verse-could-not-be-found=No se ha encontrado el verso.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=La previsualización del vídeo aún no está disponible. Por favor inténtelo de nuevo más tarde.
 the-web-content=El contenido de la página
 the-web-content-compared-with-the-previous-version-web-content=El contenido de la página comparado la versión previa del mismo

--- a/portal-impl/src/content/Language_et.properties
+++ b/portal-impl/src/content/Language_et.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Puhkuseteade informeerib teisi sinu puudumisest.
 the-value-being-validated=Kontrollitav väärtus
 the-verse-could-not-be-found=Salmi ei leitud.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Video eelvaade pole veel valmis. Proovige hiljem uuesti. (Automatic Translation)
 the-web-content=Lehe sisu
 the-web-content-compared-with-the-previous-version-web-content=Võrreldes eelmise versiooni veebisisu veebi sisu (Automatic Translation)

--- a/portal-impl/src/content/Language_eu.properties
+++ b/portal-impl/src/content/Language_eu.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Oporretako mezuak beste erabiltzaileei jakinarazten die zure absentzia.
 the-value-being-validated=Balioztatzen den balioa
 the-verse-could-not-be-found=Bertsoa ezin izan da aurkitu.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=Orriaren edukia
 the-web-content-compared-with-the-previous-version-web-content=Orriaren edukia orriaren aurreko bertsioarekin konparatuta

--- a/portal-impl/src/content/Language_fa.properties
+++ b/portal-impl/src/content/Language_fa.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=پیام تعطیلی دیگران را از عدم حضور شما مطلع می‌کند.
 the-value-being-validated=مقدار تایید شده است.
 the-verse-could-not-be-found=آیه یافت نشد
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=پیش نمایش ویدیو هنوز آماده نیست. لطفا دوباره تلاش کنید
 the-web-content=محتوای وب
 the-web-content-compared-with-the-previous-version-web-content=محتوای وب در مقایسه با نسخه قبلی

--- a/portal-impl/src/content/Language_fi.properties
+++ b/portal-impl/src/content/Language_fi.properties
@@ -5044,6 +5044,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Lomaviesti kertoo muille poissaolostasi.
 the-value-being-validated=Validoitu arvo
 the-verse-could-not-be-found=Säettä ei löydy.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Videon esikatselu ei ole vielä valmis. Yritä myöhemmin uudestaan.
 the-web-content=Sivun sisältö
 the-web-content-compared-with-the-previous-version-web-content=Sivun sisältö verratuna edelliseen versioon sivun sisällöstä.

--- a/portal-impl/src/content/Language_fr.properties
+++ b/portal-impl/src/content/Language_fr.properties
@@ -5051,6 +5051,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Le message de vacances informe les autres de votre absence.
 the-value-being-validated=La valeur étant validée
 the-verse-could-not-be-found=Le verset n'a pu être trouvé.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=La vidéo de prévisualisation n'est pas encore prête. Veuillez essayer plus tard.
 the-web-content=Le contenu de page
 the-web-content-compared-with-the-previous-version-web-content=Le contenu de page a rivalisé avec le contenu de page de version préalable

--- a/portal-impl/src/content/Language_gl.properties
+++ b/portal-impl/src/content/Language_gl.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=A mensaxe das vacacións notifica a outros da túa ausencia.
 the-value-being-validated=O valor que é validado
 the-verse-could-not-be-found=Non se atopou o verso.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=O contido da páxina
 the-web-content-compared-with-the-previous-version-web-content=O contido da páxina comparado coa versión anterior do contido da páxina

--- a/portal-impl/src/content/Language_hi_IN.properties
+++ b/portal-impl/src/content/Language_hi_IN.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=छुट्टी संदेश दूसरों आपकी अनुपस्थिति की सूचना देता है। (Automatic Translation)
 the-value-being-validated=वॅल्यू validate हो रही है
 the-verse-could-not-be-found=Verse पाया नहीं जा सका|
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=वीडियो पूर्वावलोकन अभी तक तैयार नहीं है। कृपया बाद में पुन: प्रयास करें। (Automatic Translation)
 the-web-content=वेब सामग्री (Automatic Translation)
 the-web-content-compared-with-the-previous-version-web-content=पिछले संस्करण वेब सामग्री के साथ तुलना की जाने वाली वेब सामग्री (Automatic Translation)

--- a/portal-impl/src/content/Language_hr.properties
+++ b/portal-impl/src/content/Language_hr.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Poruka o odmoru obaviještava druge o vašem odlasku.
 the-value-being-validated=Vrijednost s obzirom na potvrdio
 the-verse-could-not-be-found=Stih se ne može pronaći.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=Sadržaj stranice
 the-web-content-compared-with-the-previous-version-web-content=Sadržaja stranice u odnosu na prethodnu verziju sadržaja stranice

--- a/portal-impl/src/content/Language_hu.properties
+++ b/portal-impl/src/content/Language_hu.properties
@@ -5051,6 +5051,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=A szabadságértesítő üzenet jelzi mások számára, ha nem vagy elérhető.
 the-value-being-validated=Ellenőrzés alatt álló érték
 the-verse-could-not-be-found=A vers nem található.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=A videó előnézet még nincs kész. Próbáld újra később!
 the-web-content=A webes tartalom
 the-web-content-compared-with-the-previous-version-web-content=A webes tartalom összehasonlítva a webes tartalom előző verziójával

--- a/portal-impl/src/content/Language_in.properties
+++ b/portal-impl/src/content/Language_in.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Vacation Message memberitahukan orang lain ketidakhadiran Anda.
 the-value-being-validated=Nilai yang divalidasi
 the-verse-could-not-be-found=Ayat ini tidak dapat ditemukan.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Video preview masih belum siap. Harap coba lagi nanti. (Automatic Translation)
 the-web-content=Isi Halaman
 the-web-content-compared-with-the-previous-version-web-content=Konten halaman dibandingkan dengan konten halaman yang versi sebelumnya

--- a/portal-impl/src/content/Language_it.properties
+++ b/portal-impl/src/content/Language_it.properties
@@ -5049,6 +5049,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Il messaggio di assenza informa le altre persone della tua assenza.
 the-value-being-validated=Il valore che viene convalidato
 the-verse-could-not-be-found=Non è stato possibile trovare il verso.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=L'anteprima del video non è ancora disponibile. Prego riprovare più tardi.
 the-web-content=Contenuto Web
 the-web-content-compared-with-the-previous-version-web-content=Confronto tra il contenuto web e la sua versione precedente

--- a/portal-impl/src/content/Language_iw.properties
+++ b/portal-impl/src/content/Language_iw.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=הודעת החופשה מיידעת אחרים על העדרותך
 the-value-being-validated=הערך שנמצא בבדיקה
 the-verse-could-not-be-found=המקטע לא נמצא
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=תצוגת הוידאו המקדימה עדיין לא מוכנה. אנא נסה שנית מאוחר יותר.
 the-web-content=תוכן הדף
 the-web-content-compared-with-the-previous-version-web-content=תוכן הדף בהשוואה לתוכן הדף בגרסתו הקודמת.

--- a/portal-impl/src/content/Language_ja.properties
+++ b/portal-impl/src/content/Language_ja.properties
@@ -5049,6 +5049,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=メールを受信できない場合に、自動返信用メッセージを送信します。
 the-value-being-validated=値は評価されています。
 the-verse-could-not-be-found=節が見つかりません。
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=ビデオプレビューはまだ準備が出来ていません。しばらくしてからアクセスしてみてください
 the-web-content=Webコンテンツ
 the-web-content-compared-with-the-previous-version-web-content=前のバージョンのWebコンテンツと現在のWebコンテンツを比較

--- a/portal-impl/src/content/Language_kk.properties
+++ b/portal-impl/src/content/Language_kk.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=The vacation message notifies others of your absence. (Automatic Copy)
 the-value-being-validated=The value being validated (Automatic Copy)
 the-verse-could-not-be-found=The verse could not be found. (Automatic Copy)
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)

--- a/portal-impl/src/content/Language_ko.properties
+++ b/portal-impl/src/content/Language_ko.properties
@@ -5045,6 +5045,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=휴가 메시지는 너의 휴무의 다른 사람을 통지한다.
 the-value-being-validated=유효하게 하는 가치
 the-verse-could-not-be-found=운문은 발견될 수 없었다.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=비디오 미리 보기에 아직 준비 되지 않습니다. 나중에 다시 시도 하십시오. (Automatic Translation)
 the-web-content=페이지 내용
 the-web-content-compared-with-the-previous-version-web-content=페이지 내용은 이전 버전 페이지 내용과 비교했다

--- a/portal-impl/src/content/Language_lo.properties
+++ b/portal-impl/src/content/Language_lo.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=The vacation message notifies others of your absence. (Automatic Copy)
 the-value-being-validated=The value being validated (Automatic Copy)
 the-verse-could-not-be-found=ບໍ່ສາມາດຊອກຫາຫົວຂໍ້ໄດ້
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=ເນື້ອຫາໃນໜ້າ
 the-web-content-compared-with-the-previous-version-web-content=ໜ້າເນື້ອຫາໄດ້ປຽບທຽບກັບໜ້າເນື້ອຫາເວີເຊີ້ນກ່ອນໜ້ານີ້

--- a/portal-impl/src/content/Language_lt.properties
+++ b/portal-impl/src/content/Language_lt.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Atostogų pranešimas praneša apie tai kitas valstybes nares apie savo nebuvimo. (Automatic Translation)
 the-value-being-validated=Patvirtintas vertė (Automatic Translation)
 the-verse-could-not-be-found=Nepavyko rasti stichijos. (Automatic Translation)
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Vaizdo peržiūrą dar neparuošta. Bandykite dar kartą vėliau. (Automatic Translation)
 the-web-content=Žiniatinklio turinį (Automatic Translation)
 the-web-content-compared-with-the-previous-version-web-content=Palyginti su ankstesnės versijos žiniatinklio turinio žiniatinklio turinį (Automatic Translation)

--- a/portal-impl/src/content/Language_nb.properties
+++ b/portal-impl/src/content/Language_nb.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Feriemeldingen varsler andre om ditt fravær.
 the-value-being-validated=Siden som blir validert
 the-verse-could-not-be-found=Verset ble ikke funnet.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Video-forhåndsvisningen er ikke klar. Vennligst prøv igjen senere.
 the-web-content=Sideinnholdet
 the-web-content-compared-with-the-previous-version-web-content=Sidens innhold sammenlignet med den tidligere versjonens innhold

--- a/portal-impl/src/content/Language_nl.properties
+++ b/portal-impl/src/content/Language_nl.properties
@@ -5052,6 +5052,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Het vakantiebericht informeert anderen over uw afwezigheid.
 the-value-being-validated=De waarde wordt gevalideerd
 the-verse-could-not-be-found=Het vers werd niet gevonden.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=De videopreview is nog niet klaar. Probeer het later nog eens.
 the-web-content=De pagina-inhoud
 the-web-content-compared-with-the-previous-version-web-content=De pagina-inhoud in vergelijking met de vorige versie

--- a/portal-impl/src/content/Language_nl_BE.properties
+++ b/portal-impl/src/content/Language_nl_BE.properties
@@ -5052,6 +5052,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Het vakantiebericht verteld anderen van jouw afwezigheid.
 the-value-being-validated=De waarde die wordt gevalideerd
 the-verse-could-not-be-found=Het vers kon niet worden gevonden.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=De video preview is nog niet klaar. Please try again later. (Automatic Translation)
 the-web-content=De pagina-inhoud
 the-web-content-compared-with-the-previous-version-web-content=De pagina-inhoud die met de vorige versie wordt vergeleken

--- a/portal-impl/src/content/Language_pl.properties
+++ b/portal-impl/src/content/Language_pl.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Wiadomość o urlopie informuje innych o Twojej nieobecności.
 the-value-being-validated=Wartość, która jest walidowana
 the-verse-could-not-be-found=Werset nie został odnaleziony.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Podgląd video nie jest jeszcze gotowy. Spróbuj później.
 the-web-content=Zawartość strony
 the-web-content-compared-with-the-previous-version-web-content=Treść strony w porównaniu do poprzedniej wersji treści strony

--- a/portal-impl/src/content/Language_pt_BR.properties
+++ b/portal-impl/src/content/Language_pt_BR.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=A mensagem de férias notifica os outros de sua ausência.
 the-value-being-validated=O valor que está sendo validado
 the-verse-could-not-be-found=O verso não pode ser encontrado.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=A pré-visualização do vídeo não esta pronta ainda. Por favor, tente novamente mais tarde.
 the-web-content=O conteúdo da página
 the-web-content-compared-with-the-previous-version-web-content=O conteúdo da página comparado com o conteúdo da página da versão anterior

--- a/portal-impl/src/content/Language_pt_PT.properties
+++ b/portal-impl/src/content/Language_pt_PT.properties
@@ -5051,6 +5051,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=A mensagem de férias notifica os outros da sua ausência.
 the-value-being-validated=O valor que está a ser validado
 the-verse-could-not-be-found=O verso não pode ser encontrado.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=A pré-visualização do vídeo ainda não esta pronta. Por favor, tente novamente mais tarde.
 the-web-content=O conteúdo web
 the-web-content-compared-with-the-previous-version-web-content=O conteúdo web comparado com o conteúdo web da versão anterior

--- a/portal-impl/src/content/Language_ro.properties
+++ b/portal-impl/src/content/Language_ro.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Mesajul de vacanta ii anunta pe ceilalti legat de absenta ta
 the-value-being-validated=Valoarea care este validata
 the-verse-could-not-be-found=Versul nu a putut fi gasit
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Previzualizare video nu este încă gata. Vă rugăm să încercaţi din nou mai târziu. (Automatic Translation)
 the-web-content=Continutul de pagina
 the-web-content-compared-with-the-previous-version-web-content=Continutul de pagina comparat cu continutul de pagina anterior

--- a/portal-impl/src/content/Language_ru.properties
+++ b/portal-impl/src/content/Language_ru.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Сообщение об отсутствии уведомляет остальных о вашем отсутствии.
 the-value-being-validated=Значение проверяется
 the-verse-could-not-be-found=Строфа не найдена.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Просмотр видео пока не готов. Пожалуйста, повторите попытку позже. (Automatic Translation)
 the-web-content=Содержимое страницы
 the-web-content-compared-with-the-previous-version-web-content=Контент страницы в сравнении с предыдущей версией страницы

--- a/portal-impl/src/content/Language_sk.properties
+++ b/portal-impl/src/content/Language_sk.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Dovolenková správa notifikuje ostatných o Vašej neprítomnosti.
 the-value-being-validated=Hodnota sa validuje
 the-verse-could-not-be-found=Verš sa nenašiel.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Náhľad videa ešte nie je hotový. Skúste neskôr, prosím.
 the-web-content=Obsah stránky
 the-web-content-compared-with-the-previous-version-web-content=Porovnanie obsahu stránky s predchádzajúcou verziou

--- a/portal-impl/src/content/Language_sl.properties
+++ b/portal-impl/src/content/Language_sl.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Sporočilo o odsotnosti obvešča ostale o vaši odsotnosti.
 the-value-being-validated=Vrednost, ki se preverja
 the-verse-could-not-be-found=Verza ni moč najti
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Video predogled še ni pripravljen. Poskusite znova pozneje. (Automatic Translation)
 the-web-content=Vsebina strani
 the-web-content-compared-with-the-previous-version-web-content=Spletne vsebine, v primerjavi s prejšnjo različico spletne vsebine (Automatic Translation)

--- a/portal-impl/src/content/Language_sr_RS.properties
+++ b/portal-impl/src/content/Language_sr_RS.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Одмор порука обавештава друге о вашем одсуству.
 the-value-being-validated=Вредност је потврђена
 the-verse-could-not-be-found=Стих није могао бити пронађен.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=Садржај странице
 the-web-content-compared-with-the-previous-version-web-content=Садржај странице у односу на претходне верзије садржаја странице

--- a/portal-impl/src/content/Language_sr_RS_latin.properties
+++ b/portal-impl/src/content/Language_sr_RS_latin.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Odmor poruka obaveštava druge o vašem odsustvu.
 the-value-being-validated=Vrednost je potvrđena
 the-verse-could-not-be-found=Stih nije mogao biti pronađen.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=The video preview is not yet ready. Please try again later. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)

--- a/portal-impl/src/content/Language_sv.properties
+++ b/portal-impl/src/content/Language_sv.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Meddelande som ska meddela de andra användarna om din frånvaro.
 the-value-being-validated=Värdet som skall kontrolleras.
 the-verse-could-not-be-found=Versen kunde inte hittas.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Förhandsvisning av video är inte klar än. Försök igen senare.
 the-web-content=Sidans innehåll
 the-web-content-compared-with-the-previous-version-web-content=Sidans innehåll jämfört med den föregående sidans innehåll

--- a/portal-impl/src/content/Language_ta_IN.properties
+++ b/portal-impl/src/content/Language_ta_IN.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=The vacation message notifies others of your absence.
 the-value-being-validated=மதிப்பு சரிபார்க்கப்பட்டது
 the-verse-could-not-be-found=Verse கிடைக்கவில்லை.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=வீடியோ முன்னோட்டம் இன்னும் தயாராகவில்லை. தயவு செய்து மீண்டும் முயற்சிக்கவும்.
 the-web-content=வலை உள்ளடக்கம்
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content

--- a/portal-impl/src/content/Language_th.properties
+++ b/portal-impl/src/content/Language_th.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=ข้อความหยุดจะแจ้งให้ทราบคนอื่น ๆ การขาดงานของคุณ (Automatic Translation)
 the-value-being-validated=ค่าที่ถูกตรวจสอบ (Automatic Translation)
 the-verse-could-not-be-found=ไม่พบข้อความ (Automatic Translation)
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=ตัวอย่างวิดีโอยังไม่พร้อม โปรดลองอีกครั้ง (Automatic Translation)
 the-web-content=เนื้อหาเว็บ (Automatic Translation)
 the-web-content-compared-with-the-previous-version-web-content=เนื้อหาของเว็บเมื่อเทียบกับเนื้อหาเว็บรุ่นก่อนหน้า (Automatic Translation)

--- a/portal-impl/src/content/Language_tr.properties
+++ b/portal-impl/src/content/Language_tr.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Tatil mesajı diğerlerini yokluğunuzdan haberdar eder.
 the-value-being-validated=Değer doğrulanıyor.
 the-verse-could-not-be-found=Satır bulunamadı.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Video önizlemesi henüz hazır değil. Lütfen daha sonra yeniden deneyin. (Automatic Translation)
 the-web-content=Sayfa İçeriği
 the-web-content-compared-with-the-previous-version-web-content=Önceki sürüm web içeriği ile karşılaştırıldığında web içeriği (Automatic Translation)

--- a/portal-impl/src/content/Language_uk.properties
+++ b/portal-impl/src/content/Language_uk.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Повідомлення про відсутність попереджає інших про вашу відсутність.
 the-value-being-validated=Значення перевіряється
 the-verse-could-not-be-found=Строфа не знайдена.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Відео-превью він ще не готовий. Будь ласка, спробуйте ще раз пізніше. (Automatic Translation)
 the-web-content=Зміст сторінки
 the-web-content-compared-with-the-previous-version-web-content=Веб-контенту, в порівнянні з Попередня версія веб-вмісту (Automatic Translation)

--- a/portal-impl/src/content/Language_vi.properties
+++ b/portal-impl/src/content/Language_vi.properties
@@ -5046,6 +5046,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=Thông báo kỳ nghỉ cho các bạn bè.
 the-value-being-validated=Giá trị được xác nhận
 the-verse-could-not-be-found=Trích dẫn không tìm thấy.
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=Nghe trước tập tin âm thanh chưa có sẵn, mời bạn thử lại sau.
 the-web-content=Nội dung trang
 the-web-content-compared-with-the-previous-version-web-content=So sánh nội dung trang hiện tại với phiên bản trước

--- a/portal-impl/src/content/Language_zh_CN.properties
+++ b/portal-impl/src/content/Language_zh_CN.properties
@@ -5049,6 +5049,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=休假消息提醒其他人您正在休假。
 the-value-being-validated=正在被验证的值
 the-verse-could-not-be-found=找不到相应文章节录。
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=视频预览未就绪。请稍后重试。
 the-web-content=web 内容
 the-web-content-compared-with-the-previous-version-web-content=web 内容与上一个版本的 web 内容相比

--- a/portal-impl/src/content/Language_zh_TW.properties
+++ b/portal-impl/src/content/Language_zh_TW.properties
@@ -5047,6 +5047,7 @@ the-users-with-the-following-roles-can-add-this-portlet-to-the-pages-they-manage
 the-vacation-message-notifies-others-of-your-absence=休假訊息通知其他人您的缺席。
 the-value-being-validated=被驗證的值
 the-verse-could-not-be-found=找不到文章節錄。
+the-version-that-is-going-to-be-edited-is-not-the-one-shown-because-recent-versions-have-been-created-on-top-of-it=The version that is going to be edited is not the one shown because recent versions have been created on top of it. (Automatic Copy)
 the-video-preview-is-not-yet-ready.-please-try-again-later=影片預覽尚未準備好。請稍候再試。
 the-web-content=頁面內容
 the-web-content-compared-with-the-previous-version-web-content=頁面內容相較於先前版本頁面內容


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97720

The issue is when a user clicks on an older version of Web Content's title, the user is redirected to the latest article's edit page. The fix is a warning message that lets the user know the link will not direct the user to a view of the content, but instead it will redirect them to the edit page of the latest article.

Hovering over the link will display a message. It is implemented for the three display styles in Web Content.