### PR TITLE
J cords lps 102786

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8325,6 +8325,10 @@ public class JournalArticleLocalServiceImpl
 			}
 		}
 
+		if (!subscriptionSender.hasSubscribers()) {
+			return;
+		}
+
 		String articleTitle = article.getTitle(serviceContext.getLanguageId());
 
 		String fromName = journalGroupServiceConfiguration.emailFromName();

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8250,6 +8250,81 @@ public class JournalArticleLocalServiceImpl
 			return;
 		}
 
+		SubscriptionSender subscriptionSender =
+			new GroupSubscriptionCheckSubscriptionSender(
+				JournalConstants.RESOURCE_NAME);
+
+		subscriptionSender.setClassName(article.getModelClassName());
+		subscriptionSender.setClassPK(article.getId());
+		subscriptionSender.setCompanyId(article.getCompanyId());
+
+		JournalFolder folder = journalFolderPersistence.fetchByPrimaryKey(
+			article.getFolderId());
+
+		subscriptionSender.addPersistedSubscribers(
+			JournalFolder.class.getName(), article.getGroupId());
+
+		Group group = groupLocalService.getGroup(article.getGroupId());
+
+		long liveGroupId = group.getLiveGroupId();
+
+		if (liveGroupId > 0) {
+			subscriptionSender.addPersistedSubscribers(
+				JournalFolder.class.getName(), liveGroupId, false);
+		}
+
+		if (folder != null) {
+			subscriptionSender.addPersistedSubscribers(
+				JournalFolder.class.getName(), folder.getFolderId());
+
+			for (Long ancestorFolderId : folder.getAncestorFolderIds()) {
+				subscriptionSender.addPersistedSubscribers(
+					JournalFolder.class.getName(), ancestorFolderId);
+			}
+
+			if (liveGroupId > 0) {
+				folder = journalFolderPersistence.fetchByUUID_G(
+					folder.getUuid(), liveGroupId);
+
+				if (folder != null) {
+					subscriptionSender.addPersistedSubscribers(
+						JournalFolder.class.getName(), folder.getFolderId(),
+						false);
+
+					for (Long ancestorFolderId :
+							folder.getAncestorFolderIds()) {
+
+						subscriptionSender.addPersistedSubscribers(
+							JournalFolder.class.getName(), ancestorFolderId,
+							false);
+					}
+				}
+			}
+		}
+
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
+			_portal.getSiteGroupId(article.getGroupId()),
+			classNameLocalService.getClassNameId(JournalArticle.class),
+			article.getDDMStructureKey(), true);
+
+		subscriptionSender.addPersistedSubscribers(
+			DDMStructure.class.getName(), ddmStructure.getStructureId());
+
+		subscriptionSender.addPersistedSubscribers(
+			JournalArticle.class.getName(), article.getResourcePrimKey());
+
+		if (liveGroupId > 0) {
+			JournalArticle liveGroupArticle =
+				journalArticlePersistence.fetchByUUID_G(
+					article.getUuid(), liveGroupId);
+
+			if (liveGroupArticle != null) {
+				subscriptionSender.addPersistedSubscribers(
+					JournalArticle.class.getName(),
+					liveGroupArticle.getResourcePrimKey(), false);
+			}
+		}
+
 		String articleTitle = article.getTitle(serviceContext.getLanguageId());
 
 		String fromName = journalGroupServiceConfiguration.emailFromName();
@@ -8354,13 +8429,6 @@ public class JournalArticleLocalServiceImpl
 		catch (Exception e) {
 		}
 
-		SubscriptionSender subscriptionSender =
-			new GroupSubscriptionCheckSubscriptionSender(
-				JournalConstants.RESOURCE_NAME);
-
-		subscriptionSender.setClassName(article.getModelClassName());
-		subscriptionSender.setClassPK(article.getId());
-		subscriptionSender.setCompanyId(article.getCompanyId());
 		subscriptionSender.setContextAttribute(
 			"[$ARTICLE_CONTENT$]", articleContent, false);
 		subscriptionSender.setContextAttribute(
@@ -8368,9 +8436,6 @@ public class JournalArticleLocalServiceImpl
 			false);
 
 		String folderName = StringPool.BLANK;
-
-		JournalFolder folder = journalFolderPersistence.fetchByPrimaryKey(
-			article.getFolderId());
 
 		if (folder != null) {
 			folderName = folder.getName();
@@ -8415,69 +8480,6 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setReplyToAddress(fromAddress);
 		subscriptionSender.setScopeGroupId(article.getGroupId());
 		subscriptionSender.setServiceContext(serviceContext);
-
-		subscriptionSender.addPersistedSubscribers(
-			JournalFolder.class.getName(), article.getGroupId());
-
-		Group group = groupLocalService.getGroup(article.getGroupId());
-
-		long liveGroupId = group.getLiveGroupId();
-
-		if (liveGroupId > 0) {
-			subscriptionSender.addPersistedSubscribers(
-				JournalFolder.class.getName(), liveGroupId, false);
-		}
-
-		if (folder != null) {
-			subscriptionSender.addPersistedSubscribers(
-				JournalFolder.class.getName(), folder.getFolderId());
-
-			for (Long ancestorFolderId : folder.getAncestorFolderIds()) {
-				subscriptionSender.addPersistedSubscribers(
-					JournalFolder.class.getName(), ancestorFolderId);
-			}
-
-			if (liveGroupId > 0) {
-				folder = journalFolderPersistence.fetchByUUID_G(
-					folder.getUuid(), liveGroupId);
-
-				if (folder != null) {
-					subscriptionSender.addPersistedSubscribers(
-						JournalFolder.class.getName(), folder.getFolderId(),
-						false);
-
-					for (Long ancestorFolderId :
-							folder.getAncestorFolderIds()) {
-
-						subscriptionSender.addPersistedSubscribers(
-							JournalFolder.class.getName(), ancestorFolderId,
-							false);
-					}
-				}
-			}
-		}
-
-		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
-			_portal.getSiteGroupId(article.getGroupId()),
-			classNameLocalService.getClassNameId(JournalArticle.class),
-			article.getDDMStructureKey(), true);
-
-		subscriptionSender.addPersistedSubscribers(
-			DDMStructure.class.getName(), ddmStructure.getStructureId());
-
-		subscriptionSender.addPersistedSubscribers(
-			JournalArticle.class.getName(), article.getResourcePrimKey());
-
-		if (liveGroupId > 0) {
-			article = journalArticlePersistence.fetchByUUID_G(
-				article.getUuid(), liveGroupId);
-
-			if (article != null) {
-				subscriptionSender.addPersistedSubscribers(
-					JournalArticle.class.getName(),
-					article.getResourcePrimKey(), false);
-			}
-		}
 
 		subscriptionSender.flushNotificationsAsync();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -259,6 +259,27 @@ public class SubscriptionSender implements Serializable {
 		return serviceContext;
 	}
 
+	public boolean hasSubscribers() {
+		if (!_runtimeSubscribersOVPs.isEmpty()) {
+			return true;
+		}
+
+		for (Tuple tuple : _persistedSubscribersTuples) {
+			String className = (String)tuple.getObject(0);
+			long classPK = (long)tuple.getObject(1);
+
+			List<Subscription> subscriptions =
+				SubscriptionLocalServiceUtil.getSubscriptions(
+					companyId, className, classPK);
+
+			if (!subscriptions.isEmpty()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public void initialize() throws Exception {
 		if (_initialized) {
 			return;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102786
https://issues.liferay.com/browse/LPP-34711

Resent from https://github.com/SamZiemer/liferay-portal/pull/660 after rebasing.

**Problem:** Backporting [LPS-99857](https://issues.liferay.com/browse/LPS-99857) to 7.0.x revealed an issue where harmless freemarker errors are thrown: https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(7.0.x)/AXIS_VARIABLE=0,label_exp=!master/27977//consoleText 
JournalArticle templates will try to be rendered content during an import. If the template needs information from a request, because there is no request during an import or service call, it will fail and throw freemarker errors. 

**Solution:** While there errors are appropriate, we can minimize the cases where freemarker throws errors (such as when porygon-theme is deployed) by quick returning before trying to render if there are no subscribers.