### PR TITLE
LPS-109315

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -73,6 +73,7 @@ import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelper;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -1796,7 +1797,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 		int suffix = 1;
 
-		for (int i = 0; i < _UNIQUE_FILE_NAME_TRIES; i++) {
+		for (int i = 0;
+			 i < _uploadServletRequestConfigurationHelper.getMaxTries(); i++) {
+
 			String curFileName = FileUtil.appendParentheticalSuffix(
 				fileName, String.valueOf(suffix));
 
@@ -2334,8 +2337,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 	private static final String _SMALL_IMAGE_FOLDER_NAME = "Small Image";
 
-	private static final int _UNIQUE_FILE_NAME_TRIES = 50;
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		BlogsEntryLocalServiceImpl.class);
 
@@ -2376,5 +2377,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 	@Reference
 	private UnsubscribeHelper _unsubscribeHelper;
+
+	@Reference
+	private UploadServletRequestConfigurationHelper
+		_uploadServletRequestConfigurationHelper;
 
 }

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryAttachmentFileEntryHelperTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryAttachmentFileEntryHelperTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelperUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -263,7 +264,10 @@ public class BlogsEntryAttachmentFileEntryHelperTest {
 
 		int suffix = 1;
 
-		for (int i = 0; i < _UNIQUE_FILE_NAME_TRIES; i++) {
+		for (int i = 0;
+			 i < UploadServletRequestConfigurationHelperUtil.getMaxTries();
+			 i++) {
+
 			String curFileName = FileUtil.appendParentheticalSuffix(
 				fileName, String.valueOf(suffix));
 
@@ -344,8 +348,6 @@ public class BlogsEntryAttachmentFileEntryHelperTest {
 	}
 
 	private static final String _TEMP_FOLDER_NAME = BlogsEntry.class.getName();
-
-	private static final int _UNIQUE_FILE_NAME_TRIES = 50;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBAttachmentFileEntryUtil.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBAttachmentFileEntryUtil.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelperUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
@@ -117,7 +118,10 @@ public class MBAttachmentFileEntryUtil {
 
 		int suffix = 1;
 
-		for (int i = 0; i < _UNIQUE_FILE_NAME_TRIES; i++) {
+		for (int i = 0;
+			 i < UploadServletRequestConfigurationHelperUtil.getMaxTries();
+			 i++) {
+
 			String curFileName = FileUtil.appendParentheticalSuffix(
 				fileName, String.valueOf(suffix));
 
@@ -135,8 +139,6 @@ public class MBAttachmentFileEntryUtil {
 				"Unable to get a unique file name for ", fileName,
 				" in folder ", folderId));
 	}
-
-	private static final int _UNIQUE_FILE_NAME_TRIES = 50;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		MBAttachmentFileEntryUtil.class);

--- a/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/configuration/UploadServletRequestConfiguration.java
+++ b/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/configuration/UploadServletRequestConfiguration.java
@@ -36,6 +36,12 @@ public interface UploadServletRequestConfiguration {
 	public long maxSize();
 
 	@Meta.AD(
+		deflt = "50", description = "max-tries-help",
+		name = "overall-maximum-unique-file-name-tries", required = false
+	)
+	public long maxTries();
+
+	@Meta.AD(
 		description = "temp-dir-help", name = "temporary-storage-directory",
 		required = false
 	)

--- a/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/configuration/settings/UploadServletRequestConfigurationHelperImpl.java
+++ b/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/configuration/settings/UploadServletRequestConfigurationHelperImpl.java
@@ -42,6 +42,11 @@ public class UploadServletRequestConfigurationHelperImpl
 	}
 
 	@Override
+	public long getMaxTries() {
+		return _uploadServletRequestConfiguration.maxTries();
+	}
+
+	@Override
 	public String getTempDir() {
 		String tempDir = _uploadServletRequestConfiguration.tempDir();
 

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50.
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory.
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ar.properties
@@ -1,4 +1,6 @@
 max-size-help=قم بتعيين أقصى طول لمحتوى طلب تحميل servlet. القيمة الافتراضية هي 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=الحد الأقصى لحجم طلب التحميل الكلي
 please-enter-a-valid-temporary-storage-directory=يرجى إدخال دليل تخزين مؤقت صالح.
 temp-dir-help=قم بتعيين الدليل المؤقت للملفات المحملة.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_bg.properties
@@ -1,4 +1,6 @@
 max-size-help=Задаване на максималното качване servlet заявка съдържание дължина. По подразбиране е 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Общото максимално качване искане размер (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Моля, въведете валиден временно съхранение директория. (Automatic Translation)
 temp-dir-help=Определя временната директория за качените файлове. Празна стойност ще определи конфигурацията обратно към стойността по подразбиране. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ca.properties
@@ -1,4 +1,6 @@
 max-size-help=Estableix la llargada màxima del contingut de la sol·licitud del servlet de càrrega. Per defecte és 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Nombre màxim total de peticions de pujada
 please-enter-a-valid-temporary-storage-directory=Introduïu un directori d'emmagatzematge temporal vàlid.
 temp-dir-help=Estableix el directori temporal dels fitxers carregats.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_cs.properties
@@ -1,4 +1,6 @@
 max-size-help=Nastavení délky obsahu požadavku maximální upload servlet. Výchozí hodnota je 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Celková velikost požadavku maximální uložení (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Zadejte prosím platný dočasný adresář úložiště. (Automatic Translation)
 temp-dir-help=Nastavte dočasný adresář pro soubory. Prázdná hodnota nastaví konfiguraci zpět na výchozí hodnotu. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_da.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Samlede maksimale Upload anmodning størrelse (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_de.properties
@@ -1,4 +1,6 @@
 max-size-help=Legen Sie die maximale Inhaltslänge für Servlet Upload-Requests fest. Standard ist 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Maximale Gesamtgröße von Upload-Requests
 please-enter-a-valid-temporary-storage-directory=Bitte geben Sie ein gültiges temporäres Speicherverzeichnis an.
 temp-dir-help=Legen Sie das vorübergehende Directory für hochgeladene Dateien fest.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_el.properties
@@ -1,4 +1,6 @@
 max-size-help=Για να ορίσετε το μέγιστο upload servlet αίτηση μήκος περιεχομένου. Η προεπιλογή είναι 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Συνολικά μέγιστος φορτώνω μέγεθος αίτηση (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Παρακαλώ εισάγετε ένα έγκυρο προσωρινό κατάλογο αποθήκευσης. (Automatic Translation)
 temp-dir-help=Για να ορίσετε τον προσωρινό κατάλογο για τα μεταφορτωμένα αρχεία. Μια κενή τιμή θα οριστεί η ρύθμιση παραμέτρων στην προεπιλεγμένη τιμή. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_en.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50.
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory.
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_en_AU.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_en_GB.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_es.properties
@@ -1,4 +1,6 @@
 max-size-help=Establece la longitud máxima del contenido de la solicitud de carga del servlet. El valor por defecto es 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Tamaño máximo total de la solicitud
 please-enter-a-valid-temporary-storage-directory=Especifique un directorio de almacenamiento temporal válido.
 temp-dir-help=Establece el directorio temporal de los archivos cargados.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_et.properties
@@ -1,4 +1,6 @@
 max-size-help=Määrake Maksimaalne üleslaadimise servlet taotluse sisu. Vaikimisi on 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Üldine taotlus Üleslaadimismahu (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Palun sisestage kehtiv ajutise ladustamise kataloog. (Automatic Translation)
 temp-dir-help=Määrata ajutise kausta üles laaditud faile. Tühja väärtust näidatakse seatud konfiguratsiooni tagasi vaikimisi väärtus. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_eu.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fa.properties
@@ -1,4 +1,6 @@
 max-size-help=تنظیم حداکثر آپلود servlet درخواست طول محتوا. پیش فرض 1024 * 1024 * 100 است. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=حداکثر سایز بارگذاری موردنیاز
 please-enter-a-valid-temporary-storage-directory=لطفا پوشه ذخیره موقت معتبر را وارد کنید. (Automatic Translation)
 temp-dir-help=مجموعه دایرکتوری موقت برای فایل های آپلود شده. یک مقدار خالی پیکربندی به مقدار پیش فرض تنظیم می کند. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fi.properties
@@ -1,4 +1,6 @@
 max-size-help=Asettaa suurimman sisäänlatauksen palvelinsovelman pyynnön sisällön pituuden. Oletusarvo on 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Yleinen suurin sisääntuonnin kokorajoitus
 please-enter-a-valid-temporary-storage-directory=Anna kelvollinen väliaikainen tallennushakemisto.
 temp-dir-help=Aseta ladattujen tieodstojen väliaikaishakemisto.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fr.properties
@@ -1,4 +1,6 @@
 max-size-help=Définissez la taille maximum du contenu de la requête servlet du téléchargement. Par défaut : 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Taille de demande de téléchargement maximum globale
 please-enter-a-valid-temporary-storage-directory=Veuillez saisir un répertoire de stockage temporaire valide.
 temp-dir-help=Définissez le répertoire temporaire pour les fichiers téléchargés. Une valeur vide réinitialisera la configuration à la valeur par défaut.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fr_CA.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_gl.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_hi_IN.properties
@@ -1,4 +1,6 @@
 max-size-help=अधिकतम अपलोड servlet अनुरोध सामग्री लंबाई सेट करें। डिफ़ॉल्ट 1024 * 1024 * 100 है। (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=कुल मिलाकर अधिकतम अपलोड अनुरोध आकार (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=कृपया कोई मांय अस्थाई संग्रह निर्देशिका दर्ज करें । (Automatic Translation)
 temp-dir-help=अपलोड की गई फ़ाइलों के लिए अस्थाई निर्देशिका सेट करें । कोई रिक्त मान कॉन्फ़िगरेशन डिफ़ॉल्ट मान के लिए वापस सेट करेगा । (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_hr.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_hu.properties
@@ -1,4 +1,6 @@
 max-size-help=Állítsa be a maximális feltöltési servlet-kérelem tartalmának a hosszát. Az alapértelmezett érték 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Átfogó maximális feltöltési kérés méret
 please-enter-a-valid-temporary-storage-directory=Adj meg egy érvényes átmeneti könyvtárat a tárhelyen.
 temp-dir-help=Állítsa be a feltöltött fájlok ideiglenes könyvtárát.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_in.properties
@@ -1,4 +1,6 @@
 max-size-help=Menetapkan maksimum meng-upload servlet permintaan konten panjang. Default adalah 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Secara keseluruhan ukuran maksimum meng-Upload permintaan (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Masukkan direktori penyimpanan sementara yang berlaku. (Automatic Translation)
 temp-dir-help=Mengatur direktori sementara untuk upload file. Nilai kosong akan mengatur konfigurasi kembali ke nilai default. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_it.properties
@@ -1,4 +1,6 @@
 max-size-help=Imposta la dimensione massima degli upload. Il valore predefinito è 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Dimensione Complessiva Massima File da Caricare
 please-enter-a-valid-temporary-storage-directory=Si prega di inserire una directory di archiviazione temporanea valida. (Automatic Translation)
 temp-dir-help=Imposta la cartella temporanea per il caricamento di file.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_iw.properties
@@ -1,4 +1,6 @@
 max-size-help=הגדר אורך תוכן בקשת העלאת servlet מרבי. ברירת המחדל היא 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=גודל בקשת ההעלאה הכולל המקסימלי
 please-enter-a-valid-temporary-storage-directory=הזינו בבקשה את ספריית אחסון זמני בתוקף. (Automatic Translation)
 temp-dir-help=הגדר את הספרייה הזמנית לקבצים שהועלו.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ja.properties
@@ -1,4 +1,6 @@
 max-size-help=アップロードサーブレットリクエストコンテンツ長の最大値を設定します。
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=合計最大アップロードリクエストサイズ
 please-enter-a-valid-temporary-storage-directory=有効な一時ファイル用ディレクトリを入力してください。
 temp-dir-help=アップロードファイルの一時ディレクトリを設定します。

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_kk.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ko.properties
@@ -1,4 +1,6 @@
 max-size-help=최대 업로드 서블릿 요청 콘텐츠 길이 설정 합니다. 기본값은 1024 * 1024 * 100입니다. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=전반적인 최대 업로드 요청 크기 (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=유효한 임시 저장소 디렉터리를 입력 하십시오. (Automatic Translation)
 temp-dir-help=업로드 된 파일에 대 한 임시 디렉터리를 설정 합니다. 빈 값은 기본 값으로 다시 구성을 설정 합니다. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_lo.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_lt.properties
@@ -1,4 +1,6 @@
 max-size-help=Nustatytas maksimalus nusiuntimo servlet prašymo turinio ilgis. Numatytasis parametras yra 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Apskritai didžiausias nusiunčiamo prašymą dydis (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Prašome įvesti galiojantį laikinojo saugojimo katalogą. (Automatic Translation)
 temp-dir-help=Nustatyti laikiną katalogą failus. Tuščią reikšmę bus nustatyti konfigūraciją atgal į numatytąją vertę. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_nb.properties
@@ -1,4 +1,6 @@
 max-size-help=Angi den maksimale opplastingshastigheten servlet forespørsel innholdslengden. Standarden er 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Samlet maksimal forespørsel opplastingsstørrelse (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Angi en gyldig midlertidig lagringskatalog. (Automatic Translation)
 temp-dir-help=Angi den midlertidige katalogen for opplastede filer. En tom verdi settes konfigurasjonen tilbake til standardverdien. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl.properties
@@ -1,4 +1,6 @@
 max-size-help=Stel de maximale lengte in voor de inhoud van het uploadverzoek van de servlet. Standaard 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Algehele maximale grootte voor uploadverzoeken
 please-enter-a-valid-temporary-storage-directory=Voer een geldige tijdelijke opslagmap in.
 temp-dir-help=Stel de tijdelijke directory in voor geüploade bestanden.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl_BE.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Over het geheel genomen maximale Upload verzoek grootte (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_pl.properties
@@ -1,4 +1,6 @@
 max-size-help=Ustawianie długości zawartości żądania servlet maksymalnego. Wartość domyślna to 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Ogólny rozmiar żądanie maksymalny Upload (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Proszę podać prawidłowy magazynu tymczasowego katalogu. (Automatic Translation)
 temp-dir-help=Ustaw katalog tymczasowy do przesłanych plików. Wartość pustą będzie ustawić konfiguracji na wartość domyślną. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_BR.properties
@@ -1,4 +1,6 @@
 max-size-help=Definir o tamanho máximo do conteúdo da solicitação do servlet de upload. O padrão é 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Tamanho Máximo Total da Solicitação de Transferência
 please-enter-a-valid-temporary-storage-directory=Por favor, insira um diretório de armazenamento temporário válido.
 temp-dir-help=Definir o diretório temporário para arquivos carregados.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_PT.properties
@@ -1,4 +1,6 @@
 max-size-help=Defina o tamanho do conteúdo de solicitação upload máximo servlet. O padrão é 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Tamanho Máximo Global para Pedido de Upload
 please-enter-a-valid-temporary-storage-directory=Por favor insira um diretório de armazenamento temporário válido. (Automatic Translation)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ro.properties
@@ -1,4 +1,6 @@
 max-size-help=Stabili o lungime de conţinut maximă de încărcare servlet cerere. Implicit este de 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Dimensiunea de cererea totală maximă de încărcare (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Vă rugăm să introduceţi un director de stocare temporară valabil. (Automatic Translation)
 temp-dir-help=Setaţi directorul temporar pentru fişierele încărcate. O valoare necompletată va stabili configuraţia înapoi la valoarea implicită. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ru.properties
@@ -1,4 +1,6 @@
 max-size-help=Задайте длину содержимого запроса сервлета максимальной загрузки. Значение по умолчанию — 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Общий максимальный размер запроса (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Пожалуйста, введите действительный временного хранения каталога. (Automatic Translation)
 temp-dir-help=Установите временный каталог для загруженных файлов. Пустое значение будет задать конфигурацию обратно в значение по умолчанию. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sk.properties
@@ -1,4 +1,6 @@
 max-size-help=Nastavte maximálnu upload servlet požiadavka dĺžka obsahu. Predvolená hodnota je 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Celková maximálna požiadavka veľkosť odovzdania (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Zadajte platné dočasné adresár. (Automatic Translation)
 temp-dir-help=Nastavenie dočasného adresára pre nahrané súbory. Prázdna hodnota nastaví konfiguráciu späť na predvolenú hodnotu. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sl.properties
@@ -1,4 +1,6 @@
 max-size-help=Nastavite največjo upload servlet zahtevo vsebine dolžino. Privzeto je 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Splošno največ Upload zahtevo velikost (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Prosimo, Vnesite veljaven začasno skladiščenje imenik. (Automatic Translation)
 temp-dir-help=Nastaviti začasnega imenika za naložene datoteke. Prazna vrednost bo nastavljeno konfiguracijo nazaj na privzeto vrednost. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,4 +1,6 @@
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
 please-enter-a-valid-temporary-storage-directory=Please enter a valid temporary storage directory. (Automatic Copy)
 temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sv.properties
@@ -1,4 +1,6 @@
 max-size-help=Ange maximal innehållslängd för uppladdning av servlet-begäran. Standard är 1024 * 1024 * 100.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Maximal storlek på överföringsbegäran
 please-enter-a-valid-temporary-storage-directory=Ange en giltig tillfällig arkivkatalog.
 temp-dir-help=Ange en tillfällig katalog för överförda filer.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ta_IN.properties
@@ -1,4 +1,6 @@
 max-size-help=அதிகபட்ச upload servlet request content length அமைக்கவும். Default 1024 * 1024 * 100 ஆகும்.
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=ஒட்டுமொத்த அதிகபட்ச பதிவேற்ற கோரிக்கை அளவு
 please-enter-a-valid-temporary-storage-directory=சரியான தற்காலிக சேமிப்பு டைரக்டரியை உள்ளிடுக.
 temp-dir-help=பதிவேற்றிய ஃபைல்களுக்கான தற்காலிக டைரக்டரியை அமைக்கவும். எதுவுமே கொடுக்கவில்லையென்றால் இயல்பாக என்ன இருக்குமோ அது பொருந்தும்.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_th.properties
@@ -1,4 +1,6 @@
 max-size-help=ตั้งค่าการอัปโหลดสูงสุด servlet ขอเนื้อหายาว ค่าเริ่มต้นคือ 1024 * 1024 * 100 (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=ขนาดขออัพโหลดสูงสุดโดยรวม (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=โปรดป้อนไดเรกทอรีเก็บชั่วคราวที่ถูกต้อง (Automatic Translation)
 temp-dir-help=ตั้งค่าไดเรกทอรีชั่วคราวสำหรับอัปโหลดแฟ้ม ค่าว่างจะตั้งค่ากลับสู่ค่าเริ่มต้น (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_tr.properties
@@ -1,4 +1,6 @@
 max-size-help=Maksimum yükleme servlet isteğini içerik uzunluğu ayarlayın. Varsayılan değer 1024 * 1024 * 100 dür. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Genel olarak maksimum yükleme isteği boyutu (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Lütfen geçerli geçici depolama dizini girin. (Automatic Translation)
 temp-dir-help=Karşıya yüklenen dosyaları geçici dizini ayarlayın. Boş bir değer yapılandırmayı varsayılan değerine geri ayarlayın. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_uk.properties
@@ -1,4 +1,6 @@
 max-size-help=Визначте максимально завантажити сервлетів запиту вмісту. Значенням за промовчанням є 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=В цілому максимум запит розмір для завантаження (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Будь ласка, Введіть припустимий тимчасового зберігання каталогу. (Automatic Translation)
 temp-dir-help=Встановити тимчасового каталогу для завантажених файлів. Пусте значення встановить конфігурацію назад в значення за замовчуванням. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_vi.properties
@@ -1,4 +1,6 @@
 max-size-help=Thiết lập yêu cầu nội dung servlet tải lên tối đa chiều dài. Mặc định là 1024 * 1024 * 100. (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=Tổng thể tải lên tối đa yêu cầu kích thước (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=Hãy nhập vào một thư mục lưu trữ tạm thời hợp lệ. (Automatic Translation)
 temp-dir-help=Thiết lập thư mục tạm thời cho các tập tin được tải lên. Một giá trị trống sẽ đặt cấu hình lại cho giá trị mặc định. (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_CN.properties
@@ -1,4 +1,6 @@
 max-size-help=设置最大上传Servlet请求内容长度，默认值为1024 * 1024 * 100。
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=总体最大上传需求大小
 please-enter-a-valid-temporary-storage-directory=请输入有效的临时存储目录。
 temp-dir-help=设置上传文件的临时目录。

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_TW.properties
@@ -1,4 +1,6 @@
 max-size-help=設置最大上載 servlet 請求內容的長度。預設值為 1024 * 1024 * 100。 (Automatic Translation)
+max-tries-help=Set the maximum number of tries for unique file name creation. Default is 50. (Automatic Copy)
+overall-maximum-unique-file-name-tries=Overall Maximum Unique File Name Creation Tries (Automatic Copy)
 overall-maximum-upload-request-size=整體最大上載請求大小 (Automatic Translation)
 please-enter-a-valid-temporary-storage-directory=請輸入有效的臨時存儲目錄。 (Automatic Translation)
 temp-dir-help=設置上載檔的臨時目錄。空值將配置設置回預設值。 (Automatic Translation)

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestUploadHandler.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestUploadHandler.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
+import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelperUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -184,7 +185,10 @@ public class TestUploadHandler {
 
 		int suffix = 1;
 
-		for (int i = 0; i < _UNIQUE_FILE_NAME_TRIES; i++) {
+		for (int i = 0;
+			 i < UploadServletRequestConfigurationHelperUtil.getMaxTries();
+			 i++) {
+
 			String curFileName = FileUtil.appendParentheticalSuffix(
 				fileName, String.valueOf(suffix));
 
@@ -257,8 +261,6 @@ public class TestUploadHandler {
 			throw new SystemException(ioException);
 		}
 	}
-
-	private static final int _UNIQUE_FILE_NAME_TRIES = 50;
 
 	private final TestUploadPortlet _testUploadPortlet;
 

--- a/modules/apps/upload/upload-web/src/main/java/com/liferay/upload/web/internal/DefaultUniqueFileNameProvider.java
+++ b/modules/apps/upload/upload-web/src/main/java/com/liferay/upload/web/internal/DefaultUniqueFileNameProvider.java
@@ -16,6 +16,7 @@ package com.liferay.upload.web.internal;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelper;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.upload.UniqueFileNameProvider;
 
@@ -24,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -42,7 +44,9 @@ public class DefaultUniqueFileNameProvider implements UniqueFileNameProvider {
 		int tries = 0;
 
 		while (predicate.test(uniqueFileName)) {
-			if (tries >= _UNIQUE_FILE_NAME_TRIES) {
+			if (tries >=
+					_uploadServletRequestConfigurationHelper.getMaxTries()) {
+
 				throw new PortalException(
 					"Unable to get a unique file name for " + fileName);
 			}
@@ -73,9 +77,11 @@ public class DefaultUniqueFileNameProvider implements UniqueFileNameProvider {
 		return fileName;
 	}
 
-	private static final int _UNIQUE_FILE_NAME_TRIES = 50;
-
 	private static final Pattern _pattern = Pattern.compile(
 		"(?<name>.+) \\(\\d+\\)(\\.(?<extension>[^.]+))?");
+
+	@Reference
+	private UploadServletRequestConfigurationHelper
+		_uploadServletRequestConfigurationHelper;
 
 }

--- a/modules/apps/upload/upload-web/src/test/java/com/liferay/upload/web/internal/DefaultUniqueFileNameProviderTest.java
+++ b/modules/apps/upload/upload-web/src/test/java/com/liferay/upload/web/internal/DefaultUniqueFileNameProviderTest.java
@@ -15,6 +15,7 @@
 package com.liferay.upload.web.internal;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelperUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.util.FileImpl;
 
@@ -43,7 +44,10 @@ public class DefaultUniqueFileNameProviderTest {
 
 		String originalFileName = "filename.extension";
 
-		for (int i = 1; i <= 50; i++) {
+		for (int i = 1;
+			 i <= UploadServletRequestConfigurationHelperUtil.getMaxTries();
+			 i++) {
+
 			String uniqueFileName = _defaultUniqueFileNameProvider.provide(
 				originalFileName, _existsUntil(i));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/upload/UploadServletRequestConfigurationHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upload/UploadServletRequestConfigurationHelper.java
@@ -24,6 +24,8 @@ public interface UploadServletRequestConfigurationHelper {
 
 	public long getMaxSize();
 
+	public long getMaxTries();
+
 	public String getTempDir();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upload/UploadServletRequestConfigurationHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upload/UploadServletRequestConfigurationHelperUtil.java
@@ -25,6 +25,10 @@ public class UploadServletRequestConfigurationHelperUtil {
 		return _uploadServletRequestConfigurationHelper.getMaxSize();
 	}
 
+	public static long getMaxTries() {
+		return _uploadServletRequestConfigurationHelper.getMaxTries();
+	}
+
 	public static String getTempDir() {
 		return _uploadServletRequestConfigurationHelper.getTempDir();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/upload/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upload/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-109315

We introduced an arbitrary cap of 50 for unique file name tries in which we stop adding (#) suffix at the end of duplicate file names after 50 tries.

The fix is to make the value configurable.

Sincerely,
Brian Kim