### PR TITLE
LPS-107518 Add the missing upgrade step

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/AssetPublisherWebUpgrade.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/AssetPublisherWebUpgrade.java
@@ -55,6 +55,12 @@ public class AssetPublisherWebUpgrade implements UpgradeStepRegistrator {
 			"1.0.2", "1.0.3",
 			new com.liferay.asset.publisher.web.internal.upgrade.v1_2_0.
 				UpgradePortletPreferences());
+
+		registry.register(
+			"1.0.3", "1.0.4",
+			new com.liferay.asset.publisher.web.internal.upgrade.v1_1_0.
+				UpgradePortletPreferences());
+
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/AssetPublisherWebUpgrade.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/AssetPublisherWebUpgrade.java
@@ -60,7 +60,6 @@ public class AssetPublisherWebUpgrade implements UpgradeStepRegistrator {
 			"1.0.3", "1.0.4",
 			new com.liferay.asset.publisher.web.internal.upgrade.v1_1_0.
 				UpgradePortletPreferences());
-
 	}
 
 	@Reference


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-107518

There are 5 upgrade steps that need to register on Asset Publisher in total - 

1.0.0 -> 1.0.1 -> 1.0.2 -> 1.1.0 -> 1.2.0

1.1.0 was never registered, due to this commit: https://github.com/brianchandotcom/liferay-portal/pull/56253/commits/f735209e4e2646f4b121d1e89cff259ac43114b2.
This fix re-introduces 1.1.0 step and upgrades the database Release_ schema version to 1.0.4.
