### PR TITLE
J cords lps 101662

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMStructureKeywordQueryContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMStructureKeywordQueryContributor.java
@@ -14,11 +14,15 @@
 
 package com.liferay.dynamic.data.mapping.internal.search.spi.model.query.contributor;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.query.QueryHelper;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
@@ -57,22 +61,46 @@ public class DDMStructureKeywordQueryContributor
 		SearchContext searchContext =
 			keywordQueryContributorHelper.getSearchContext();
 
-		if (Validator.isNull(searchContext.getAttribute(fieldName))) {
+		String value = GetterUtil.getString(
+			searchContext.getAttribute(fieldName));
+
+		if (Validator.isNull(value)) {
 			return;
 		}
 
-		String fieldNameLocalizedName = LocalizationUtil.getLocalizedName(
-			fieldName, searchContext.getLanguageId());
-
-		searchContext.setAttribute(
-			fieldNameLocalizedName, searchContext.getAttribute(fieldName));
-
-		queryHelper.addSearchLocalizedTerm(
-			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
-			fieldName, false);
+		_addLocalizedFields(
+			booleanQuery, fieldName, value, false, searchContext);
 	}
 
 	@Reference
 	protected QueryHelper queryHelper;
+
+	private void _addLocalizedFields(
+		BooleanQuery booleanQuery, String fieldName, String value, boolean like,
+		SearchContext searchContext) {
+
+		String[] localizedFieldNames =
+			_searchLocalizationHelper.getLocalizedFieldNames(
+				new String[] {fieldName}, searchContext);
+
+		for (String localizedFieldName : localizedFieldNames) {
+			try {
+				booleanQuery.addTerm(localizedFieldName, value, like);
+
+				searchContext.setAttribute(localizedFieldName, value);
+			}
+			catch (ParseException pe) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("ParseException creating search query", pe);
+				}
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMStructureKeywordQueryContributor.class);
+
+	@Reference
+	private SearchLocalizationHelper _searchLocalizationHelper;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMTemplateKeywordQueryContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMTemplateKeywordQueryContributor.java
@@ -14,11 +14,15 @@
 
 package com.liferay.dynamic.data.mapping.internal.search.spi.model.query.contributor;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.query.QueryHelper;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
@@ -57,22 +61,46 @@ public class DDMTemplateKeywordQueryContributor
 		SearchContext searchContext =
 			keywordQueryContributorHelper.getSearchContext();
 
-		if (Validator.isNull(searchContext.getAttribute(fieldName))) {
+		String value = GetterUtil.getString(
+			searchContext.getAttribute(fieldName));
+
+		if (Validator.isNull(value)) {
 			return;
 		}
 
-		String fieldNameLocalizedName = LocalizationUtil.getLocalizedName(
-			fieldName, searchContext.getLanguageId());
-
-		searchContext.setAttribute(
-			fieldNameLocalizedName, searchContext.getAttribute(fieldName));
-
-		queryHelper.addSearchLocalizedTerm(
-			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
-			fieldName, false);
+		_addLocalizedFields(
+			booleanQuery, fieldName, value, false, searchContext);
 	}
 
 	@Reference
 	protected QueryHelper queryHelper;
+
+	private void _addLocalizedFields(
+		BooleanQuery booleanQuery, String fieldName, String value, boolean like,
+		SearchContext searchContext) {
+
+		String[] localizedFieldNames =
+			_searchLocalizationHelper.getLocalizedFieldNames(
+				new String[] {fieldName}, searchContext);
+
+		for (String localizedFieldName : localizedFieldNames) {
+			try {
+				booleanQuery.addTerm(localizedFieldName, value, like);
+
+				searchContext.setAttribute(localizedFieldName, value);
+			}
+			catch (ParseException pe) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("ParseException creating search query", pe);
+				}
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMTemplateKeywordQueryContributor.class);
+
+	@Reference
+	private SearchLocalizationHelper _searchLocalizationHelper;
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutKeywordQueryContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutKeywordQueryContributor.java
@@ -14,9 +14,15 @@
 
 package com.liferay.layout.internal.search.spi.model.query.contributor;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.query.QueryHelper;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
@@ -42,13 +48,50 @@ public class LayoutKeywordQueryContributor implements KeywordQueryContributor {
 		SearchContext searchContext =
 			keywordQueryContributorHelper.getSearchContext();
 
-		queryHelper.addSearchLocalizedTerm(
-			booleanQuery, searchContext, Field.CONTENT, false);
-		queryHelper.addSearchLocalizedTerm(
-			booleanQuery, searchContext, Field.TITLE, false);
+		String[] fields = {Field.CONTENT, Field.TITLE};
+
+		for (String field : fields) {
+			String value = GetterUtil.getString(
+				searchContext.getAttribute(field));
+
+			if (Validator.isNull(value)) {
+				continue;
+			}
+
+			_addLocalizedFields(
+				booleanQuery, field, value, false, searchContext);
+		}
 	}
 
 	@Reference
 	protected QueryHelper queryHelper;
+
+	private void _addLocalizedFields(
+		BooleanQuery booleanQuery, String fieldName, String value, boolean like,
+		SearchContext searchContext) {
+
+		String[] localizedFieldNames =
+			_searchLocalizationHelper.getLocalizedFieldNames(
+				new String[] {fieldName}, searchContext);
+
+		for (String localizedFieldName : localizedFieldNames) {
+			try {
+				booleanQuery.addTerm(localizedFieldName, value, like);
+
+				searchContext.setAttribute(localizedFieldName, value);
+			}
+			catch (ParseException pe) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("ParseException creating search query", pe);
+				}
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutKeywordQueryContributor.class);
+
+	@Reference
+	private SearchLocalizationHelper _searchLocalizationHelper;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101662
https://issues.liferay.com/browse/LPP-35055

**Problem:** [queryHelper.addSearchLocalizedTerm()](https://github.com/liferay/liferay-portal/blob/237b9f6bc506deb197ef82a248dd67425ab5e092/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java#L44-L51) only considers the 1 locale in the searchContext for localizing the fieldname during the search. This results in situations where the normal results will list entries that a search will not find if the searched term is in a different language. (See ticket for more info.) 

**Solution:** Mimic code of [JournalArticleIndexer](https://github.com/liferay/liferay-portal/blob/495d93e80ecca793ae99544d7922ae5e67b7adc3/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java#L330-L348) added by [LPS-84703](https://issues.liferay.com/browse/LPS-84703) which adds all locales to be searched.

An alternative to placing an _addLocalizedFields() inside each class, I could modify [QueryHelperImpl](https://github.com/liferay/liferay-portal/blob/237b9f6bc506deb197ef82a248dd67425ab5e092/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java) by adding a similar method there and calling it from each of the affected classes. I chose the first way as it avoided changes interfaces.

**Note**: The ParseException catch is necessary because [BooleanQuery.addTerm](https://github.com/liferay/liferay-portal/blob/50888548989ba65c75f7cb7c9c90fa1957cd2117/portal-kernel/src/com/liferay/portal/kernel/search/BooleanQuery.java#L114-L115) has a throw in the interface, but our implementations don't actually throw any exceptions.