### PR TITLE
LPS-102390 Our check needs to be stricter and smarter.

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalWebResourcesUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalWebResourcesUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.servlet;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -69,7 +70,11 @@ public class PortalWebResourcesUtil {
 		for (PortalWebResources portalWebResources :
 				_portalWebResourcesMap.values()) {
 
-			if (requestURI.startsWith(portalWebResources.getContextPath())) {
+			String contextPath = portalWebResources.getContextPath();
+
+			if (requestURI.equals(Portal.PATH_MODULE) ||
+				contextPath.startsWith(requestURI)) {
+
 				return portalWebResources.getLastModified();
 			}
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102390

Hello @SamZiemer ,

The issue here is that the timestamps portion of URLs for updated theme related files are not getting updated.
See linked ticket and also the LPP linked for detailed descriptions of the issue.

The reason this issue occurs is because when [getStaticResourceURL()](https://github.com/liferay/liferay-portal/blob/27de5e6a1e9a782a5a34aa924cff52ae08cbaaf6/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L5434-L5435) is called, it will utilize [PortalWebResourcesUtil.getPathLastModified()](https://github.com/liferay/liferay-portal/blob/27de5e6a1e9a782a5a34aa924cff52ae08cbaaf6/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalWebResourcesUtil.java#L66-L78). 

The check:

`			if (requestURI.startsWith(portalWebResources.getContextPath())) {
				return portalWebResources.getLastModified();
			}`
is insufficient because if the resource context path is Portal.Path_MODULE, the check will be fulfilled because requestURI will always start with Portal.PATH_MODULE, therefore returning the lastModified time of Portal.PATH_MODULE and not the lastModified time for the requsted URI.

Therefore, the solution is to improve the logic by either checking whether the contextPath is equal to Portal.PATH_MODULE or whether the contextPath starts with requestURI.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim