### PR TITLE
LPS-99836 Reduce length to 1024 and send into review

### DIFF
--- a/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
@@ -241,7 +241,7 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 			httpServletRequest, "/combo", "minifierType=js", jsLastModified);
 
 		for (String url : urls) {
-			if ((sb.length() + url.length() + 1) >= 2000) {
+			if ((sb.length() + url.length() + 1) >= 1024) {
 				_renderScriptURL(printWriter, sb.toString());
 
 				sb = new StringBundler();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-99836
https://issues.liferay.com/browse/LPP-34555

LPS-99836 was recently committed here: https://github.com/brianchandotcom/liferay-portal/pull/77071

Because of the nature of the url length problem, it is difficult to reproduce and has not been reproduced in master. In our original testing on 7.1 bedf729391ee066dbb3c94cce2faf187665fcbf4  where the problem was reproducible. Setting the length to 2000, along with the other changes, was sufficient to solve the issue. However, when I went to apply the changes in master to a dxp-11 hotfix, the issue was still reproducible. After following the suggestion for setting the max length to 1024 [from StackOverflow](https://stackoverflow.com/questions/812925/what-is-the-maximum-possible-length-of-a-query-string/48230425#48230425), the issue was no longer reproducible on dxp-11.