### PR TITLE
LPS-104356 Image URL's groupId used in Page Fragments does not adjust upon Import

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
@@ -86,6 +86,10 @@ public class FragmentEntryLinkExportImportContentProcessor
 				replaceExportContentReferences(
 					portletDataContext, stagedModel, content, true, false);
 
+		if (!content.startsWith("{")) {
+			return content;
+		}
+
 		JSONObject editableValuesJSONObject = JSONFactoryUtil.createJSONObject(
 			content);
 
@@ -153,6 +157,10 @@ public class FragmentEntryLinkExportImportContentProcessor
 			_dlReferencesExportImportContentProcessor.
 				replaceImportContentReferences(
 					portletDataContext, stagedModel, content);
+
+		if (!content.startsWith("{")) {
+			return content;
+		}
 
 		JSONObject editableValuesJSONObject = JSONFactoryUtil.createJSONObject(
 			content);

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryLinkStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryLinkStagedModelDataHandler.java
@@ -94,6 +94,14 @@ public class FragmentEntryLinkStagedModelDataHandler
 
 		fragmentEntryLink.setEditableValues(editableValues);
 
+		String html =
+			_fragmentEntryLinkExportImportContentProcessor.
+				replaceExportContentReferences(
+					portletDataContext, fragmentEntryLink,
+					fragmentEntryLink.getHtml(), true, false);
+
+		fragmentEntryLink.setHtml(html);
+
 		portletDataContext.addClassedModel(
 			fragmentEntryLinkElement,
 			ExportImportPathUtil.getModelPath(fragmentEntryLink),
@@ -189,6 +197,14 @@ public class FragmentEntryLinkStagedModelDataHandler
 					fragmentEntryLink.getEditableValues());
 
 		importedFragmentEntryLink.setEditableValues(editableValues);
+
+		String html =
+			_fragmentEntryLinkExportImportContentProcessor.
+				replaceImportContentReferences(
+					portletDataContext, fragmentEntryLink,
+					fragmentEntryLink.getHtml());
+
+		importedFragmentEntryLink.setHtml(html);
 
 		FragmentEntryLink existingFragmentEntryLink =
 			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.fragment.internal.exportimport.data.handler;
 
+import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
@@ -34,6 +35,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Pavel Savinov
@@ -92,6 +95,14 @@ public class FragmentEntryStagedModelDataHandler
 				PortletDataContext.REFERENCE_TYPE_WEAK);
 		}
 
+		String html =
+			_fragmentEntryLinkExportImportContentProcessor.
+				replaceExportContentReferences(
+					portletDataContext, fragmentEntry, fragmentEntry.getHtml(),
+					true, false);
+
+		fragmentEntry.setHtml(html);
+
 		Element entryElement = portletDataContext.getExportDataElement(
 			fragmentEntry);
 
@@ -140,6 +151,13 @@ public class FragmentEntryStagedModelDataHandler
 		importedFragmentEntry.setGroupId(portletDataContext.getScopeGroupId());
 		importedFragmentEntry.setFragmentCollectionId(fragmentCollectionId);
 
+		String html =
+			_fragmentEntryLinkExportImportContentProcessor.
+				replaceImportContentReferences(
+					portletDataContext, fragmentEntry, fragmentEntry.getHtml());
+
+		importedFragmentEntry.setHtml(html);
+
 		FragmentEntry existingFragmentEntry =
 			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(
 				fragmentEntry.getUuid(), portletDataContext.getScopeGroupId());
@@ -186,6 +204,14 @@ public class FragmentEntryStagedModelDataHandler
 
 	@Reference
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(model.class.name=com.liferay.fragment.model.FragmentEntryLink)"
+	)
+	private volatile ExportImportContentProcessor<String>
+		_fragmentEntryLinkExportImportContentProcessor;
 
 	@Reference
 	private FragmentEntryLocalService _fragmentEntryLocalService;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-104356

**Issue**: 
Importing a Page Fragment that is associated with an image results in the Page Fragment image being broken. This is because the groupId associated with the image link is not updated to the new site's groupId. The original groupId is retained and its visibility would depend if there is an existing groupId in this bundle's instance. 

**Solution**: 
`_fragmentEntryLinkExportImportContentProcessor.replaceExportContentReferences()` makes the link updates possible when the contents are imported because it appends `dlReference`, which `replaceImportContentReferences()` searches for to then replace with the updated link.

Using `replaceExportContentReferences()` when exporting content, updates the image links to have references. Originally, the exported links did not hold references so when importing the content, the links could not be updated. The addition of `replaceExportContentReferences()` allows finding link patterns and appending `dlReference`, which would be required because `replaceImportDLReferences()` will replace the `dlReference`. However if no `dlReference` exists within the content, the links will not be updated.