### PR TITLE
LPS-101515 Elasticsearch Limit of total fields being exceeded with over indexed DDM fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -45,7 +45,7 @@ AUI.add(
 
 		var structureFieldIndexEnable = function() {
 			var indexTypeNode = A.one(
-				'#_' + Liferay.Portlet.list[0] + '_indexable'
+				'#_com_liferay_journal_web_portlet_JournalPortlet_indexable'
 			);
 
 			if (indexTypeNode) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101515

This commit hardcodes the portletNamespace instead of indexing from the list. 

An extra commit to be added due to the instance when the list contains multiple namespaces and journal-web is not the first one. 