### PR TITLE
LPS-111915 Unable to preview display page template in draft web content

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
@@ -422,7 +422,9 @@ public class JournalContentImpl
 		String languageId, int page, PortletRequestModel portletRequestModel,
 		ThemeDisplay themeDisplay) {
 
-		if (article.getStatus() != WorkflowConstants.STATUS_APPROVED) {
+		if (!((article.getStatus() == WorkflowConstants.STATUS_APPROVED) ||
+			  (article.getStatus() == WorkflowConstants.STATUS_DRAFT))) {
+
 			return null;
 		}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
@@ -175,9 +175,18 @@ public class JournalContentImpl
 		long groupId, String articleId, String ddmTemplateKey, String viewMode,
 		String languageId, ThemeDisplay themeDisplay) {
 
-		return getContent(
-			groupId, articleId, ddmTemplateKey, viewMode, languageId,
+		JournalArticle article = _journalArticleLocalService.fetchArticle(
+			groupId, articleId);
+
+		JournalArticleDisplay articleDisplay = getDisplay(
+			article, ddmTemplateKey, viewMode, languageId, 1,
 			(PortletRequestModel)null, themeDisplay);
+
+		if (articleDisplay != null) {
+			return articleDisplay.getContent();
+		}
+
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
[LPS-111915](https://issues.liferay.com/browse/LPS-111915)

**Observed Error**: Users are unable to preview the display page template of a web content before the web content is published.

**Root Cause**: To preview the draft web content, the portal fetched the latest _Approved_ version of the article; however, newly created drafts don't have an _Approved_ version yet.

**Solution:** 
Currently, the article to be viewed is fetched by its `groupId` and `articleId` and has a filter of `WorkflowConstants.STATUS_APPROVED` later applied to the query, seen in 
https://github.com/liferay/liferay-portal/blob/7e7782a8cfb106ddfb68231dc8f217633b4a8110/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java#L347-L348
The solution bypasses that method and calls `getDisplay()` directly, eliminatating the need for the _Approved_ version of the article to be retrieved and allowing the user to view the _Draft_ article.