### PR TITLE
LPS-101682 Columns names are using field name instead of the field label

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/EditTableView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/EditTableView.es.js
@@ -219,11 +219,18 @@ const EditTableView = ({
 								fieldTypes={availableFields.map(field => ({
 									description: field.fieldType,
 									disabled: columns.some(
-										column => column === field.name
+										column =>
+											column ===
+											field.label[
+												themeDisplay.getLanguageId()
+											]
 									),
 									icon: field.fieldType,
-									label: field.name,
-									name: field.fieldType
+									label:
+										field.label[
+											themeDisplay.getLanguageId()
+										],
+									name: field.name
 								}))}
 								keywords={keywords}
 								onDoubleClick={({label}) => onAddColumn(label)}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101682

Column name for App Builder's table view uses the field name, but it should be using the field label. I updated the values to match the field's key.