### PR TITLE
LPS-97649 Cannot set page friendly URL to one alphabetic character

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -647,6 +647,6 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 		LayoutLocalServiceHelper.class);
 
 	private static final Pattern _urlSeparatorPattern = Pattern.compile(
-		"/[A-Za-z]");
+		"/[BDWbdw]");
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97649

[LPS-93425](https://issues.liferay.com/browse/LPS-93425) commits https://github.com/brianchandotcom/liferay-portal/pull/71240/commits/76552bc9b366001f4e4db45488ffb2d52f8db271 that does not allow a character to be a friendly URL because there are friendly URL that contain specific characters ([comment](https://issues.liferay.com/browse/LPS-93425?focusedCommentId=1755856&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1755856) from LPS-93425).

I changed the pattern to only contain the characters I found in the project. 

/b for blogs
/d for documents
/w for web-content