### PR TITLE
J cords lps 98088

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/portlet/preferences/processor/BlogsExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/exportimport/portlet/preferences/processor/BlogsExportImportPortletPreferencesProcessor.java
@@ -21,6 +21,7 @@ import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
@@ -28,6 +29,7 @@ import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
@@ -79,7 +81,11 @@ public class BlogsExportImportPortletPreferencesProcessor
 		}
 
 		if (!portletDataContext.getBooleanParameter(
-				_blogsPortletDataHandler.getNamespace(), "entries")) {
+				_blogsPortletDataHandler.getNamespace(), "entries") ||
+			!MapUtil.getBoolean(
+				portletDataContext.getParameterMap(),
+				PortletDataHandlerKeys.PORTLET_DATA + "_" +
+					BlogsPortletKeys.BLOGS_ADMIN)) {
 
 			return portletPreferences;
 		}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -93,10 +93,14 @@ public class DLExportImportPortletPreferencesProcessor
 			PortletPreferences portletPreferences)
 		throws PortletDataException {
 
-		if (!MapUtil.getBoolean(
+		if ((!MapUtil.getBoolean(
 				portletDataContext.getParameterMap(),
 				PortletDataHandlerKeys.PORTLET_DATA) &&
-			MergeLayoutPrototypesThreadLocal.isInProgress()) {
+			 MergeLayoutPrototypesThreadLocal.isInProgress()) ||
+			!MapUtil.getBoolean(
+				portletDataContext.getParameterMap(),
+				PortletDataHandlerKeys.PORTLET_DATA + "_" +
+					DLPortletKeys.DOCUMENT_LIBRARY_ADMIN)) {
 
 			return portletPreferences;
 		}

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/portlet/preferences/processor/MBExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/exportimport/portlet/preferences/processor/MBExportImportPortletPreferencesProcessor.java
@@ -17,6 +17,7 @@ package com.liferay.message.boards.web.internal.exportimport.portlet.preferences
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
@@ -34,6 +35,7 @@ import com.liferay.message.boards.service.MBThreadFlagLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
@@ -82,6 +84,14 @@ public class MBExportImportPortletPreferencesProcessor
 			pde.setType(PortletDataException.EXPORT_PORTLET_PERMISSIONS);
 
 			throw pde;
+		}
+
+		if (!MapUtil.getBoolean(
+				portletDataContext.getParameterMap(),
+				PortletDataHandlerKeys.PORTLET_DATA + "_" +
+					MBPortletKeys.MESSAGE_BOARDS_ADMIN)) {
+
+			return portletPreferences;
 		}
 
 		try {

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/portlet/preferences/processor/WikiExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/portlet/preferences/processor/WikiExportImportPortletPreferencesProcessor.java
@@ -18,6 +18,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.wiki.constants.WikiConstants;
@@ -79,7 +81,11 @@ public class WikiExportImportPortletPreferencesProcessor
 		throws PortletDataException {
 
 		if (!portletDataContext.getBooleanParameter(
-				_wikiPortletDataHandler.getNamespace(), "wiki-pages")) {
+				_wikiPortletDataHandler.getNamespace(), "wiki-pages") ||
+			!MapUtil.getBoolean(
+				portletDataContext.getParameterMap(),
+				PortletDataHandlerKeys.PORTLET_DATA + "_" +
+					WikiPortletKeys.WIKI_ADMIN)) {
 
 			return portletPreferences;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98088
https://issues.liferay.com/browse/LPP-34342

**Problem**: Changes from [LPS-79312](https://github.com/liferay/liferay-portal-ee/commit/aa08c6a8afb12f7515c5ba6d2c103e204b0e2b0e) uses PortletPreferences to export Blogs, WIki, Documents, and Message Boards - however it only references the individual checkboxes (the ones that can be seen after clicking "Change"). This approach didn't take into account the master checkboxes for the entire group.
**Solution**: Take into account the master checkboxes for the entire group.

**Note**: Bookmarks is not part of master, but a similar change is necessary where LPS-79312 is backported and bookmarks exist.