### PR TITLE
LPS-102240

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1030,10 +1030,9 @@ public class AssetPublisherDisplayContext {
 		}
 
 		SearchContainer searchContainer = new SearchContainer(
-			_portletRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM,
-			getDelta(), getPortletURL(), null, null);
+			_portletRequest, getPortletURL(), null, null);
 
-		if (!isPaginationTypeNone()) {
+		if (isPaginationTypeNone()) {
 			searchContainer.setDelta(getDelta());
 			searchContainer.setDeltaConfigurable(false);
 		}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1032,7 +1032,7 @@ public class AssetPublisherDisplayContext {
 		SearchContainer searchContainer = new SearchContainer(
 			_portletRequest, getPortletURL(), null, null);
 
-		if (isPaginationTypeNone()) {
+		if (isPaginationTypeNone() || isPaginationTypeSimple()) {
 			searchContainer.setDelta(getDelta());
 			searchContainer.setDeltaConfigurable(false);
 		}
@@ -1353,6 +1353,14 @@ public class AssetPublisherDisplayContext {
 		String curPaginationType = getPaginationType();
 
 		return curPaginationType.equals(paginationType);
+	}
+
+	public boolean isPaginationTypeSimple() {
+		if (Objects.equals(getPaginationType(), PAGINATION_TYPE_SIMPLE)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isSearchWithIndex() {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=Enable Manual Export
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple.
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported.
 ordering=Ordering
 other-site=Other Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ar.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=أصول ذات صلة
 manual-export-enabled=التصدير اليدوي ممكّن
 manual-export-enabled-key-description=حدد هذه الخانة لتمكين المستخدمين من تحديد الأصول ذات الصلة يدويًا لتصديرها.
-number-of-items-to-display-help=الحد الأقصى لعدد العناصر المراد عرضها في حالة تعطيل تقسيم الصفحات، وإلا عرض عدد العناصر لكل صفحة.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=لا يتم دعم إلا قاعدة واحدة بالمجموعة {0}.
 ordering=إرسال طلب
 other-site=ولاية أخرى

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_bg.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Съответните активи (Automatic Translation)
 manual-export-enabled=Разреши ръчно износ (Automatic Translation)
 manual-export-enabled-key-description=Отметнете това квадратче, за да разрешите на потребителите да изберете ръчно съответните активи за експортиране. (Automatic Translation)
-number-of-items-to-display-help=Максимален брой елементи за показване ако пагинация е изключена, в противен случай брой елементи за показване на страница. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Поръчване (Automatic Translation)
 other-site=Друго състояние

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ca.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Continguts relacionats
 manual-export-enabled=Exportació manual habilitada
 manual-export-enabled-key-description=Activeu aquesta casella per permetre que els usuaris seleccionin manualment els continguts relacionats per exportar.
-number-of-items-to-display-help=El màxim nombre d'elements a visualitzar si la paginació està desactivada, en qualsevol altre cas, nombre d'elements a visualitzar per pàgina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Només es suporta una regla amb la combinació {0}.
 ordering=Ordenació
 other-site=Un altre lloc

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_cs.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Související položky
 manual-export-enabled=Povolit ruční Export (Automatic Translation)
 manual-export-enabled-key-description=Zaškrtněte toto políčko, chcete-li umožnit uživatelům ručně vybrat související aktiva pro export. (Automatic Translation)
-number-of-items-to-display-help=Maximální počet zobrazených položek, pokud je stránkování vypnuto. Pokud je zapnuto, jedná se o počet zobrazených položek na stránku.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Je podporováno pouze jedno pravidlo s kombinací {0}.
 ordering=Řazení (Automatic Translation)
 other-site=Jiný stav

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_da.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterede assets
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Other Site (Automatic Copy)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_de.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Verknüpfte Assets
 manual-export-enabled=Manueller Export aktiviert
 manual-export-enabled-key-description=Aktivieren Sie diese Option, damit Benutzer verbundene Assets zum Exportieren manuell auswählen können.
-number-of-items-to-display-help=Die Anzahl der anzuzeigenden Elemente wenn kein Seitenumbruch verwendet wird, ansonsten die maximale Anzahl von Elementen pro Seite.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Es wird nur eine Richtlinie mit der Kombination {0} unterstützt.
 ordering=Sortierung
 other-site=Andere Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_el.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Σχετικά αντικείμενα
 manual-export-enabled=Ενεργοποίηση μη αυτόματης εξαγωγής (Automatic Translation)
 manual-export-enabled-key-description=Τσεκάρετε το κουτί αυτό για να επιτρέψετε στους χρήστες να επιλέξετε χειροκίνητα σχετικών περιουσιακών στοιχείων για την εξαγωγή. (Automatic Translation)
-number-of-items-to-display-help=Ο μέγιστος αριθμός αντικειμένων που θα εμφανίζονται αν η σελιδοποίηση είναι απενεργοποιημένη, ειδάλλως ο αριθμός των αντικειμένων ανά σελίδα.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Παραγγελία (Automatic Translation)
 other-site=Άλλη κατάσταση

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_en.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=Enable Manual Export
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple.
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported.
 ordering=Ordering
 other-site=Other Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_es.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Contenidos web relacionados
 manual-export-enabled=Exportación manual habilitada
 manual-export-enabled-key-description=Active esta casilla para permitir que los usuarios puedan seleccionar de forma manual los activos relacionados que se exportarán.
-number-of-items-to-display-help=Numero máximo de elementos a mostrar cuando la paginación está deshabilitada. En otro caso, número de elementos por página.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Sólo una regla con la combinación {0} es soportada
 ordering=Orden
 other-site=Otro Sitio

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_et.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Seotud varad (Automatic Translation)
 manual-export-enabled=Lubade kasutada käsitsi ekspordi programmi (Automatic Translation)
 manual-export-enabled-key-description=Märkige see ruut, et kasutajad valida käsitsi varade eksportida. (Automatic Translation)
-number-of-items-to-display-help=Palju üksusi kuvada kui lehekülgjaotuse on keelatud, muidu ühel lehel kuvatavate üksuste arv. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Tellimine (Automatic Translation)
 other-site=Muu riik

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_eu.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Erlazionatutako Edukiak
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Beste egoera

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fa.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=داده‌های مرتبط
 manual-export-enabled=صادر کردن کتابچه راهنمای کاربر را قادر می سازد (Automatic Translation)
 manual-export-enabled-key-description=این جعبه برای فعال کردن کاربران به دستی دارایی های مرتبط برای صادرات را انتخاب کنید. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy) تعداد بخش‌های نمایشح
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=فقط یک قانون با ترکیب {0} پشتیبانی می‌شود.
 ordering=مرتب سازی
 other-site=سایر سایت‌ها

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fi.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Liittyvät sisällöt
 manual-export-enabled=Manuaalinen Vienti Käytössä
 manual-export-enabled-key-description=Valitse tämä ruutu salliaksesi käyttäjien manuaalisesti valita liittyviä sisältöjä vietäväksi.
-number-of-items-to-display-help=Suurin määrä kohteita näytettäväks ilman sivujakoa, muuten näytetään sivujaon mukainen määrä.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Vain yksi sääntö per yhdistelmä {0} on tuettu.
 ordering=Järjestäminen
 other-site=Toinen sivusto

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Actifs associés
 manual-export-enabled=Exportation manuelle activée
 manual-export-enabled-key-description=Cochez cette option pour permettre aux utilisateurs de sélectionner manuellement les actifs liés à exporter.
-number-of-items-to-display-help=Nombre maximum d'éléments à afficher si la pagination est désactivée, sinon nombre d'items à afficher par page.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Une seule règle avec la combinaison {0} est supportée.
 ordering=Ordre
 other-site=Autre site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_gl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Elementos relacionados
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Outro estado

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hi_IN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=संबंधित संपत्ति (Automatic Translation)
 manual-export-enabled=मैंयुअल निर्यात सक्षम करें (Automatic Translation)
 manual-export-enabled-key-description=उपयोगकर्ताओं को निर्यात करने के लिए संबंधित परिसंपत्तियों को मैंयुअली चुनने में सक्षम करने के लिए इस बॉक्स को चेक (Automatic Translation)
-number-of-items-to-display-help=यदि पृष्ठ पर अंक लगाना अक्षम की गई है, प्रदर्शित करने के लिए आइटम्स की अधिकतम संख्या नहीं तो प्रति पृष्ठ प्रदर्शित करने के लिए आइटम्स की संख्या। (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=आदेश (Automatic Translation)
 other-site=अन्य साइट (Automatic Translation)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Srodna imovina
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Druga država

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hu.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Kapcsolódó tartalmak
 manual-export-enabled=Manuális exportálás engedélyezve
 manual-export-enabled-key-description=Jelölje be ezt a mezőt, ha engedélyezni kívánja, hogy a felhasználók manuálisan válasszák ki exportálásra a kapcsolódó tartalmakat.
-number-of-items-to-display-help=Maximum tételek száma jelenjen meg, ha a lapozás ki van kapcsolva, egyébként az oldalankénti tételek száma jelenjen meg.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Csak egy szabály támogatott a {0}-val kombinálva.
 ordering=Sorrend
 other-site=Egyéb webhely

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_in.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Terkait Aset
 manual-export-enabled=Mengaktifkan ekspor Manual (Automatic Translation)
 manual-export-enabled-key-description=Centang kotak ini untuk memungkinkan pengguna untuk secara manual memilih aset terkait untuk ekspor. (Automatic Translation)
-number-of-items-to-display-help=Maksimum jumlah item untuk menampilkan jika pagination dinonaktifkan, jika jumlah item untuk ditampilkan per halaman. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Memesan (Automatic Translation)
 other-site=Negara Lain

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_it.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Risorse correlate
 manual-export-enabled=Abilitare l'esportazione manuale (Automatic Translation)
 manual-export-enabled-key-description=Selezionare questa casella per consentire agli utenti di selezionare manualmente i relativi beni da esportare. (Automatic Translation)
-number-of-items-to-display-help=Massimo numero di elementi da visualizzare se la paginazione é disabilitata, altrimenti, numero di elementi da visualizzare per pagina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=E' consentita solo una regola con la combinazione {0}.
 ordering=L'ordinazione (Automatic Translation)
 other-site=Altro Sito

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_iw.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=נכסים קשורים
 manual-export-enabled=ייצוא ידני מופעל
 manual-export-enabled-key-description=סמן תיבה זו כדי לאפשר למשתמשים לבחור באופן ידני נכסים הקשורים לייצוא.
-number-of-items-to-display-help=מספר מרבי של פריטים להצגה במקרה שהחלוקה לדפים אינה פעילה, אחרת, מספר הפריטים להצגה בכל דף.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=רק כלל אחד עם הצירוף {0} נתמך.
 ordering=סידור
 other-site=אתר אחר

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ja.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=関連するアセット
 manual-export-enabled=手動エクスポートを有効にする
 manual-export-enabled-key-description=ここにチェックすると、エクスポートする関連するアセットを手動で選択できる機能が有効になります。
-number-of-items-to-display-help=ページネーションが無効の場合は、表示できるだけのデータを表示します。もしくはページ毎に表示できるアイテム数を表示します。
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported={0}のコンビネーションにはひとつのルールしかサポートされていません。
 ordering=順序付け
 other-site=他のサイト

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_kk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets (Automatic Copy)
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Other Site (Automatic Copy)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ko.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=관련된 자산 (Automatic Translation)
 manual-export-enabled=수동 내보내기 사용 (Automatic Translation)
 manual-export-enabled-key-description=사용자가 수동으로 내보낼 관련된 자산을 선택 하도록 설정 하려면이 확인란을 확인 하십시오. (Automatic Translation)
-number-of-items-to-display-help=페이지 매김을 사용 하는 경우 표시할 항목의 최대 수 그렇지 않으면 페이지 당 표시할 항목의 번호. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=주문 (Automatic Translation)
 other-site=그밖 국가

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lo.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=ຊັບພະຍາກອນທີ່ກ່ຽວຂ້ອງ
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=ລັດອື່ນໆ

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lt.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Susijusio turto (Automatic Translation)
 manual-export-enabled=Įgalinti rankiniu būdu eksporto (Automatic Translation)
 manual-export-enabled-key-description=Pažymėkite šį laukelį, kad vartotojai galėtų pasirinkti neautomatiniu būdu eksportuoti susijusio turto. (Automatic Translation)
-number-of-items-to-display-help=Maksimalus naikintinų elementų Rodyti Jei numeracija yra išjungta, kitaip skaičius viename puslapyje rodomų elementų. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Užsisakyti (Automatic Translation)
 other-site=Kitos svetainės (Automatic Translation)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nb.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterte ressurser
 manual-export-enabled=Aktivere manuell eksport (Automatic Translation)
 manual-export-enabled-key-description=Merk av i denne boksen for å la brukerne velge manuelt relaterte eiendeler for å eksportere. (Automatic Translation)
-number-of-items-to-display-help=Maksimalt antall innlegg som skal vises dersom paginering er påslått, ellers antall innlegg som skal vises på hver side.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Bare en regel med kombinasjonen {0} støttes.
 ordering=Bestilling (Automatic Translation)
 other-site=Annet nettsted

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Gerelateerde content
 manual-export-enabled=Handmatige export ingeschakeld
 manual-export-enabled-key-description=Vink dit vakje aan om gebruikers toe te staan handmatige verwante assets te selecteren voor export.
-number-of-items-to-display-help=Maximaal aantal weer te geven items bij uitgeschakelde paginering. Anders het aantal items per pagina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Er wordt slechts één regel met de combinatie {0} ondersteund.
 ordering=Ordenen
 other-site=Andere site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl_BE.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Gerelateerde content
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximaal aantal weer te geven items als paginering is uitgeschakeld. Anders het het aantal items per pagina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Andere provincie/staat

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Powiązane treści
 manual-export-enabled=Po ręcznym eksportu (Automatic Translation)
 manual-export-enabled-key-description=Zaznacz to pole, aby umożliwić użytkownikom ręcznie wybierz powiązane zasoby do eksportu. (Automatic Translation)
-number-of-items-to-display-help=Maksymalna liczba wyświetlanych elementów, o ile stronicowanie jest wyłączone, lub ilość elementów wyświetlanych na każdej stronie.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=W połączeniu z {0} tylko jedna reguła jest dozwolona.
 ordering=Zamawianie (Automatic Translation)
 other-site=Inne województwo

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_BR.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Conteúdo Relacionado
 manual-export-enabled=Exportação Manual Habilitada
 manual-export-enabled-key-description=Marcar esta caixa para permitir que os usuários selecionem manualmente os conteúdos relacionados a serem exportados.
-number-of-items-to-display-help=O número máximo de itens a serem exibidos se a paginação estiver desabilitada ou, caso contrário, o número de itens a serem exibidos por página.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Apenas uma regra é suportada com a combinação {0}.
 ordering=Ordem
 other-site=Outro site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_PT.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Conteúdo Relacionado
 manual-export-enabled=Ativar exportação Manual (Automatic Translation)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Número máximo de itens apresentados caso a paginação esteja desabilitada, caso contrário, o número de itens apresentados por página.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Apenas uma regra com a combinação {0} é suportada.
 ordering=Ordering (Automatic Copy)
 other-site=Outro site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ro.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Resurse conectate
 manual-export-enabled=Permite exportul manuală (Automatic Translation)
 manual-export-enabled-key-description=Bifați această casetă pentru a permite utilizatorilor să selecteze manual activelor legate de export. (Automatic Translation)
-number-of-items-to-display-help=Numărul maxim de elemente pentru a afişa dacă paginare este dezactivat, altfel numărul de elemente pentru a afişa pe pagină. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Comanda (Automatic Translation)
 other-site=Alt Judet

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ru.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Связанные ресурсы
 manual-export-enabled=Включить руководство экспорт (Automatic Translation)
 manual-export-enabled-key-description=Установите этот флажок, чтобы пользователи могли вручную выбрать связанные ресурсы для экспорта. (Automatic Translation)
-number-of-items-to-display-help=Максимально количестов элементов для показа, если постраничный просмотр отключен, иначе это будет количество элементов для показа на одной странице.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=С комбинацией {0} может быть только одно правило.
 ordering=Заказ (Automatic Translation)
 other-site=Другое состояние

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Súvisiace príspevky
 manual-export-enabled=Povolenie ručné vývozných (Automatic Translation)
 manual-export-enabled-key-description=Toto políčko umožňuje používateľom manuálne vybrať súvisiaceho majetku na export. (Automatic Translation)
-number-of-items-to-display-help=Maximálny počet zobrazovaných položiek ak je zakázané stránkovanie, inak počet položiek na stránku.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Podporované je len jedno pravidlo s kombináciou {0}.
 ordering=Objednávanie (Automatic Translation)
 other-site=Iné sídlo

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Povezanih sredstev (Automatic Translation)
 manual-export-enabled=Omogoči izvoz ročno (Automatic Translation)
 manual-export-enabled-key-description=Potrdite to polje, če želite omogočiti uporabnikom, da ročno izberete povezanih sredstev za izvoz. (Automatic Translation)
-number-of-items-to-display-help=Največje število elementov za prikaz označeno je onemogočena, sicer število elementov za prikaz na strani. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Naročanje (Automatic Translation)
 other-site=Drugo stanje

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Повезане Имовине
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Друга Стања

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Povezane Imovine
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Other Site (Automatic Copy)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sv.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterat innehåll
 manual-export-enabled=Manuell export aktiverad
 manual-export-enabled-key-description=Markera den här rutan för att aktivera att användare manuellt kan välja relaterade tillgångar att exportera.
-number-of-items-to-display-help=Maximalt antal objekt att visa om sidnumrering är inaktiverat. Annars antalet objekt att visa per sida.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Endast en regel med kombinationen {0} stöds.
 ordering=Sortering
 other-site=Annat tillstånd

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ta_IN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=தானாக எக்ஸ்போர்ட் செய்வதை செயல்படுத்து
 manual-export-enabled-key-description=எக்ஸ்போர்ட் செய்ய தொடர்புடைய Assets-களை Manual-ஆக தேர்ந்தெடுப்பதற்கு பயனர்களை இயக்குவதற்கு இந்த பாக்ஸை டிக் செய்யவும்.
-number-of-items-to-display-help=Pagination முடக்கப்பட்டால் காட்டப்படும் அயிட்டம்களின் அதிகபட்ச எண்ணிக்கை, இல்லையெனில் ஒரு பக்கத்தில் காட்டப்படும் அயிட்டம்களின் எண்ணிக்கை.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=இதனுடன் {0} ஒரே ஒரு விதி மட்டும் ஆதரிக்கப்படுகிறது.
 ordering=வரிசைப்படுத்துதல்
 other-site=மற்ற தளங்கள்

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_th.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=สินทรัพย์ที่เกี่ยวข้อง (Automatic Translation)
 manual-export-enabled=เปิดใช้งานการส่งออกด้วยตนเอง (Automatic Translation)
 manual-export-enabled-key-description=เลือกช่องนี้เพื่อให้ผู้ใช้สามารถเลือกสินทรัพย์ที่เกี่ยวข้องกับการส่งออกด้วยตนเอง (Automatic Translation)
-number-of-items-to-display-help=จำนวนสูงสุดของรายการที่จะแสดงการแบ่งงาน หรือหมายเลขของสินค้าที่จะแสดงต่อหน้า (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=การสั่งซื้อ (Automatic Translation)
 other-site=เว็บไซต์อื่น ๆ (Automatic Translation)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_tr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=İlgili varlık (Automatic Translation)
 manual-export-enabled=El ile ihracat etkinleştirmek (Automatic Translation)
 manual-export-enabled-key-description=Kullanıcıların el ile vermek için ilgili kıymetleri seçmek bu onay kutusunu işaretleyin. (Automatic Translation)
-number-of-items-to-display-help=En fazla sayfalama devre dışıysa, görüntülenecek öğe sayısını aksi takdirde sayfa başına görüntülenecek öğe sayısı. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Sipariş (Automatic Translation)
 other-site=Diğer Şehir

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_uk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Відповідних активів (Automatic Translation)
 manual-export-enabled=Увімкнути ручний експорту (Automatic Translation)
 manual-export-enabled-key-description=Позначте цей пункт, щоб надати користувачам можливість вибрати вручну відповідних активів для експорту. (Automatic Translation)
-number-of-items-to-display-help=Максимальна кількість елементів для відображення, якщо вимкнуто нумерацію сторінок, в іншому випадку кількість пунктів для відображення на сторінці. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Замовлення (Automatic Translation)
 other-site=Інший стан

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_vi.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Tài sản liên quan
 manual-export-enabled=Sử xuất khẩu hướng dẫn sử dụng (Automatic Translation)
 manual-export-enabled-key-description=Kiểm tra hộp này để cho phép người dùng tự lựa chọn các tài sản có liên quan để xuất khẩu. (Automatic Translation)
-number-of-items-to-display-help=Tham số quy định tổng số Nội dung được hiển thị nếu bỏ qua hiển thị dạng phân trang, trường hợp cho phép phân trang sẽ quy định số Nội dung được hiển thị trên từng trang.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Chỉ duy nhất luật với kết hợp {0} được hỗ trợ.
 ordering=Đặt hàng (Automatic Translation)
 other-site=Trạng thái khác

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_CN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=相关资产
 manual-export-enabled=启用手动导出
 manual-export-enabled-key-description=选中此框可以让用户手动选择要导出的相关资产。
-number-of-items-to-display-help=页码禁用时，此值为展示条目的最大值，其他情况下，此值为每页展示条目数。
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=对于组合{0}只有一个规则是被支持的。
 ordering=排序
 other-site=其他站点

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_TW.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=相關資產
 manual-export-enabled=啟用手動匯出 (Automatic Translation)
 manual-export-enabled-key-description=選中此框可使使用者手動選擇要匯出的相關資產。 (Automatic Translation)
-number-of-items-to-display-help=當分頁被停用時顯示最大項目數，否則顯示每頁項目數。
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=只有組合 {0} 的一個規則被支援。
 ordering=訂購 (Automatic Translation)
 other-site=其它站台


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102240

Hello @SamZiemer ,

Issue is that:

You cannot specify items per page using the pagination bar for asset publisher portlets. Page navigation behavior is similar as in other Control Panel menus, like in Web Content. The difference is that it's possible to specify the items per page, thus displaying the navigation if items are 6+ makes sense. In AP, it is not possible to specify items per page, rendering the pagination useless.

The reason for the issue is that our current searchContainer implementation logic for AssetPublisherDisplayContext is not in line with our other existing implementations.

For AssetPublisher, we allow paginationType "None","Regular", and "Simple".

The expected behaviors of the three are: (from https://portal.liferay.dev/docs/7-1/user/-/knowledge_base/u/configuring-display-settings)

> Pagination Type: This can be set to None, Simple, or Regular. None displays at most the number of assets specified in the Number of Items to Display property. Simple adds Previous and Next buttons for browsing through pages of assets in the Asset Publisher. Regular adds more options and information including First and Last buttons, a dropdown selector for pages, the number of items per page, and the total number of results (assets being displayed).

For our AP use-case, paginationType "Regular" needs to use the default searchContainer propKeys and propValues in determining its pagination while "None" and "Simple" should use the Number of Items to Display property set in the configuration setting for AP portlet.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim