### PR TITLE
LPS-84108 Calendar Events marked "All Day" do not update with change of Time Zone

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -157,13 +157,6 @@ public class CalendarBookingLocalServiceImpl
 		java.util.Calendar endTimeJCalendar = JCalendarUtil.getJCalendar(
 			endTime, timeZone);
 
-		if (allDay) {
-			startTimeJCalendar = JCalendarUtil.toMidnightJCalendar(
-				startTimeJCalendar);
-			endTimeJCalendar = JCalendarUtil.toLastHourJCalendar(
-				endTimeJCalendar);
-		}
-
 		if (firstReminder < secondReminder) {
 			long originalSecondReminder = secondReminder;
 
@@ -1207,13 +1200,6 @@ public class CalendarBookingLocalServiceImpl
 			startTime, timeZone);
 		java.util.Calendar endTimeJCalendar = JCalendarUtil.getJCalendar(
 			endTime, timeZone);
-
-		if (allDay) {
-			startTimeJCalendar = JCalendarUtil.toMidnightJCalendar(
-				startTimeJCalendar);
-			endTimeJCalendar = JCalendarUtil.toLastHourJCalendar(
-				endTimeJCalendar);
-		}
 
 		if (firstReminder < secondReminder) {
 			long originalSecondReminder = secondReminder;

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -125,10 +125,6 @@ public class CalendarBookingLocalServiceTest {
 		assertSameDay(nowJCalendar, startTimeJCalendar);
 
 		assertSameDay(nowJCalendar, endTimeJCalendar);
-
-		assertEqualsTime(0, 0, startTimeJCalendar);
-
-		assertEqualsTime(23, 59, endTimeJCalendar);
 	}
 
 	@Test

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -1151,12 +1151,6 @@ public class CalendarPortlet extends MVCPortlet {
 	}
 
 	protected TimeZone getTimeZone(PortletRequest portletRequest) {
-		boolean allDay = ParamUtil.getBoolean(portletRequest, "allDay");
-
-		if (allDay) {
-			return TimeZoneUtil.getTimeZone(StringPool.UTC);
-		}
-
 		PortletPreferences preferences = portletRequest.getPreferences();
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/util/CalendarUtil.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/util/CalendarUtil.java
@@ -182,10 +182,6 @@ public class CalendarUtil {
 			calendarBooking.getDescription(themeDisplay.getLocale())
 		);
 
-		if (calendarBooking.isAllDay()) {
-			timeZone = TimeZone.getTimeZone(StringPool.UTC);
-		}
-
 		java.util.Calendar endTimeJCalendar = JCalendarUtil.getJCalendar(
 			calendarBooking.getEndTime(), timeZone);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84108

**Issue**:
Calendar events marked as "All Day" does not update its timestamp according to the configured time zone of the Calendar portlet. 

**Solution**:
Calender events marked with "All Day" should not default with the UTC time zone, instead it should be dependent on the configured time zone set within the Calendar portlet. The "All Day" event timestamps will not be changed to the UTC timestamps, instead it will be using the configured time zone. Also, the timestamps saved in the database depends on the time zone configured and not the defaulted UTC time zone.