### PR TITLE
LPS-107295 Remove file version from URL to show latest

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/resolver/FileEntryDownloadFileEntryItemSelectorReturnTypeResolver.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/resolver/FileEntryDownloadFileEntryItemSelectorReturnTypeResolver.java
@@ -68,7 +68,7 @@ public class FileEntryDownloadFileEntryItemSelectorReturnTypeResolver
 			"url",
 			_dlURLHelper.getDownloadURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
-				StringPool.BLANK, true, false)
+				StringPool.BLANK, false, false)
 		).put(
 			"uuid", fileEntry.getUuid()
 		);


### PR DESCRIPTION
Notes from @katienesterovich:

> https://issues.liferay.com/browse/LPS-107295
> 
> Turns out this was a simple parameter: by setting `appendVersion` to false, the link is generated without a version and the latest image is displayed.

Test result: https://github.com/brianikim/liferay-portal/pull/91#issuecomment-576438424