### PR TITLE
LPS-102733 Change 2 digits year to 4 digits year in DDL

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DateDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DateDDMFormFieldValueRenderer.java
@@ -28,6 +28,10 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
 import java.util.Locale;
 
 /**
@@ -64,7 +68,18 @@ public class DateDDMFormFieldValueRenderer
 
 	private String _format(Serializable value, Locale locale) {
 		try {
-			return DateUtil.formatDate("yyyy-MM-dd", value.toString(), locale);
+			Date dateValue = DateUtil.parseDate(
+				"yyyy-MM-dd", value.toString(), locale);
+
+			SimpleDateFormat dateFormat =
+				(SimpleDateFormat)DateFormat.getDateInstance(
+					SimpleDateFormat.SHORT, locale);
+
+			String formatPattern = dateFormat.toPattern();
+
+			formatPattern = formatPattern.replaceAll("\\byy\\b", "yyyy");
+
+			return DateUtil.getDate(dateValue, formatPattern, locale);
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/render/DDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/render/DDMFormFieldValueRendererTest.java
@@ -141,12 +141,12 @@ public class DDMFormFieldValueRendererTest extends BaseDDMTestCase {
 		String renderedValue = ddmFormFieldValueRenderer.render(
 			ddmFormFieldValue, LocaleUtil.US);
 
-		Assert.assertEquals("10/22/14", renderedValue);
+		Assert.assertEquals("10/22/2014", renderedValue);
 
 		renderedValue = ddmFormFieldValueRenderer.render(
 			ddmFormFieldValue, LocaleUtil.BRAZIL);
 
-		Assert.assertEquals("22/10/14", renderedValue);
+		Assert.assertEquals("22/10/2014", renderedValue);
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102733
Previous pr: https://github.com/leoadb/liferay-portal/pull/570

Edited the test to check for 4 digit year instead of 2 digit year and changed the logic for `_format` to replace the years in the date format's pattern.

The issue is the display of DDL date is not consistent. The data list stores the information with pattern `yyyy`, but on retrieve the API extracts the value with pattern `yy`. The solution is to use a different function that uses the specified date pattern intended to keep consistency.

cc/ @inacionery