### PR TITLE
[TS] LPS-118902 Portlet ID references in custom css not upgraded from 6.2

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/upgrade/v1_0_0/UpgradeDDLFormPortletId.java
@@ -174,6 +174,10 @@ public class UpgradeDDLFormPortletId extends BaseUpgradePortletId {
 			"<preference><name>formView</name><value>true</value>" +
 				"</preference></portlet-preferences>");
 
+		newPreferences = StringUtil.replace(
+			newPreferences, "#portlet_" + oldRootPortletId,
+			"#portlet_" + newRootPortletId);
+
 		portletPreferences.setPreferences(newPreferences);
 
 		_portletPreferencesLocalService.updatePortletPreferences(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradePortletId;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.PortletPreferencesImpl;
 
 import java.sql.PreparedStatement;
@@ -74,7 +75,9 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 		return 0;
 	}
 
-	protected String getNewPreferences(long plid, String preferences)
+	protected String getNewPreferences(
+			long plid, String preferences, String oldRootPortletId,
+			String newRootPortletId)
 		throws Exception {
 
 		PortletPreferences oldPortletPreferences =
@@ -92,6 +95,8 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 			oldPortletPreferences.getValue("pageDelta", StringPool.BLANK));
 		String pageUrl = oldPortletPreferences.getValue(
 			"pageUrl", StringPool.BLANK);
+		String portletSetupCss = oldPortletPreferences.getValue(
+			"portletSetupCss", StringPool.BLANK);
 		String type = oldPortletPreferences.getValue("type", StringPool.BLANK);
 
 		PortletPreferences newPortletPreferences = new PortletPreferencesImpl();
@@ -131,6 +136,12 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 		newPortletPreferences.setValue("orderByColumn1", orderByCol);
 		newPortletPreferences.setValue("orderByType1", orderByType);
 		newPortletPreferences.setValue("paginationType", "none");
+
+		portletSetupCss = StringUtil.replace(
+			portletSetupCss, "#portlet_" + oldRootPortletId,
+			"#portlet_" + newRootPortletId);
+
+		newPortletPreferences.setValue("portletSetupCss", portletSetupCss);
 
 		long categoryId = getCategoryId(layout.getCompanyId(), type);
 
@@ -219,7 +230,8 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 				long plid = rs.getLong("plid");
 				String portletId = rs.getString("portletId");
 
-				String newPreferences = getNewPreferences(plid, preferences);
+				String newPreferences = getNewPreferences(
+					plid, preferences, oldRootPortletId, newRootPortletId);
 
 				long userId = PortletIdCodec.decodeUserId(portletId);
 				String instanceId = PortletIdCodec.decodeInstanceId(portletId);

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -220,6 +220,13 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 				"update PortletPreferences set portletId = '", newRootPortletId,
 				"' where portletId = '", oldRootPortletId, "'"));
 
+		runSQL(
+			StringBundler.concat(
+				"update PortletPreferences set preferences = replace(",
+				"preferences, '#portlet_", oldRootPortletId, "', '#portlet_",
+				newRootPortletId, "') where portletId = '", newRootPortletId,
+				"'"));
+
 		if (!newRootPortletId.contains("_INSTANCE_")) {
 			runSQL(
 				StringBundler.concat(
@@ -227,6 +234,13 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 					"portletId, '", oldRootPortletId, "_INSTANCE_', '",
 					newRootPortletId, "_INSTANCE_') where portletId like '",
 					oldRootPortletId, "_INSTANCE_%'"));
+
+			runSQL(
+				StringBundler.concat(
+					"update PortletPreferences set preferences = replace(",
+					"preferences, '#portlet_", oldRootPortletId, "_INSTANCE_',",
+					"'#portlet_", newRootPortletId, "_INSTANCE_') where ",
+					"portletId like '", newRootPortletId, "_INSTANCE_%'"));
 		}
 
 		runSQL(
@@ -235,6 +249,13 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 				"'", oldRootPortletId, "_USER_', '", newRootPortletId,
 				"_USER_') where portletId like '", oldRootPortletId,
 				"_USER_%'"));
+
+		runSQL(
+			StringBundler.concat(
+				"update PortletPreferences set preferences = replace(",
+				"preferences, '#portlet_", oldRootPortletId, "_USER_', ",
+				"'#portlet_", newRootPortletId, "_USER_') where portletId ",
+				"like '", newRootPortletId, "_USER_%'"));
 	}
 
 	protected void updateLayout(long plid, String typeSettings)


### PR DESCRIPTION
Hi @SamZiemer, I'm sending this pr to the upgrade team although I'm not sure which other team should review its semantics. Please redirect me if you believe another team should review it instead. 

The issue to solve by this pr is the outdated references to portlet id's when upgrading from 6.2 (or 6.1) to 7.0 and above due to the extensive renaming from numerical to fully qualified identifiers. The current upgrade makes sure to replace the portletId in PortletPreferences but won't touch css references in the preferences. 

These references to the portlet id's may be there or not because it's up to the user to use them, but if they choose to do so, they must be the id's specified by Liferay. This pr updates the css references starting with the string '#portlet_'. 

The main changes are all done in a single method, except for a couple of cases where this method is overridden and the code has to be adapted accordingly. 

Please let me know if you have any questions. Thanks!