### PR TITLE
J cords lps 101662 2

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMStructureKeywordQueryContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMStructureKeywordQueryContributor.java
@@ -67,9 +67,9 @@ public class DDMStructureKeywordQueryContributor
 		searchContext.setAttribute(
 			fieldNameLocalizedName, searchContext.getAttribute(fieldName));
 
-		queryHelper.addSearchLocalizedTerm(
+		queryHelper.addSearchLocalizedField(
 			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
-			fieldName, false);
+			fieldName, false, true);
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMTemplateKeywordQueryContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMTemplateKeywordQueryContributor.java
@@ -67,9 +67,9 @@ public class DDMTemplateKeywordQueryContributor
 		searchContext.setAttribute(
 			fieldNameLocalizedName, searchContext.getAttribute(fieldName));
 
-		queryHelper.addSearchLocalizedTerm(
+		queryHelper.addSearchLocalizedField(
 			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
-			fieldName, false);
+			fieldName, false, true);
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutKeywordQueryContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutKeywordQueryContributor.java
@@ -42,10 +42,10 @@ public class LayoutKeywordQueryContributor implements KeywordQueryContributor {
 		SearchContext searchContext =
 			keywordQueryContributorHelper.getSearchContext();
 
-		queryHelper.addSearchLocalizedTerm(
-			booleanQuery, searchContext, Field.CONTENT, false);
-		queryHelper.addSearchLocalizedTerm(
-			booleanQuery, searchContext, Field.TITLE, false);
+		queryHelper.addSearchLocalizedField(
+			booleanQuery, searchContext, Field.CONTENT, false, true);
+		queryHelper.addSearchLocalizedField(
+			booleanQuery, searchContext, Field.TITLE, false, true);
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryHelper.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/query/QueryHelper.java
@@ -26,6 +26,10 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface QueryHelper {
 
+	public Query addSearchLocalizedField(
+		BooleanQuery searchQuery, SearchContext searchContext, String field,
+		boolean like, boolean allLocalizations);
+
 	public void addSearchLocalizedTerm(
 		BooleanQuery searchQuery, SearchContext searchContext, String field,
 		boolean like);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.query.QueryHelper;
 
 import java.io.Serializable;
@@ -33,6 +34,7 @@ import java.io.Serializable;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Michael C. Han
@@ -41,19 +43,9 @@ import org.osgi.service.component.annotations.Component;
 public class QueryHelperImpl implements QueryHelper {
 
 	@Override
-	public void addSearchLocalizedTerm(
+	public Query addSearchLocalizedField(
 		BooleanQuery searchQuery, SearchContext searchContext, String field,
-		boolean like) {
-
-		addSearchTerm(
-			searchQuery, searchContext,
-			getLocalizedName(field, searchContext.getLocale()), like);
-	}
-
-	@Override
-	public Query addSearchTerm(
-		BooleanQuery searchQuery, SearchContext searchContext, String field,
-		boolean like) {
+		boolean like, boolean allLocalizations) {
 
 		if (Validator.isBlank(field)) {
 			return null;
@@ -88,21 +80,55 @@ public class QueryHelperImpl implements QueryHelper {
 			return null;
 		}
 
-		Query query = null;
+		String[] localizedFieldNames = null;
 
-		if (searchContext.isAndSearch()) {
-			query = searchQuery.addRequiredTerm(field, value, like);
+		if (allLocalizations) {
+			localizedFieldNames =
+				_searchLocalizationHelper.getLocalizedFieldNames(
+					new String[] {field}, searchContext);
 		}
 		else {
-			try {
-				query = searchQuery.addTerm(field, value, like);
+			localizedFieldNames = new String[] {field};
+		}
+
+		Query query = null;
+
+		for (String localizedFieldName : localizedFieldNames) {
+			if (searchContext.isAndSearch()) {
+				query = searchQuery.addRequiredTerm(
+					localizedFieldName, value, like);
 			}
-			catch (ParseException pe) {
-				throw new SystemException(pe);
+			else {
+				try {
+					query = searchQuery.addTerm(
+						localizedFieldName, value, like);
+				}
+				catch (ParseException pe) {
+					throw new SystemException(pe);
+				}
 			}
 		}
 
 		return query;
+	}
+
+	@Override
+	public void addSearchLocalizedTerm(
+		BooleanQuery searchQuery, SearchContext searchContext, String field,
+		boolean like) {
+
+		addSearchTerm(
+			searchQuery, searchContext,
+			getLocalizedName(field, searchContext.getLocale()), like);
+	}
+
+	@Override
+	public Query addSearchTerm(
+		BooleanQuery searchQuery, SearchContext searchContext, String field,
+		boolean like) {
+
+		return addSearchLocalizedField(
+			searchQuery, searchContext, field, like, false);
 	}
 
 	protected Localization getLocalization() {
@@ -124,5 +150,8 @@ public class QueryHelperImpl implements QueryHelper {
 	}
 
 	protected Localization localization;
+
+	@Reference
+	private SearchLocalizationHelper _searchLocalizationHelper;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101662
https://issues.liferay.com/browse/LPP-35055

Resent from https://github.com/SamZiemer/liferay-portal/pull/647 after addressing test failures. Test failures were because [JournalArticleIndexer](https://github.com/liferay/liferay-portal/blob/495d93e80ecca793ae99544d7922ae5e67b7adc3/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java#L330-L348) failed to account for empty attributes but existing keywords in a searchContext. Because [queryHelper.addSearchTerm()](https://github.com/liferay/liferay-portal/blob/237b9f6bc506deb197ef82a248dd67425ab5e092/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java#L54-L106) more comprehensively accounts for all search scenarios, it makes sense to use it's code instead of creating new methods in the individual classes. Because the new method is so similar to the existing code, the old method utilizes the new one to remove code duplication.

Original comment:

> **Problem:** [queryHelper.addSearchLocalizedTerm()](https://github.com/liferay/liferay-portal/blob/237b9f6bc506deb197ef82a248dd67425ab5e092/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java#L44-L51) only considers the 1 locale in the searchContext for localizing the fieldname during the search. This results in situations where the normal results will list entries that a search will not find if the searched term is in a different language. (See ticket for more info.) 
> 
> **Solution:** Mimic code of [JournalArticleIndexer](https://github.com/liferay/liferay-portal/blob/495d93e80ecca793ae99544d7922ae5e67b7adc3/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java#L330-L348) added by [LPS-84703](https://issues.liferay.com/browse/LPS-84703) which adds all locales to be searched.
> 
> An alternative to placing an _addLocalizedFields() inside each class, I could modify [QueryHelperImpl](https://github.com/liferay/liferay-portal/blob/237b9f6bc506deb197ef82a248dd67425ab5e092/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/QueryHelperImpl.java) by adding a similar method there and calling it from each of the affected classes. I chose the first way as it avoided changes interfaces.
> 
> **Note**: The ParseException catch is necessary because [BooleanQuery.addTerm](https://github.com/liferay/liferay-portal/blob/50888548989ba65c75f7cb7c9c90fa1957cd2117/portal-kernel/src/com/liferay/portal/kernel/search/BooleanQuery.java#L114-L115) has a throw in the interface, but our implementations don't actually throw any exceptions.