### PR TITLE
LPS-101196 Repeated Fields are initially empty

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -815,20 +815,6 @@ AUI.add(
 					parser.parseContent(content);
 				},
 
-				populateRepeatedSiblings(locale) {
-					var instance = this;
-
-					var siblings = instance.getRepeatedSiblings();
-
-					siblings.forEach(function(item) {
-						var localizationMap = item.get('localizationMap');
-
-						if (Lang.isUndefined(localizationMap[locale])) {
-							localizationMap[locale] = '';
-						}
-					});
-				},
-
 				remove() {
 					var instance = this;
 
@@ -1100,8 +1086,6 @@ AUI.add(
 							value !== localizationMap[defaultLocale]
 						) {
 							localizationMap[locale] = value;
-
-							instance.populateRepeatedSiblings(locale);
 						}
 					} else {
 						localizationMap = value;
@@ -4009,6 +3993,11 @@ AUI.add(
 								field.originalField,
 								field
 							);
+							instance.populateBlankLocalizationMap(
+								defaultLocale,
+								field,
+								field.originalField
+							);
 						}
 					);
 				},
@@ -4046,11 +4035,10 @@ AUI.add(
 
 					var currentLocale = repeatedField.get('displayLocale');
 
-					for (var localization in totalLocalizations) {
-						if (localization === currentLocale) {
-							continue;
-						}
+					var localizations = Object.keys(totalLocalizations);
+					localizations.push(currentLocale);
 
+					localizations.forEach(function(localization) {
 						if (!newFieldLocalizations[localization]) {
 							var localizationValue = '';
 
@@ -4069,7 +4057,7 @@ AUI.add(
 								localization
 							] = localizationValue;
 						}
-					}
+					});
 
 					repeatedField.set('localizationMap', newFieldLocalizations);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101196

Issue:
Implementation for [LPS-98527](https://issues.liferay.com/browse/LPS-98527) had introduced the method populateRepeatedSiblings, which proactively fills repeated fields with empty values for form submission. These fields instead need to take the default language value for display and publishing.

Context:
As the localizationMap is parsed in the backend and persisted, it's required that each repeatedField duplicated from one field has data for the same set of languages, even if the data is an empty string "".

Fix:
Existing logic in populateBlankLocalizationMap works for updating repeated fields with the default values, it just needs adjustment to populate a few more localizations than it does currently. 

Firstly, I added the current localization to be processed, so the current state of the form fields are saved. 

Secondly, I inserted another call to populateBlankLocalizationMap with inversed field arguments. Calling this function twice will guarantee that all languages are filled for a repeated parent and its children.

Hopefully this makes sense, but please feel free to let me know if there are any questions.