### PR TITLE
LPS-107002 Unable to select scheduled content when adding related assets for a calendar event entry

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
@@ -102,7 +102,7 @@ public class AssetPublisherViewContentDisplayContext {
 		try {
 			if (_assetRenderer.hasViewPermission(
 					_themeDisplay.getPermissionChecker()) &&
-				_assetRenderer.isDisplayable()) {
+				(_assetRenderer.isDisplayable() || _assetEntry.isVisible())) {
 
 				return true;
 			}

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
@@ -348,6 +348,9 @@ public class InputAssetLinksDisplayContext {
 		portletURL.setParameter("eventName", getEventName());
 		portletURL.setParameter(
 			"multipleSelection", String.valueOf(Boolean.TRUE));
+		portletURL.setParameter("showScheduled", String.valueOf(Boolean.TRUE));
+		portletURL.setParameter(
+			"showNonindexable", String.valueOf(Boolean.TRUE));
 		portletURL.setPortletMode(PortletMode.VIEW);
 		portletURL.setWindowState(LiferayWindowState.POP_UP);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6286,7 +6286,11 @@ public class JournalArticleLocalServiceImpl
 			String[] assetTagNames, long[] assetLinkEntryIds, Double priority)
 		throws PortalException {
 
-		boolean visible = (article.isApproved() || article.isScheduled());
+		boolean visible = false;
+
+		if (article.isApproved() || article.isScheduled()) {
+			visible = true;
+		}
 
 		if (article.getClassNameId() !=
 				JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
@@ -6632,7 +6636,8 @@ public class JournalArticleLocalServiceImpl
 				user.getUserId(), article, action, serviceContext);
 		}
 
-		updateAsset(userId, article, serviceContext.getAssetCategoryIds(),
+		updateAsset(
+			userId, article, serviceContext.getAssetCategoryIds(),
 			serviceContext.getAssetTagNames(),
 			serviceContext.getAssetLinkEntryIds(),
 			serviceContext.getAssetPriority());

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6286,7 +6286,7 @@ public class JournalArticleLocalServiceImpl
 			String[] assetTagNames, long[] assetLinkEntryIds, Double priority)
 		throws PortalException {
 
-		boolean visible = article.isApproved();
+		boolean visible = (article.isApproved() || article.isScheduled());
 
 		if (article.getClassNameId() !=
 				JournalArticleConstants.CLASSNAME_ID_DEFAULT) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6632,6 +6632,11 @@ public class JournalArticleLocalServiceImpl
 				user.getUserId(), article, action, serviceContext);
 		}
 
+		updateAsset(userId, article, serviceContext.getAssetCategoryIds(),
+			serviceContext.getAssetTagNames(),
+			serviceContext.getAssetLinkEntryIds(),
+			serviceContext.getAssetPriority());
+
 		return article;
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleScheduledTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleScheduledTest.java
@@ -175,13 +175,13 @@ public class JournalArticleScheduledTest {
 
 		if (when == _WHEN_FUTURE) {
 			Assert.assertFalse(article.isApproved());
-			Assert.assertFalse(assetEntry.isVisible());
 
 			if (approved) {
 				Assert.assertTrue(article.isScheduled());
 			}
 			else {
 				Assert.assertTrue(article.isDraft());
+				Assert.assertFalse(assetEntry.isVisible());
 			}
 		}
 		else {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-107002

The ability to view scheduled web content existed in 6.1.X. In 6.1, `scheduled` Journal Articles had a workflow `status` of 0 (`approved`) and the related Asset Entry had a `visible` status of 1 (true). In 7.3 the workflow status is 7 (`scheduled`) and the asset `visible` column is marked 0 (false). This pull request aims to fix that. 

- `showScheduled` and `showNonindexable` parameters allow the scheduled entries to be displayed in 'Related Assets' when scheduling an event. 

- In an article with workflow, when the article is in a pending status, it is not approved nor scheduled. The article is only marked scheduled once it has been approved within the workflow. In other words,`scheduled` status is only assigned to `approved` articles. Therefore, we can say that a `scheduled` article is `approved`- and if an `approved` article is visible, then a `scheduled` article should also be visible. **This change previously caused a test failure** in https://github.com/brianikim/liferay-portal/pull/89, so I modified the test to reflect the changes.

- When a journal article is created, it is first given a `draft` status (regardless of what the actual status is). It then goes through a default workflow which sets the correct status. However, that does not reflect in the related asset entry. To fix that, I added an `updateAsset` method to the end of `updateStatus`. 

- Asset publisher will not display `scheduled` web content, since it's not `displayable`. (Displayable implies that the article is approved to be shown to public at current time). However, we want our users to view the scheduled articles from the event scheduler, so I added a check to display the asset if `isVisible()`. From local testing, no scheduled articles display in the regular Asset Publisher, only if a direct link is given (such as one from the event scheduler). 

I have tested this fix locally and was successful using no workflow and the 1-person approval workflow. I am able to see the scheduled events in the search container when selecting my related assets, I am able to see the selected resources in the event 'View Details', and I am able to view the full asset entry in an asset publisher given a link from the event. 

NOTE: this fix is specific to Basic Web Content entires and does not address a similar issue with blog entries. 