### PR TITLE
LPS-101946 Return the sort function to journal history

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
@@ -68,6 +68,10 @@ public class JournalHistoryDisplayContext {
 			JournalPortletUtil.getArticleOrderByComparator(
 				getOrderByCol(), getOrderByType());
 
+		articleSearchContainer.setOrderByCol(getOrderByCol());
+		articleSearchContainer.setOrderByComparator(orderByComparator);
+		articleSearchContainer.setOrderByType(getOrderByType());
+
 		List<JournalArticle> articleVersions =
 			JournalArticleServiceUtil.getArticlesByArticleId(
 				_article.getGroupId(), _article.getArticleId(),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101946
https://issues.liferay.com/browse/LPP-35112

This issue was caused by LPS-78342 where they did not add `articleSearchContainer.setOrderByType()` in their creation of [JournalHistoryDisplayContext](https://github.com/brianchandotcom/liferay-portal/pull/57364/files#diff-9909f289205f0a11bf1e969b39169a1cR121) whereas it was correctly added to a similar file: [JournalViewMoreMenuItemsDisplayContext](https://github.com/brianchandotcom/liferay-portal/pull/57364/files#diff-f1548a53ec491eddf667e0e80b6c4c28R96).

Adding the orderers resolves the issue.