### PR TITLE
LPS-116548 Remove the additional layer so MvccVersion is updated sooner.

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -3194,7 +3194,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 			updateParentLayoutId(draftLayout.getPlid(), parentPlid);
 		}
 
-		return layoutLocalService.updateLayout(layout);
+		return layoutPersistence.update(layout);
 	}
 
 	/**


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-116548

The way the behavior occurs in LPS-116548:

1. [doProcessAction](https://github.com/liferay/liferay-portal/blob/89b619a60717e2f19a5948dd973b40d08957e8af/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/MoveLayoutMVCActionCommand.java#L73) is called in MoveLayoutMVCActionCommand.
2. Above method in Step 1 eventually calls [updateParentLayoutIdAndPriority](https://github.com/liferay/liferay-portal/blob/89b619a60717e2f19a5948dd973b40d08957e8af/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java#L3214) in LayoutLocalServiceImpl.
3. Above method in Step 2 calls [updateParentLayoutId](https://github.com/liferay/liferay-portal/blob/89b619a60717e2f19a5948dd973b40d08957e8af/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java#L3101) which ultimately calls [updateLayout](https://github.com/liferay/liferay-portal/blob/89b619a60717e2f19a5948dd973b40d08957e8af/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalServiceWrapper.java#L1738) using the wrapper in LayoutLocalServiceWrapper.
4. Because staging + page versioning is involved, the updated layout is wrapped before it's returned in [wrapLayout](https://github.com/liferay/liferay-portal/blob/89b619a60717e2f19a5948dd973b40d08957e8af/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java#L552) in LayoutLocalServiceStagingAdvice.
5. Again, because staging + page versioning is involved, above method in Step 4 ultimately calls [getProxiedLayout](https://github.com/liferay/liferay-portal/blob/89b619a60717e2f19a5948dd973b40d08957e8af/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java#L488).
6. In getProxiedLayout, we have the following code check:
```
if (layout.getMvccVersion() ==
		cachedProxiedLayout.getMvccVersion()) {

	return cachedProxiedLayout;
```

This is the reason the behavior in LPS-116548 occurs incorrectly. Layout, in this case, is correct, and identifies itself as a child page after the drag is finished. 

However, because above check completes (MvccVersion is the same), the cachedProxiedLayout (which is the layout prior to the drag initiated) is returned.

The solution for this issue is to ensure we remove the additional layer by calling persistence directly so the MvccVersion is updated.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim