### PR TITLE
LPS-100257 Update Image Description required icon to use Lexicon

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -132,7 +132,7 @@ AUI.add(
 			'<label class="control-label">' +
 			A.Escape.html(Liferay.Language.get('image-description')) +
 			'</label>' +
-			'<span class="glyphicon glyphicon-asterisk hide" style="display: none;" hidden="hidden"></span>' +
+			Liferay.Util.getLexiconIconTpl('asterisk') +
 			'<input class="field form-control" type="text" value="" disabled>' +
 			'</div>';
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
@@ -383,13 +383,13 @@ AUI.add(
 						arguments
 					);
 
-					if (field.name === 'ddm-image' && field.get('required')) {
+					if (field.name === 'ddm-image' && !field.get('required')) {
 						var requiredNode = field
 							._getFieldNode()
-							.one('.glyphicon-asterisk');
+							.one('.lexicon-icon-asterisk');
 
 						if (requiredNode) {
-							requiredNode.toggle(true);
+							requiredNode.toggle(false);
 						}
 					}
 
@@ -852,7 +852,7 @@ AUI.add(
 							var state = changed.value.newVal === 'true';
 							var requiredNode = editingField
 								._getFieldNode()
-								.one('.glyphicon-asterisk');
+								.one('.lexicon-icon-asterisk');
 
 							if (requiredNode) {
 								requiredNode.toggle(state);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100257

Issue:
We had modified Web Structures in [LPS-99093](https://issues.liferay.com/browse/LPS-99093) and replaced the glyphicons with new lexicon icons, but Image Description required asterisk is still a glyphicon currently.

Fix:
I just updated the references to glyphicon. It was easier to implement the asterisk as showing upon creation and change this at a later time than add an extra span to hide the icon, so this is the solution I used.