### PR TITLE
LPS-98019

### DIFF
--- a/modules/apps/document-library/document-library-asset-auto-tagger-google-cloud-vision/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-google-cloud-vision/src/main/resources/content/Language_fi.properties
@@ -1,4 +1,4 @@
 api-key-description=Asettaa API-avaimen Google Cloud Vision API:lle. Laskutuksen on oltava käytössä, jotta tämä API toimii. Katso lisätietoja kohdasta {0}.
-enabled-description=Ota asiakirjakirjastossa käyttöön Automaattinen tagien merkintä käyttäen Google Cloud Vision API:a.
+enabled-description=Ottaa käyttöön Automaattisen kuvien tag-merkinnän käyttäen Google Cloud Vision API:a.
 google-cloud-vision-asset-auto-tag-provider-configuration-name=Google Cloud Vision Kuvan Automaattinen Tagien merkintä
 google-cloud-vision-asset-auto-tag-provider-description=Automaattinen kuvien tag-merkintä Google Cloud Vision API:lla.

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/content/Language_ta_IN.properties
@@ -1,6 +1,6 @@
 edit-display-page-template=Display Page Template-யைத் திருத்து
 layout.types.asset_display=Display Page Template
-layout.types.asset_display.description=ஒரு பக்க டெம்ப்ளேட்டின் அடிப்படையில் அசெட்களைக் காட்ட ஒரு container-ஆக மட்டுமே செயல்படும் பக்கத்தை உருவாக்கவும்.
+layout.types.asset_display.description=ஒரு பக்க டெம்ப்ளேட்டின் அடிப்படையில் assets-களைக் காட்ட ஒரு container-ஆக மட்டுமே செயல்படும் பக்கத்தை உருவாக்கவும்.
 the-display-page-template-was-created-succesfully=Display Page Template வெற்றிகரமாக உருவாக்கப்பட்டது.
 the-display-page-template-was-published-succesfully=Display Page டெம்ப்ளேட் வெற்றிகரமாக வெளியிடப்பட்டது.
 there-is-no-content-to-be-displayed=காண்பிப்பதற்கு எந்த content-ம் இல்லை.

--- a/modules/apps/portal-search-solr7/portal-search-solr7-api/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-api/src/main/resources/content/Language_ta_IN.properties
@@ -1,6 +1,6 @@
 cert=Cert (Automatic Copy)
-log-exceptions-only-help=Set to true to only log exceptions from Solr and not rethrow them. (Automatic Copy)
+log-exceptions-only-help=Set to true to only log exceptions from Solr and not rethrow them.
 replicated=Replicated (Automatic Copy)
-solr7-configuration-name=Solr 7 (Automatic Copy)
-solr7-http-client-factory-configuration-name=Solr 7 HTTP Client Factory (Automatic Copy)
-solr7-ssl-socket-factory-configuration-name=Solr 7 SSL Factory (Automatic Copy)
+solr7-configuration-name=Solr 7
+solr7-http-client-factory-configuration-name=Solr 7 HTTP Client Factory
+solr7-ssl-socket-factory-configuration-name=SOLR 7 SSL Factory

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -188,6 +188,8 @@ public class PortletPreferencesLocalServiceImpl
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId) {
 
+		plid = _swapPlidForPortletPreferences(plid);
+
 		PortletPreferences portletPreferences =
 			portletPreferencesPersistence.fetchByO_O_P_P(
 				ownerId, ownerType, plid, portletId);


### PR DESCRIPTION
Notes from @matthewchan123:

> https://issues.liferay.com/browse/LPS-98019
> 
> Issue:
> Keyword name of search bar cannot be modified from configurations once staging is enabled.
> 
> Cause:
> We swap the plids of themeDisplays passed into PortletPreferencesLocalServiceImpl.java for plids associated with LayoutRevisions. This was likely implemented due to inconsistencies of plid between themeDisplays of staged and live sites. Since we had added the _swapPlidForPortletPreferences() call to get, add, and update methods and forgot it in fetchPortletPreferences(), it creates the issue where either the wrong preferences or null is fetched.
> 
> Fix:
> Since we had passed in the plid for [themeDisplay](https://github.com/liferay/liferay-portal/blob/7.1.x/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/preferences/PortletPreferencesLookupImpl.java#L50) rather than LayoutRevision, we simply need to utilize _swapPlidForPortletPreferences() for fetching portletPreferences. Then, the correct database table row is fetched and the keyword name can be updated.

