### PR TITLE
LPS-102610

### DIFF
--- a/portal-web/docroot/html/taglib/init.jsp
+++ b/portal-web/docroot/html/taglib/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ include file="/html/common/init.jsp" %>
 
-<%@ page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.exception.NoSuchLayoutException" %><%@
+page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %><%@
 page import="com.liferay.taglib.util.InlineUtil" %><%@
 page import="com.liferay.taglib.util.PortalIncludeUtil" %><%@

--- a/portal-web/docroot/html/taglib/init.jsp
+++ b/portal-web/docroot/html/taglib/init.jsp
@@ -17,6 +17,7 @@
 <%@ include file="/html/common/init.jsp" %>
 
 <%@ page import="com.liferay.portal.kernel.exception.NoSuchLayoutException" %><%@
+page import="com.liferay.portal.kernel.servlet.MultiSessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %><%@
 page import="com.liferay.taglib.util.InlineUtil" %><%@

--- a/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
+++ b/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
@@ -46,6 +46,12 @@ else if (group.isStagingGroup()) {
 
 	inStaging = true;
 }
+
+boolean layoutException = false;
+
+if (!SessionErrors.isEmpty(request)) {
+	layoutException = SessionErrors.contains(request, NoSuchLayoutException.class.getName());
+}
 %>
 
 <c:if test="<%= liveGroup.isStaged() && !liveGroup.isStagedPortlet(portlet.getRootPortletId()) %>">
@@ -97,6 +103,6 @@ else if (group.isStagingGroup()) {
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_PREFERENCES %>" message="you-have-successfully-updated-your-preferences" />
 
-<c:if test="<%= !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE) %>">
+<c:if test="<%= !layoutException && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE) %>">
 	<liferay-ui:error embed="<%= false %>" />
 </c:if>

--- a/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
+++ b/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
@@ -46,12 +46,6 @@ else if (group.isStagingGroup()) {
 
 	inStaging = true;
 }
-
-boolean layoutException = false;
-
-if (!SessionErrors.isEmpty(request)) {
-	layoutException = SessionErrors.contains(request, NoSuchLayoutException.class.getName());
-}
 %>
 
 <c:if test="<%= liveGroup.isStaged() && !liveGroup.isStagedPortlet(portlet.getRootPortletId()) %>">
@@ -103,6 +97,6 @@ if (!SessionErrors.isEmpty(request)) {
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_PREFERENCES %>" message="you-have-successfully-updated-your-preferences" />
 
-<c:if test="<%= !layoutException && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE) %>">
+<c:if test="<%= !MultiSessionErrors.contains(renderRequest, NoSuchLayoutException.class.getName()) && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE) %>">
 	<liferay-ui:error embed="<%= false %>" />
 </c:if>


### PR DESCRIPTION
Notes from @katienesterovich :

> https://issues.liferay.com/browse/LPS-102610
> 
> `NoSuchLayoutException` triggers a Clay toast alert which is not suppressed. As a fix, I created a check to prevent error pop-ups due to `NoSuchLayoutException`.

