### PR TITLE
LPS-118602 Delete structure link when updating DLFileEntry's type

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.document.library.kernel.util.comparator.RepositoryModelModifi
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
+import com.liferay.dynamic.data.mapping.kernel.DDMStructureLinkManagerUtil;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructureManagerUtil;
 import com.liferay.dynamic.data.mapping.kernel.StorageEngineManagerUtil;
 import com.liferay.expando.kernel.model.ExpandoBridge;
@@ -1645,6 +1646,26 @@ public class DLFileEntryLocalServiceImpl
 			PortalUtil.getCurrentAndAncestorSiteGroupIds(
 				dlFileEntry.getGroupId()),
 			dlFileEntry.getFolderId(), fileEntryTypeId);
+
+		if ((fileEntryTypeId != dlFileEntry.getFileEntryTypeId()) &&
+			(dlFileEntry.getFileEntryTypeId() != 0)) {
+
+			DLFileEntryMetadata dlFileEntryMetadata =
+				dlFileEntryMetadataPersistence.fetchByFileEntryId_Last(
+					fileEntryId, null);
+
+			DDMStructure ddmStructure = DDMStructureManagerUtil.fetchStructure(
+				dlFileEntry.getGroupId(),
+				classNameLocalService.getClassNameId(DLFileEntryMetadata.class),
+				DLUtil.getDDMStructureKey(dlFileEntry.getDLFileEntryType()));
+
+			long classNameId = classNameLocalService.getClassNameId(
+				DLFileEntryMetadata.class);
+
+			DDMStructureLinkManagerUtil.deleteStructureLink(
+				classNameId, dlFileEntryMetadata.getFileEntryMetadataId(),
+				ddmStructure.getStructureId());
+		}
 
 		return updateFileEntry(
 			userId, fileEntryId, sourceFileName, extension, mimeType, title,


### PR DESCRIPTION
Notes from @noornajj:

> 
> https://issues.liferay.com/browse/LPS-118602
> 
> The issue here was caused by a thrown exception, MustNotDeleteStructureReferencedByStructureLinks, in DDMStructureLocalServiceImpl.deleteStructure(). When a file entry is updated to use a different document type, the DDMStructureLink table is not updated to delete the link to the old document type. Therefore, deleteStructure thinks that the document type is still in use which, in turn, leads to the exception to be thrown.
> To solve this issue, I updated the updateFileEntry method to delete the old structure link if the document type is being changed. I also added a condition that the old document type must not be a Basic Document because a structure link is not created for Basic Document types.