### PR TITLE
Lps 119263

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/validator/DDMFormValidationException.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/validator/DDMFormValidationException.java
@@ -313,6 +313,25 @@ public class DDMFormValidationException extends PortalException {
 
 	}
 
+	public static class MustSetValidTypeForFieldType
+		extends DDMFormValidationException {
+
+		public MustSetValidTypeForFieldType(String fieldType) {
+			super(
+				String.format(
+					"Invalid type entered for field type %s", fieldType));
+
+			_fieldType = fieldType;
+		}
+
+		public String getFieldType() {
+			return _fieldType;
+		}
+
+		private final String _fieldType;
+
+	}
+
 	public static class MustSetValidValidationExpression
 		extends MustSetValidDDMFormFieldExpression {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/validator/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/validator/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
@@ -41,6 +41,7 @@ import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.Mus
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidDefaultLocaleForProperty;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidFormRuleExpression;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidIndexType;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidTypeForFieldType;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidValidationExpression;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidVisibilityExpression;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidator;
@@ -278,6 +279,20 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 			throw new MustSetFieldType(ddmFormField.getName());
 		}
 
+		Boolean validType = false;
+
+		for (String type : _SUPPORTED_DDM_FORM_FIELD_TYPES) {
+			if (type.equals(ddmFormField.getType())) {
+				validType = true;
+
+				break;
+			}
+		}
+
+		if (!validType) {
+			throw new MustSetValidTypeForFieldType(ddmFormField.getType());
+		}
+
 		Matcher matcher = _ddmFormFieldTypePattern.matcher(
 			ddmFormField.getType());
 
@@ -441,6 +456,14 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 
 	private static final String[] _DDM_FORM_FIELD_INDEX_TYPES = {
 		StringPool.BLANK, "keyword", "none", "text"
+	};
+
+	private static final String[] _SUPPORTED_DDM_FORM_FIELD_TYPES = {
+		"checkbox", "ddm-color", "ddm-date", "ddm-decimal",
+		"ddm-documentlibrary", "ddm-geolocation", "ddm-image", "ddm-integer",
+		"ddm-journal-article", "ddm-link-to-page", "ddm-number",
+		"ddm-paragraph", "ddm-separator", "ddm-text-html", "fieldset", "option",
+		"radio", "select", "text", "textarea"
 	};
 
 	private static final Pattern _ddmFormFieldNamePattern = Pattern.compile(


### PR DESCRIPTION
Notes from @noornajj:

In the future, please make sure you are keeping track of the failures. Semantic versioning can be fixed by running baseline commands in the modules as well.

gw baseline.

> https://issues.liferay.com/browse/LPS-119263
> 
> The issue here was that the validateDDMFormFieldType method did not validate whether the field type being added is one of the predefined types in DDMFormFieldType.
> To fix the issue, I added a check whether the field type is one of the predefined types. If not, then I added a new DDMFormValidationException class, MustSetValidTypeForFieldType, that is thrown.

