### PR TITLE
LPS-102150 Remove comma from description

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -2401,7 +2401,7 @@
     #
     # Env: LIFERAY_SYSTEM_PERIOD_ROLE_PERIOD__UPPERCASEA_NALYTICS_PERIOD__UPPERCASEA_DMINISTRATOR_PERIOD_DESCRIPTION
     #
-    system.role.Analytics.Administrator.description=Analytics Administrators are users who can view data across the company, but cannot make changes except to the company preferences.
+    system.role.Analytics.Administrator.description=Analytics Administrators are users who can view data across the company but cannot make changes except to the company preferences.
 
     #
     # Set the description of the Guest system role.


### PR DESCRIPTION
**Low priority.**

Notes from @katienesterovich :

> https://issues.liferay.com/browse/LPS-102150
> 
> This is a workaround rather than a true fix. Role descriptions are defined in `portal.properties` and do not use language keys. Putting a comma segregates the sentence into an array of strings and any spaces after the comma are trimmed when put back together.
> 
> The descriptions of other roles exclude commas (for example, Site Administrator).

