### PR TITLE
LPS-120258 Wrap variableName in parenthesis to avoid potential syntax errors.

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/image.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/image.ftl
@@ -6,7 +6,7 @@
 />
 
 <#if stringUtil.equals(language, "ftl")>
-${r"<#if"} ${variableName}?? && ${variableName} != "">
+${r"<#if"} (${variableName})?? && ${variableName} != "">
 	<img alt="${getVariableReferenceCode(variableAltName)}" data-fileentryid="${getVariableReferenceCode(variableFieldEntryId)}" src="${getVariableReferenceCode(variableName)}" />
 ${r"</#if>"}
 <#else>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-120258

Hello @SamZiemer ,

The issue is straightforward. The default code we provide for a image field web content template has a possibility of syntax error when the following is utilized:
`
$(variableName)??`

The solution is essentially a source format commit to wrap variableName in parenthesis to avoid such possibility.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim