### PR TITLE
LPS-97825 Forcibly disable staging doesn't work if the remote server is not accessible

### DIFF
--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -71,6 +71,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 				<aui:input name="groupId" type="hidden" value="<%= liveGroupId %>" />
 				<aui:input name="liveGroupId" type="hidden" value="<%= liveGroupId %>" />
 				<aui:input name="stagingGroupId" type="hidden" value="<%= stagingGroupId %>" />
+				<aui:input name="forceDisable" type="hidden" value="<%= false %>" />
 
 				<c:if test="<%= !privateLayoutSet.isLayoutSetPrototypeLinkActive() && !publicLayoutSet.isLayoutSetPrototypeLinkActive() %>">
 					<div class="sheet-header">
@@ -157,7 +158,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 </c:choose>
 
 <script>
-	function <portlet:namespace />saveGroup() {
+	function <portlet:namespace />saveGroup(forceDisable) {
 		var form = document.<portlet:namespace />fm;
 		var ok = true;
 
@@ -196,6 +197,13 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 				}
 			}
 		</c:if>
+
+		if (forceDisable) {
+			form.elements['<portlet:namespace />forceDisable'].value = true;
+			form.elements['<portlet:namespace />none'].checked = true;
+			form.elements['<portlet:namespace />redirect'].value = '<portlet:renderURL><portlet:param name="mvcPath" value="/view.jsp" /><portlet:param name="historyKey" value='<%= renderResponse.getNamespace() + "staging" %>' /></portlet:renderURL>';
+			form.elements['<portlet:namespace />remote'].checked = false;
+		}
 
 		if (ok) {
 			submitForm(form);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97825

The issue is that when remote staging is inaccessible, the staging server cannot be disabled. This is because the link never set the value to true. So the service context fetched a false value for 'forceDisable' since it was never explicitly set.

I changed the function to take in a parameter and used that parameter to set the value of 'forceDisable' to true. This allows the staging site to forcibly disable from the remote staging site.