### PR TITLE
LPS-102795 Use default locale's value for repeatable fields if other …

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -790,6 +790,11 @@ public class JournalConverterImpl implements JournalConverter {
 
 				Serializable fieldValue = ddmField.getValue(locale, count);
 
+				if (fieldValue == null) {
+					fieldValue = ddmField.getValue(
+						ddmField.getDefaultLocale(), count);
+				}
+
 				String valueString = String.valueOf(fieldValue);
 
 				updateDynamicContentValue(


### PR DESCRIPTION
…locale values were not set, this matches visually what the user sees

https://issues.liferay.com/browse/LPS-102795
https://issues.liferay.com/browse/LPP-35232

**Problem:** JournalConverterImpl was setting non-initialized local fields to null, following [this logic](https://github.com/liferay/liferay-portal/blob/7fad9b6328342607719cb17f5456a55fc136bfbe/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/Field.java#L199).

**Solution:** From the user's perspective, non-initialized fields have the value of the default locale's field while they are editing the document. Use that value to populate the field instead of null when using the JournalConverter.