### PR TITLE
LPS-103347 Add Batch Engine to language keys

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/content/Language.properties
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/content/Language.properties
@@ -10,6 +10,7 @@ category.api-authentication=API Authentication
 category.assets=Assets
 category.audit=Audit
 category.auto-login=Auto Login
+category.batch-engine=Batch Engine
 category.blogs=Blogs
 category.breadcrumbs=Breadcrumbs
 category.captcha=CAPTCHA


### PR DESCRIPTION
Notes from @katienesterovich :

> https://issues.liferay.com/browse/LPS-103347
> 
> Language.properties file was missing the language key for `category.batch-engine`


Test Result here: https://github.com/brianikim/liferay-portal/pull/65#issuecomment-543859694