### PR TITLE
LPS-100154 Cannot Select Multiple Groups of Identical Child Categories in Asset Publisher

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -121,7 +121,7 @@ class SelectCategory extends PortletBase {
 			const data = {};
 
 			newVal.forEach(node => {
-				data[node.name] = {
+				data[node.id] = {
 					categoryId: node.vocabulary ? 0 : node.id,
 					value: node.name,
 					vocabularyId: node.vocabulary ? node.id : 0
@@ -130,7 +130,7 @@ class SelectCategory extends PortletBase {
 
 			selectedNodes.forEach(node => {
 				if (newVal.indexOf(node) === -1) {
-					data[node.name] = {
+					data[node.id] = {
 						categoryId: node.vocabulary ? 0 : node.id,
 						unchecked: true,
 						value: node.name,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100154

The issue is that the project allows the user to create the same categories with identically labeled child categories; but the asset publisher will only remember the last of the identical child categories you selected, not all of them.

For example, if A and B are the parent categories, and C and D are the children so you have:

Parent Category A
Child Category C
Child Category D

Parent Category B
Child Category C
Child Category D

and you tried to select each of the child categories in an Asset Publisher so C and D under A and C and D under B, the asset publisher would only remember the C and D under B. The expected behavior is that it remember both sets of child categories.

My fix uses the node's ID instead of its name so that the data list is not replacing an existing element's properties with the same name. 