### PR TITLE
LPS-119020 Add defaultLanguageId to taglib for Web Content title

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -136,6 +136,9 @@
 
 			var ddmFormDefinition = <%= DDMUtil.getDDMFormJSONString(ddmForm) %>;
 
+			ddmFormDefinition.defaultLanguageId =
+				'<%= LocaleUtil.toLanguageId(defaultLocale) %>';
+
 			var liferayDDMForm = Liferay.component(
 				'<portlet:namespace /><%= HtmlUtil.escapeJS(fieldsNamespace) %>ddmForm',
 				new Liferay.DDM.Form({


### PR DESCRIPTION
Hello Sam,

Could you take a look at how this behaves on your machine? This fix seems to address the problem in [LPS-119020](https://issues.liferay.com/browse/LPS-119020) just fine but my strong concern is that it's the reverse code as in [LPS-115891](https://issues.liferay.com/browse/LPS-115891). Mai's tested [LPS-115891](https://issues.liferay.com/browse/LPS-115891) and isn't able to reproduce it on her machine with her fix. I've tested and can reproduce [LPS-115891](https://issues.liferay.com/browse/LPS-115891) on my machine. Could you be the sanity check on whether [LPS-115891](https://issues.liferay.com/browse/LPS-115891) is reproducible or not?

Tested here: https://github.com/joshuacords/liferay-portal/pull/96

Mai's Notes:
In LPS-119020, LPS-115891, LPP-38436, when change default language, DL and Web Content unable to create new article and upload new file. This is because defaultLanguageId wasn't sent to taglib. Therefore, I fixed this by adding defaultLanguageId to taglib.

