### PR TITLE
[TS] LPS-99216 Add required to ddm image descriptions

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/dependencies/ddm/image.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/dependencies/ddm/image.ftl
@@ -75,10 +75,13 @@
 				value="preview"
 			/>
 		</div>
+	</div>
 
+	<div class="form-group">
 		<@liferay_aui.input
 			label="image-description"
 			name="${namespacedFieldName}Alt"
+			required=required
 			type="text"
 			value="${alt}"
 		/>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3105,6 +3105,7 @@ AUI.add(
 						titleNode.val('');
 					}
 
+					instance._validateField(altNode);
 					instance._validateField(titleNode);
 
 					var clearButtonNode = A.one(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-99216

Issue:
Image Description field should have validation when the Web Structure field is configured to "required".

Fix:
I simply adjusted the Image Freemarker Template to allow this setting.