### PR TITLE
LPS-100328 Summary field should not be indexed as HTML data

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -460,7 +460,8 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 		for (String languageId : languageIds) {
 			String content = extractDDMContent(journalArticle, languageId);
 
-			String description = journalArticle.getDescription(languageId);
+			String description = _html.stripHtml(
+				journalArticle.getDescription(languageId));
 
 			String title = journalArticle.getTitle(languageId);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100328
Previous pr: https://github.com/ealonso/liferay-portal/pull/2516

https://github.com/ealonso/liferay-portal/pull/2516#issuecomment-525659476 made changes to update description/summary in JournalArticeIndexer.doGetDocument.

The issue is the data in summary field is stored as html data, but we should remove all html tags before sending it to the index, as it makes no sense for the final user to search html tags. My fix strips the summary field of its html tags before indexing it into the document entity.