### PR TITLE
LPS-120039 Add confirmation message for field deletion.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
@@ -334,8 +334,17 @@ class LayoutProvider extends Component {
 				label: Liferay.Language.get('duplicate'),
 			},
 			{
-				action: ({activePage, fieldName}) =>
-					this.dispatch('fieldDeleted', {activePage, fieldName}),
+				action: ({activePage, fieldName}) => {
+					if (
+						confirm(
+							Liferay.Language.get(
+								'are-you-sure-you-want-to-delete-this-field'
+							)
+						)
+					) {
+						this.dispatch('fieldDeleted', {activePage, fieldName});
+					}
+				},
 				label: Liferay.Language.get('delete'),
 			},
 		];


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-120039

Current behavior is that form field deletion does not have any confirmation prior to deletion.

Fix is to add a confirmation message.

Sincerely,
Brian