### PR TITLE
LPS-109221 We don't need to update calendarResource for a default user.

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/model/listener/UserModelListener.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/model/listener/UserModelListener.java
@@ -18,6 +18,7 @@ import com.liferay.calendar.model.CalendarResource;
 import com.liferay.calendar.service.CalendarResourceLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -54,6 +55,10 @@ public class UserModelListener extends BaseModelListener<User> {
 			String name = calendarResource.getName(LocaleUtil.getSiteDefault());
 
 			if (Objects.equals(name, user.getFullName())) {
+				return;
+			}
+
+			if (user.isDefaultUser() && name.equals(GroupConstants.GUEST)) {
 				return;
 			}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-109221

See ticket for issue description.

Solution is to ensure the calendarResource for a guest user is not updated.

The solution is consistent with the behavior introduced from https://github.com/liferay/liferay-portal/commit/151a7ca13f40dea2628523fefcbaec82e36fe465#diff-5ca8bc460cc7c74517a366a5622918f5 in which only a user name change warrants a calendarResource update. Guest users will never have their name values changed as it will always be "Guest".

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim
