### PR TITLE
LPS-103195 Reinstate Paragraph form field type

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ParagraphFieldType.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/field/type/v1_0/ParagraphFieldType.java
@@ -41,8 +41,8 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"data.engine.field.type.description=paragraph-field-type-description",
-		"data.engine.field.type.display.order:Integer=1",
-		"data.engine.field.type.group=interface",
+		"data.engine.field.type.display.order:Integer=10",
+		"data.engine.field.type.group=basic",
 		"data.engine.field.type.icon=paragraph",
 		"data.engine.field.type.js.module=dynamic-data-mapping-form-field-type/Paragraph/Paragraph.es",
 		"data.engine.field.type.label=paragraph-field-type-label"


### PR DESCRIPTION
From @katienesterovich :
> https://issues.liferay.com/browse/LPS-103195
> 
> Caused by https://issues.liferay.com/browse/BPR-31614 - LPS-102521 Reorder fields, commit
> [liferay/liferay-portal-ee@d6c7e34](https://github.com/liferay/liferay-portal-ee/commit/d6c7e3469b397aaa9b6822941431c9668292a525) which changes Paragraph type from `basic` to `interface`. This may have been intentional, as Paragraph type has issues/bugs.

