### PR TITLE
J cords lps 102786

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8240,6 +8240,41 @@ public class JournalArticleLocalServiceImpl
 			return;
 		}
 
+		SubscriptionSender subscriptionSender =
+			new GroupSubscriptionCheckSubscriptionSender(
+				JournalConstants.RESOURCE_NAME);
+
+		subscriptionSender.setClassName(article.getModelClassName());
+		subscriptionSender.setClassPK(article.getId());
+		subscriptionSender.setCompanyId(article.getCompanyId());
+
+		JournalFolder folder = journalFolderPersistence.fetchByPrimaryKey(
+			article.getFolderId());
+
+		subscriptionSender.addPersistedSubscribers(
+			JournalFolder.class.getName(), article.getGroupId());
+
+		if (folder != null) {
+			subscriptionSender.addPersistedSubscribers(
+				JournalFolder.class.getName(), folder.getFolderId());
+
+			for (Long ancestorFolderId : folder.getAncestorFolderIds()) {
+				subscriptionSender.addPersistedSubscribers(
+					JournalFolder.class.getName(), ancestorFolderId);
+			}
+		}
+
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
+			_portal.getSiteGroupId(article.getGroupId()),
+			classNameLocalService.getClassNameId(JournalArticle.class),
+			article.getDDMStructureKey(), true);
+
+		subscriptionSender.addPersistedSubscribers(
+			DDMStructure.class.getName(), ddmStructure.getStructureId());
+
+		subscriptionSender.addPersistedSubscribers(
+			JournalArticle.class.getName(), article.getResourcePrimKey());
+
 		String articleTitle = article.getTitle(serviceContext.getLanguageId());
 
 		String fromName = journalGroupServiceConfiguration.emailFromName();
@@ -8344,13 +8379,6 @@ public class JournalArticleLocalServiceImpl
 		catch (Exception e) {
 		}
 
-		SubscriptionSender subscriptionSender =
-			new GroupSubscriptionCheckSubscriptionSender(
-				JournalConstants.RESOURCE_NAME);
-
-		subscriptionSender.setClassName(article.getModelClassName());
-		subscriptionSender.setClassPK(article.getId());
-		subscriptionSender.setCompanyId(article.getCompanyId());
 		subscriptionSender.setContextAttribute(
 			"[$ARTICLE_CONTENT$]", articleContent, false);
 		subscriptionSender.setContextAttribute(
@@ -8358,9 +8386,6 @@ public class JournalArticleLocalServiceImpl
 			false);
 
 		String folderName = StringPool.BLANK;
-
-		JournalFolder folder = journalFolderPersistence.fetchByPrimaryKey(
-			article.getFolderId());
 
 		if (folder != null) {
 			folderName = folder.getName();
@@ -8405,30 +8430,6 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setReplyToAddress(fromAddress);
 		subscriptionSender.setScopeGroupId(article.getGroupId());
 		subscriptionSender.setServiceContext(serviceContext);
-
-		subscriptionSender.addPersistedSubscribers(
-			JournalFolder.class.getName(), article.getGroupId());
-
-		if (folder != null) {
-			subscriptionSender.addPersistedSubscribers(
-				JournalFolder.class.getName(), folder.getFolderId());
-
-			for (Long ancestorFolderId : folder.getAncestorFolderIds()) {
-				subscriptionSender.addPersistedSubscribers(
-					JournalFolder.class.getName(), ancestorFolderId);
-			}
-		}
-
-		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
-			_portal.getSiteGroupId(article.getGroupId()),
-			classNameLocalService.getClassNameId(JournalArticle.class),
-			article.getDDMStructureKey(), true);
-
-		subscriptionSender.addPersistedSubscribers(
-			DDMStructure.class.getName(), ddmStructure.getStructureId());
-
-		subscriptionSender.addPersistedSubscribers(
-			JournalArticle.class.getName(), article.getResourcePrimKey());
 
 		subscriptionSender.flushNotificationsAsync();
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8275,6 +8275,10 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.addPersistedSubscribers(
 			JournalArticle.class.getName(), article.getResourcePrimKey());
 
+		if (!subscriptionSender.hasSubscribers()) {
+			return;
+		}
+
 		String articleTitle = article.getTitle(serviceContext.getLanguageId());
 
 		String fromName = journalGroupServiceConfiguration.emailFromName();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -106,7 +106,7 @@ public class SubscriptionSender implements Serializable {
 		ObjectValuePair<String, Long> ovp = new ObjectValuePair<>(
 			className, classPK);
 
-		_persistestedSubscribersOVPs.add(ovp);
+		_persistedSubscribersOVPs.add(ovp);
 	}
 
 	public void addRuntimeSubscribers(String toAddress, String toName) {
@@ -131,7 +131,7 @@ public class SubscriptionSender implements Serializable {
 			}
 
 			for (ObjectValuePair<String, Long> ovp :
-					_persistestedSubscribersOVPs) {
+					_persistedSubscribersOVPs) {
 
 				String className = ovp.getKey();
 				long classPK = ovp.getValue();
@@ -152,7 +152,7 @@ public class SubscriptionSender implements Serializable {
 				}
 			}
 
-			_persistestedSubscribersOVPs.clear();
+			_persistedSubscribersOVPs.clear();
 
 			for (ObjectValuePair<String, String> ovp :
 					_runtimeSubscribersOVPs) {
@@ -253,6 +253,24 @@ public class SubscriptionSender implements Serializable {
 
 	public ServiceContext getServiceContext() {
 		return serviceContext;
+	}
+
+	public boolean hasSubscribers() {
+		if (!_runtimeSubscribersOVPs.isEmpty()) {
+			return true;
+		}
+
+		for (ObjectValuePair<String, Long> ovp : _persistedSubscribersOVPs) {
+			List<Subscription> subscriptions =
+				SubscriptionLocalServiceUtil.getSubscriptions(
+					companyId, ovp.getKey(), ovp.getValue());
+
+			if (!subscriptions.isEmpty()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public void initialize() throws Exception {
@@ -1029,7 +1047,7 @@ public class SubscriptionSender implements Serializable {
 	private long _notificationClassNameId;
 	private int _notificationType;
 	private final List<ObjectValuePair<String, Long>>
-		_persistestedSubscribersOVPs = new ArrayList<>();
+		_persistedSubscribersOVPs = new ArrayList<>();
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.11.0
+version 9.12.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102786
https://issues.liferay.com/browse/LPP-34711

**Problem:** Backporting [LPS-99857](https://issues.liferay.com/browse/LPS-99857) to 7.0.x revealed an issue where harmless freemarker errors are thrown: https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(7.0.x)/AXIS_VARIABLE=0,label_exp=!master/27977//consoleText 
JournalArticle templates will try to be rendered content during an import. If the template needs information from a request, because there is no request during an import or service call, it will fail and throw freemarker errors. 

**Solution:** While there errors are appropriate, we can minimize the cases where freemarker throws errors (such as when porygon-theme is deployed) by quick returning before trying to render if there are no subscribers.