### PR TITLE
LPS-111303 The Account Member role should be automatically assigned

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/dao/search/AccountRoleDisplaySearchContainerFactory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/dao/search/AccountRoleDisplaySearchContainerFactory.java
@@ -16,6 +16,7 @@ package com.liferay.account.admin.web.internal.dao.search;
 
 import com.liferay.account.admin.web.internal.display.AccountRoleDisplay;
 import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.constants.AccountRoleConstants;
 import com.liferay.account.model.AccountRole;
 import com.liferay.account.service.AccountRoleLocalServiceUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -25,6 +26,8 @@ import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.comparator.RoleNameComparator;
 import com.liferay.portal.vulcan.util.TransformUtil;
+
+import java.util.List;
 
 /**
  * @author Pei-Jung Lan
@@ -61,10 +64,16 @@ public class AccountRoleDisplaySearchContainerFactory {
 				keywords, searchContainer.getStart(), searchContainer.getEnd(),
 				new RoleNameComparator(orderByType.equals("asc")));
 
-		searchContainer.setResults(
+		List<AccountRoleDisplay> accountRoleDisplayList =
 			TransformUtil.transform(
-				baseModelSearchResult.getBaseModels(), AccountRoleDisplay::of));
-		searchContainer.setTotal(baseModelSearchResult.getLength());
+				baseModelSearchResult.getBaseModels(), AccountRoleDisplay::of);
+
+		accountRoleDisplayList.removeIf(
+			AccountRoleDisplay -> AccountRoleConstants.isImpliedRole(
+				AccountRoleDisplay.getRole()));
+
+		searchContainer.setResults(accountRoleDisplayList);
+		searchContainer.setTotal(accountRoleDisplayList.size());
 
 		return searchContainer;
 	}

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountRoleConstants.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountRoleConstants.java
@@ -60,6 +60,16 @@ public class AccountRoleConstants {
 		REQUIRED_ROLE_NAME_ACCOUNT_MANAGER, REQUIRED_ROLE_NAME_ACCOUNT_MEMBER
 	};
 
+	public static boolean isImpliedRole(Role role) {
+		String roleName = role.getName();
+
+		if (roleName.equals(REQUIRED_ROLE_NAME_ACCOUNT_MEMBER)) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isRequiredRole(Role role) {
 		return ArrayUtil.contains(REQUIRED_ROLE_NAMES, role.getName());
 	}

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -30,6 +30,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.account.constants.AccountPanelCategoryKeys" %><%@
+page import="com.liferay.account.constants.AccountRoleConstants" %><%@
 page import="com.liferay.account.model.AccountRole" %><%@
 page import="com.liferay.application.list.PanelApp" %><%@
 page import="com.liferay.application.list.PanelAppRegistry" %><%@
@@ -237,7 +238,7 @@ private StringBundler _getResourceHtmlId(String resource) {
 private boolean _isImpliedRole(Role role) {
 	String name = role.getName();
 
-	if (name.equals(RoleConstants.GUEST) || name.equals(RoleConstants.ORGANIZATION_USER) || name.equals(RoleConstants.OWNER) || name.equals(RoleConstants.SITE_MEMBER) || name.equals(RoleConstants.USER)) {
+	if (name.equals(RoleConstants.GUEST) || name.equals(RoleConstants.ORGANIZATION_USER) || name.equals(RoleConstants.OWNER) || name.equals(RoleConstants.SITE_MEMBER) || name.equals(RoleConstants.USER) || name.equals(AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_MEMBER)) {
 		return true;
 	}
 


### PR DESCRIPTION
[LPS-111303](https://issues.liferay.com/browse/LPS-111303)
Closed [#758](https://github.com/SamZiemer/liferay-portal/pull/738) to improve logic
_Design criteria can be found in the comments of the LPS._

**Observed Error:** The Account Member (renamed from Account User) role was not automatically assigned.

**Solution:** Added a method in `AccountEntryUserRelModelListener` to add/delete the role from the user whenever a relationship between the Account and User is added/deleted.

As of 1dd2baa054fa0b338e85b7e31b5051f2e13883c9, a user is assigned to the default account if they are removed from their _last_ account; the default account association is removed if they are assigned to an account. Therefore, if a user doesn't belong to an account, https://github.com/amandaaakwok/liferay-portal/blob/c9179f1342fe92d1a87eff2c5b822c6e411148cb/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountEntryUserRelModelListener.java#L120 will hold true, and their Account Member role should be revoked.