### PR TITLE
LPS-102390

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ar.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=أصول ذات صلة
 manual-export-enabled=التصدير اليدوي ممكّن
 manual-export-enabled-key-description=حدد هذه الخانة لتمكين المستخدمين من تحديد الأصول ذات الصلة يدويًا لتصديرها.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=الحد الأقصى لعدد العناصر المراد عرضها في حالة تعطيل تقسيم الصفحات، وإلا عرض عدد العناصر لكل صفحة.
 only-one-rule-with-the-combination-x-is-supported=لا يتم دعم إلا قاعدة واحدة بالمجموعة {0}.
 ordering=إرسال طلب
 other-site=ولاية أخرى

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ca.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Continguts relacionats
 manual-export-enabled=Exportació manual habilitada
 manual-export-enabled-key-description=Activeu aquesta casella per permetre que els usuaris seleccionin manualment els continguts relacionats per exportar.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=El màxim nombre d'elements a visualitzar si la paginació està desactivada, en qualsevol altre cas, nombre d'elements a visualitzar per pàgina.
 only-one-rule-with-the-combination-x-is-supported=Només es suporta una regla amb la combinació {0}.
 ordering=Ordenació
 other-site=Un altre lloc

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_cs.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Související položky
 manual-export-enabled=Povolit ruční Export (Automatic Translation)
 manual-export-enabled-key-description=Zaškrtněte toto políčko, chcete-li umožnit uživatelům ručně vybrat související aktiva pro export. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximální počet zobrazených položek, pokud je stránkování vypnuto. Pokud je zapnuto, jedná se o počet zobrazených položek na stránku.
 only-one-rule-with-the-combination-x-is-supported=Je podporováno pouze jedno pravidlo s kombinací {0}.
 ordering=Řazení (Automatic Translation)
 other-site=Jiný stav

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_de.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Verknüpfte Assets
 manual-export-enabled=Manueller Export aktiviert
 manual-export-enabled-key-description=Aktivieren Sie diese Option, damit Benutzer verbundene Assets zum Exportieren manuell auswählen können.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Die Anzahl der anzuzeigenden Elemente wenn kein Seitenumbruch verwendet wird, ansonsten die maximale Anzahl von Elementen pro Seite.
 only-one-rule-with-the-combination-x-is-supported=Es wird nur eine Richtlinie mit der Kombination {0} unterstützt.
 ordering=Sortierung
 other-site=Andere Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_el.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Σχετικά αντικείμενα
 manual-export-enabled=Ενεργοποίηση μη αυτόματης εξαγωγής (Automatic Translation)
 manual-export-enabled-key-description=Τσεκάρετε το κουτί αυτό για να επιτρέψετε στους χρήστες να επιλέξετε χειροκίνητα σχετικών περιουσιακών στοιχείων για την εξαγωγή. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Ο μέγιστος αριθμός αντικειμένων που θα εμφανίζονται αν η σελιδοποίηση είναι απενεργοποιημένη, ειδάλλως ο αριθμός των αντικειμένων ανά σελίδα.
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Παραγγελία (Automatic Translation)
 other-site=Άλλη κατάσταση

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_es.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Contenidos web relacionados
 manual-export-enabled=Exportación manual habilitada
 manual-export-enabled-key-description=Active esta casilla para permitir que los usuarios puedan seleccionar de forma manual los activos relacionados que se exportarán.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Numero máximo de elementos a mostrar cuando la paginación está deshabilitada. En otro caso, número de elementos por página.
 only-one-rule-with-the-combination-x-is-supported=Sólo una regla con la combinación {0} es soportada
 ordering=Orden
 other-site=Otro Sitio

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fa.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=داده‌های مرتبط
 manual-export-enabled=صادر کردن کتابچه راهنمای کاربر را قادر می سازد (Automatic Translation)
 manual-export-enabled-key-description=این جعبه برای فعال کردن کاربران به دستی دارایی های مرتبط برای صادرات را انتخاب کنید. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy) تعداد بخش‌های نمایشح
 only-one-rule-with-the-combination-x-is-supported=فقط یک قانون با ترکیب {0} پشتیبانی می‌شود.
 ordering=مرتب سازی
 other-site=سایر سایت‌ها

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fi.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Liittyvät sisällöt
 manual-export-enabled=Manuaalinen Vienti Käytössä
 manual-export-enabled-key-description=Valitse tämä ruutu salliaksesi käyttäjien manuaalisesti valita liittyviä sisältöjä vietäväksi.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Suurin määrä kohteita näytettäväks ilman sivujakoa, muuten näytetään sivujaon mukainen määrä.
 only-one-rule-with-the-combination-x-is-supported=Vain yksi sääntö per yhdistelmä {0} on tuettu.
 ordering=Järjestäminen
 other-site=Toinen sivusto

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Actifs associés
 manual-export-enabled=Exportation manuelle activée
 manual-export-enabled-key-description=Cochez cette option pour permettre aux utilisateurs de sélectionner manuellement les actifs liés à exporter.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Nombre maximum d'éléments à afficher si la pagination est désactivée, sinon nombre d'items à afficher par page.
 only-one-rule-with-the-combination-x-is-supported=Une seule règle avec la combinaison {0} est supportée.
 ordering=Ordre
 other-site=Autre site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hu.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Kapcsolódó tartalmak
 manual-export-enabled=Manuális exportálás engedélyezve
 manual-export-enabled-key-description=Jelölje be ezt a mezőt, ha engedélyezni kívánja, hogy a felhasználók manuálisan válasszák ki exportálásra a kapcsolódó tartalmakat.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximum tételek száma jelenjen meg, ha a lapozás ki van kapcsolva, egyébként az oldalankénti tételek száma jelenjen meg.
 only-one-rule-with-the-combination-x-is-supported=Csak egy szabály támogatott a {0}-val kombinálva.
 ordering=Sorrend
 other-site=Egyéb webhely

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_it.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Risorse correlate
 manual-export-enabled=Abilitare l'esportazione manuale (Automatic Translation)
 manual-export-enabled-key-description=Selezionare questa casella per consentire agli utenti di selezionare manualmente i relativi beni da esportare. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Massimo numero di elementi da visualizzare se la paginazione é disabilitata, altrimenti, numero di elementi da visualizzare per pagina.
 only-one-rule-with-the-combination-x-is-supported=E' consentita solo una regola con la combinazione {0}.
 ordering=L'ordinazione (Automatic Translation)
 other-site=Altro Sito

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_iw.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=נכסים קשורים
 manual-export-enabled=ייצוא ידני מופעל
 manual-export-enabled-key-description=סמן תיבה זו כדי לאפשר למשתמשים לבחור באופן ידני נכסים הקשורים לייצוא.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=מספר מרבי של פריטים להצגה במקרה שהחלוקה לדפים אינה פעילה, אחרת, מספר הפריטים להצגה בכל דף.
 only-one-rule-with-the-combination-x-is-supported=רק כלל אחד עם הצירוף {0} נתמך.
 ordering=סידור
 other-site=אתר אחר

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ja.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=関連するアセット
 manual-export-enabled=手動エクスポートを有効にする
 manual-export-enabled-key-description=ここにチェックすると、エクスポートする関連するアセットを手動で選択できる機能が有効になります。
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=ページネーションが無効の場合は、表示できるだけのデータを表示します。もしくはページ毎に表示できるアイテム数を表示します。
 only-one-rule-with-the-combination-x-is-supported={0}のコンビネーションにはひとつのルールしかサポートされていません。
 ordering=順序付け
 other-site=他のサイト

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nb.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterte ressurser
 manual-export-enabled=Aktivere manuell eksport (Automatic Translation)
 manual-export-enabled-key-description=Merk av i denne boksen for å la brukerne velge manuelt relaterte eiendeler for å eksportere. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maksimalt antall innlegg som skal vises dersom paginering er påslått, ellers antall innlegg som skal vises på hver side.
 only-one-rule-with-the-combination-x-is-supported=Bare en regel med kombinasjonen {0} støttes.
 ordering=Bestilling (Automatic Translation)
 other-site=Annet nettsted

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Gerelateerde content
 manual-export-enabled=Handmatige export ingeschakeld
 manual-export-enabled-key-description=Vink dit vakje aan om gebruikers toe te staan handmatige verwante assets te selecteren voor export.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximaal aantal weer te geven items bij uitgeschakelde paginering. Anders het aantal items per pagina.
 only-one-rule-with-the-combination-x-is-supported=Er wordt slechts één regel met de combinatie {0} ondersteund.
 ordering=Ordenen
 other-site=Andere site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl_BE.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Gerelateerde content
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximaal aantal weer te geven items als paginering is uitgeschakeld. Anders het het aantal items per pagina.
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Andere provincie/staat

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Powiązane treści
 manual-export-enabled=Po ręcznym eksportu (Automatic Translation)
 manual-export-enabled-key-description=Zaznacz to pole, aby umożliwić użytkownikom ręcznie wybierz powiązane zasoby do eksportu. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maksymalna liczba wyświetlanych elementów, o ile stronicowanie jest wyłączone, lub ilość elementów wyświetlanych na każdej stronie.
 only-one-rule-with-the-combination-x-is-supported=W połączeniu z {0} tylko jedna reguła jest dozwolona.
 ordering=Zamawianie (Automatic Translation)
 other-site=Inne województwo

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_BR.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Conteúdo Relacionado
 manual-export-enabled=Exportação Manual Habilitada
 manual-export-enabled-key-description=Marcar esta caixa para permitir que os usuários selecionem manualmente os conteúdos relacionados a serem exportados.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=O número máximo de itens a serem exibidos se a paginação estiver desabilitada ou, caso contrário, o número de itens a serem exibidos por página.
 only-one-rule-with-the-combination-x-is-supported=Apenas uma regra é suportada com a combinação {0}.
 ordering=Ordem
 other-site=Outro site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_PT.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Conteúdo Relacionado
 manual-export-enabled=Ativar exportação Manual (Automatic Translation)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Número máximo de itens apresentados caso a paginação esteja desabilitada, caso contrário, o número de itens apresentados por página.
 only-one-rule-with-the-combination-x-is-supported=Apenas uma regra com a combinação {0} é suportada.
 ordering=Ordering (Automatic Copy)
 other-site=Outro site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ru.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Связанные ресурсы
 manual-export-enabled=Включить руководство экспорт (Automatic Translation)
 manual-export-enabled-key-description=Установите этот флажок, чтобы пользователи могли вручную выбрать связанные ресурсы для экспорта. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Максимально количестов элементов для показа, если постраничный просмотр отключен, иначе это будет количество элементов для показа на одной странице.
 only-one-rule-with-the-combination-x-is-supported=С комбинацией {0} может быть только одно правило.
 ordering=Заказ (Automatic Translation)
 other-site=Другое состояние

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Súvisiace príspevky
 manual-export-enabled=Povolenie ručné vývozných (Automatic Translation)
 manual-export-enabled-key-description=Toto políčko umožňuje používateľom manuálne vybrať súvisiaceho majetku na export. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximálny počet zobrazovaných položiek ak je zakázané stránkovanie, inak počet položiek na stránku.
 only-one-rule-with-the-combination-x-is-supported=Podporované je len jedno pravidlo s kombináciou {0}.
 ordering=Objednávanie (Automatic Translation)
 other-site=Iné sídlo

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sv.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterat innehåll
 manual-export-enabled=Manuell export aktiverad
 manual-export-enabled-key-description=Markera den här rutan för att aktivera att användare manuellt kan välja relaterade tillgångar att exportera.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Maximalt antal objekt att visa om sidnumrering är inaktiverat. Annars antalet objekt att visa per sida.
 only-one-rule-with-the-combination-x-is-supported=Endast en regel med kombinationen {0} stöds.
 ordering=Sortering
 other-site=Annat tillstånd

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ta_IN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=தானாக எக்ஸ்போர்ட் செய்வதை செயல்படுத்து
 manual-export-enabled-key-description=எக்ஸ்போர்ட் செய்ய தொடர்புடைய Assets-களை Manual-ஆக தேர்ந்தெடுப்பதற்கு பயனர்களை இயக்குவதற்கு இந்த பாக்ஸை டிக் செய்யவும்.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Pagination முடக்கப்பட்டால் காட்டப்படும் அயிட்டம்களின் அதிகபட்ச எண்ணிக்கை, இல்லையெனில் ஒரு பக்கத்தில் காட்டப்படும் அயிட்டம்களின் எண்ணிக்கை.
 only-one-rule-with-the-combination-x-is-supported=இதனுடன் {0} ஒரே ஒரு விதி மட்டும் ஆதரிக்கப்படுகிறது.
 ordering=வரிசைப்படுத்துதல்
 other-site=மற்ற தளங்கள்

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_vi.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Tài sản liên quan
 manual-export-enabled=Sử xuất khẩu hướng dẫn sử dụng (Automatic Translation)
 manual-export-enabled-key-description=Kiểm tra hộp này để cho phép người dùng tự lựa chọn các tài sản có liên quan để xuất khẩu. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=Tham số quy định tổng số Nội dung được hiển thị nếu bỏ qua hiển thị dạng phân trang, trường hợp cho phép phân trang sẽ quy định số Nội dung được hiển thị trên từng trang.
 only-one-rule-with-the-combination-x-is-supported=Chỉ duy nhất luật với kết hợp {0} được hỗ trợ.
 ordering=Đặt hàng (Automatic Translation)
 other-site=Trạng thái khác

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_CN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=相关资产
 manual-export-enabled=启用手动导出
 manual-export-enabled-key-description=选中此框可以让用户手动选择要导出的相关资产。
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=页码禁用时，此值为展示条目的最大值，其他情况下，此值为每页展示条目数。
 only-one-rule-with-the-combination-x-is-supported=对于组合{0}只有一个规则是被支持的。
 ordering=排序
 other-site=其他站点

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_TW.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=相關資產
 manual-export-enabled=啟用手動匯出 (Automatic Translation)
 manual-export-enabled-key-description=選中此框可使使用者手動選擇要匯出的相關資產。 (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
+number-of-items-to-display-help=當分頁被停用時顯示最大項目數，否則顯示每頁項目數。
 only-one-rule-with-the-combination-x-is-supported=只有組合 {0} 的一個規則被支援。
 ordering=訂購 (Automatic Translation)
 other-site=其它站台

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalWebResourcesUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalWebResourcesUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.servlet;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -69,7 +70,11 @@ public class PortalWebResourcesUtil {
 		for (PortalWebResources portalWebResources :
 				_portalWebResourcesMap.values()) {
 
-			if (requestURI.startsWith(portalWebResources.getContextPath())) {
+			String contextPath = portalWebResources.getContextPath();
+
+			if (contextPath.equals(Portal.PATH_MAIN) ||
+				contextPath.startsWith(requestURI)) {
+
 				return portalWebResources.getLastModified();
 			}
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102390

Hello @SamZiemer ,

The issue here is that the timestamps portion of URLs for updated theme related files are not getting updated.
See linked ticket and also the LPP linked for detailed descriptions of the issue.

The reason this issue occurs is because when [getStaticResourceURL()](https://github.com/liferay/liferay-portal/blob/27de5e6a1e9a782a5a34aa924cff52ae08cbaaf6/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L5434-L5435) is called, it will utilize [PortalWebResourcesUtil.getPathLastModified()](https://github.com/liferay/liferay-portal/blob/27de5e6a1e9a782a5a34aa924cff52ae08cbaaf6/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalWebResourcesUtil.java#L66-L78). 

The check:

`			if (requestURI.startsWith(portalWebResources.getContextPath())) {
				return portalWebResources.getLastModified();
			}`
is insufficient because if the resource context path is Portal.Path_MAIN, the check will be fulfilled because requestURI will always start with Portal.PATH_MAIN, therefore returning the lastModified time of Portal.PATH_MAIN and not the lastModified time for the requsted URI.

Therefore, the solution is to improve the logic by either checking whether the contextPath is equal to Portal.PATH_MAIN or whether the contextPath starts with requestURI.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim