### PR TITLE
LPS-102069 Be yourself again from an impersonated user should render current user's profile

### DIFF
--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -88,12 +88,36 @@ public class GetPersonalMenuItemsMVCResourceCommand
 	}
 
 	private JSONArray _getImpersonationItemsJSONArray(
-		PortletRequest portletRequest, ThemeDisplay themeDisplay) {
+			PortletRequest portletRequest, ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		User realUser = themeDisplay.getRealUser();
+		User user = themeDisplay.getUser();
+
+		String currentURL = _http.removeParameter(
+			ParamUtil.getString(portletRequest, "currentURL"), "doAsUserId");
+
+		String userProfileURL = user.getDisplayURL(themeDisplay, false);
+		String userDashboardURL = user.getDisplayURL(themeDisplay, true);
+
+		userProfileURL = _http.getPath(userProfileURL);
+		userDashboardURL = _http.getPath(userDashboardURL);
+
+		if (currentURL.equals(userProfileURL)) {
+			String realUserProfileURL = realUser.getDisplayURL(
+				themeDisplay, false);
+
+			currentURL = _http.getPath(realUserProfileURL);
+		}
+		else if (currentURL.equals(userDashboardURL)) {
+			String realUserDashboardURL = realUser.getDisplayURL(
+				themeDisplay, true);
+
+			currentURL = _http.getPath(realUserDashboardURL);
+		}
 
 		JSONObject jsonObject1 = JSONUtil.put(
-			"href",
-			_http.removeParameter(
-				ParamUtil.getString(portletRequest, "currentURL"), "doAsUserId")
+			"href", currentURL
 		).put(
 			"icon", "change"
 		).put(
@@ -102,9 +126,6 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		);
 
 		JSONArray jsonArray = JSONUtil.put(jsonObject1);
-
-		User realUser = themeDisplay.getRealUser();
-		User user = themeDisplay.getUser();
 
 		Locale realUserLocale = realUser.getLocale();
 		Locale userLocale = user.getLocale();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-102069

Issue: When user ends impersonation in "My Profile" or "My Dashboard", the user is not redirected to their profile or dashboard. The user is redirected to the impersonated one's. 

Solution: The user's Dashboard URL and Profile URL are retrieved to be compared to the currentURL to check if the real user is on the impersonated user's page. If the real user is on the impersonated user's page, the real user's page is retrieved: [lines 106-117](https://github.com/SamZiemer/liferay-portal/compare/master...knchau:LPS-102069-1?expand=1#diff-9b493149f789aeccb6fd2f5238f1e889R106-R117). This new URL will be used as the link for the `Be Yourself Again`. 

We are using URL paths to prevent the cases of unexpected behavior, refer to previous pr: https://github.com/drewbrokke/liferay-portal/pull/901#issuecomment-546408558