### PR TITLE
LPS-121591 Get extension from the mimeType if possible.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -97,9 +97,11 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -130,9 +132,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -183,7 +187,23 @@ public class DLFileEntryLocalServiceImpl
 		String name = String.valueOf(
 			counterLocalService.increment(DLFileEntry.class.getName()));
 
-		String extension = DLAppUtil.getExtension(title, sourceFileName);
+		String extension = null;
+
+		Set<String> extensions = MimeTypesUtil.getExtensions(mimeType);
+
+		if (!extensions.isEmpty() && (extensions.size() == 1)) {
+			Iterator<String> iterator = extensions.iterator();
+
+			extension = iterator.next();
+
+			extension = extension.substring(1);
+		}
+		else if (mimeType.equals(ContentTypes.TEXT_PLAIN)) {
+			extension = "txt";
+		}
+		else {
+			extension = DLAppUtil.getExtension(title, sourceFileName);
+		}
 
 		String fileName = DLUtil.getSanitizedFileName(title, extension);
 
@@ -1639,7 +1659,23 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
 			fileEntryId);
 
-		String extension = DLAppUtil.getExtension(title, sourceFileName);
+		String extension = null;
+
+		Set<String> extensions = MimeTypesUtil.getExtensions(mimeType);
+
+		if (!extensions.isEmpty() && (extensions.size() == 1)) {
+			Iterator<String> iterator = extensions.iterator();
+
+			extension = iterator.next();
+
+			extension = extension.substring(1);
+		}
+		else if (mimeType.equals(ContentTypes.TEXT_PLAIN)) {
+			extension = "txt";
+		}
+		else {
+			extension = DLAppUtil.getExtension(title, sourceFileName);
+		}
 
 		if ((file == null) && (inputStream == null)) {
 			extension = dlFileEntry.getExtension();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-121591

See ticket for issue description.

The extension displayed in the info tab and the downloaded file should have the correct extension type fetched from the contentType.

For most use-cases, the extensionsMap will be of size 1 in the implementation. Therefore, we can return the matched extension. 

However, text/plain contentType has about 52 possible extensions due to certain application/x types having a sub-type of text/plain. For our use-case, we should consider text/plain for the extension .txt

Sincerely,
Brian Kim