### PR TITLE
LPS-97585

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
@@ -56,6 +56,13 @@
 				"stopwords": "_spanish_",
 				"type": "stop"
 			}
+		},
+		"normalizer": {
+			"keyword_lowercase": {
+				"type": "custom",
+				"char_filter": [],
+				"filter": ["lowercase"]
+			}
 		}
 	}
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
@@ -59,9 +59,11 @@
 		},
 		"normalizer": {
 			"keyword_lowercase": {
-				"type": "custom",
 				"char_filter": [],
-				"filter": ["lowercase"]
+				"filter": [
+					"lowercase"
+				],
+				"type": "custom"
 			}
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/index-settings.json
@@ -59,11 +59,7 @@
 		},
 		"normalizer": {
 			"keyword_lowercase": {
-				"char_filter": [],
-				"filter": [
-					"lowercase"
-				],
-				"type": "custom"
+				"filter": "lowercase"
 			}
 		}
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -50,9 +50,9 @@
 			{
 				"template_expando_keyword": {
 					"mapping": {
-						"analyzer" : "keyword_lowercase",
+						"normalizer": "keyword_lowercase",
 						"store": true,
-						"type": "text"
+						"type": "keyword"
 					},
 					"match": "expando__keyword__*",
 					"match_mapping_type": "string"

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -52,9 +52,9 @@
 					{
 						"template_expando_keyword" : {
 							"mapping" : {
-								"analyzer" : "keyword_lowercase",
+								"normalizer" : "keyword_lowercase",
 								"store" : true,
-								"type" : "text"
+								"type" : "keyword"
 							},
 							"match" : "expando__keyword__*",
 							"match_mapping_type" : "string"

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/ExpandoSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/ExpandoSearchTest.java
@@ -22,8 +22,10 @@ import com.liferay.document.library.test.util.DLAppTestUtil;
 import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.model.ExpandoValue;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.expando.kernel.service.ExpandoValueLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -46,6 +48,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -429,6 +432,16 @@ public class ExpandoSearchTest {
 	}
 
 	protected String getExpandoColumnValue(Document document) {
+		ExpandoColumn expandoColumn = _expandoColumns.get(0);
+
+		ExpandoValue expandoValue = ExpandoValueLocalServiceUtil.getValue(
+			expandoColumn.getTableId(), expandoColumn.getColumnId(),
+			GetterUtil.getLong(document.get("entryClassPK")));
+
+		if (expandoValue != null) {
+			return expandoValue.getData();
+		}
+
 		Map<String, Field> fields = document.getFields();
 
 		for (Field field : fields.values()) {


### PR DESCRIPTION
Notes from @katienesterovich:

> https://issues.liferay.com/browse/LPS-97585
> 
> Fix adds a normalizer for indexing which converts all keywords to lowercase values - this returns hits in all lowercase and guarantees that we find matches regardless of their case.
> 
> For example,
> 
>     * ```
>          `dog`, `Dog`, `DOG` entries are converted to `dog` for indexing
>       ```
> 
>     * ```
>          Searching for `dog`, `Dog`, or `DOG` --> returns all 3 entries
>       ```
> 
> 
> I verified that the fix works and ran source formatter, rebased to master.
> 
> Fix does not break related [LPS-69574](https://issues.liferay.com/browse/LPS-69574).
> 
> Note: to verify, deploy and Reindex all searches indexes in Control Panel > Configuration > Search

Sincerely,
Brian Kim