### PR TITLE
LPS-122233 Use AutoDeleteFileInputStream to create FileStream when saving to the temp folder

### DIFF
--- a/modules/apps/change-tracking/change-tracking-store-service/src/main/java/com/liferay/change/tracking/store/internal/CTStore.java
+++ b/modules/apps/change-tracking/change-tracking-store-service/src/main/java/com/liferay/change/tracking/store/internal/CTStore.java
@@ -290,6 +290,27 @@ public class CTStore implements Store {
 	}
 
 	@Override
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		if (!CTCollectionThreadLocal.isProductionMode() &&
+			_isCTSContentLoaded(
+				companyId, repositoryId, fileName, versionLabel)) {
+
+			CTSContent ctsContent = _ctsContentLocalService.getCTSContent(
+				companyId, repositoryId, fileName, versionLabel, _storeType);
+
+			return _ctsContentLocalService.openDataInputStream(
+				ctsContent.getCtsContentId());
+		}
+
+		return _store.getTempFileAsStream(
+			companyId, repositoryId, fileName, versionLabel);
+	}
+
+	@Override
 	public boolean hasFile(
 		long companyId, long repositoryId, String fileName,
 		String versionLabel) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -90,7 +90,7 @@ public class DLFileEntryModelDocumentContributor
 				DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
 
 				inputStream = _inputStreamSanitizer.sanitize(
-					dlFileVersion.getContentStream(false));
+					dlFileVersion.getTempContentStream(false));
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {

--- a/modules/apps/portal-store/portal-store-db/src/main/java/com/liferay/portal/store/db/DBStore.java
+++ b/modules/apps/portal-store/portal-store-db/src/main/java/com/liferay/portal/store/db/DBStore.java
@@ -153,6 +153,26 @@ public class DBStore implements Store {
 	}
 
 	@Override
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws NoSuchFileException {
+
+		try {
+			DLContent dlContent = _dlContentLocalService.getContent(
+				companyId, repositoryId, fileName, versionLabel);
+
+			return _dlContentLocalService.openDataInputStream(
+				dlContent.getContentId());
+		}
+		catch (NoSuchContentException noSuchContentException) {
+			throw new NoSuchFileException(
+				companyId, repositoryId, fileName, versionLabel,
+				noSuchContentException);
+		}
+	}
+
+	@Override
 	public boolean hasFile(
 		long companyId, long repositoryId, String fileName,
 		String versionLabel) {

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStore.java
@@ -200,6 +200,29 @@ public class FileSystemStore implements Store {
 	}
 
 	@Override
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws NoSuchFileException {
+
+		if (Validator.isNull(versionLabel)) {
+			versionLabel = getHeadVersionLabel(
+				companyId, repositoryId, fileName);
+		}
+
+		File fileNameVersionFile = getFileNameVersionFile(
+			companyId, repositoryId, fileName, versionLabel);
+
+		try {
+			return new FileInputStream(fileNameVersionFile);
+		}
+		catch (FileNotFoundException fileNotFoundException) {
+			throw new NoSuchFileException(
+				companyId, repositoryId, fileName, fileNotFoundException);
+		}
+	}
+
+	@Override
 	public boolean hasFile(
 		long companyId, long repositoryId, String fileName,
 		String versionLabel) {

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/safe/file/name/SafeFileNameStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/safe/file/name/SafeFileNameStore.java
@@ -173,6 +173,26 @@ public class SafeFileNameStore implements Store {
 	}
 
 	@Override
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		String safeFileName = FileUtil.encodeSafeFileName(fileName);
+
+		if (safeFileName.equals(fileName) ||
+			_store.hasFile(
+				companyId, repositoryId, safeFileName, versionLabel)) {
+
+			return _store.getTempFileAsStream(
+				companyId, repositoryId, safeFileName, versionLabel);
+		}
+
+		return _store.getTempFileAsStream(
+			companyId, repositoryId, fileName, versionLabel);
+	}
+
+	@Override
 	public boolean hasFile(
 		long companyId, long repositoryId, String fileName,
 		String versionLabel) {

--- a/modules/apps/portal-store/portal-store-s3/build.gradle
+++ b/modules/apps/portal-store/portal-store-s3/build.gradle
@@ -18,5 +18,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -47,6 +47,7 @@ import com.liferay.document.library.kernel.exception.AccessDeniedException;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.petra.io.AutoDeleteFileInputStream;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -259,6 +260,27 @@ public class S3Store implements Store {
 		Arrays.sort(versions, DLUtil::compareVersions);
 
 		return versions;
+	}
+
+	@Override
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		try {
+			_s3FileCache.cleanUpCacheFiles();
+
+			S3Object s3Object = getS3Object(
+				companyId, repositoryId, fileName, versionLabel);
+
+			File file = _s3FileCache.getCacheFile(s3Object, fileName);
+
+			return new AutoDeleteFileInputStream(file);
+		}
+		catch (IOException ioException) {
+			throw new SystemException(ioException);
+		}
 	}
 
 	public TransferManager getTransferManager() {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionImpl.java
@@ -131,6 +131,14 @@ public class DLFileVersionImpl extends DLFileVersionBaseImpl {
 	}
 
 	@Override
+	public InputStream getTempContentStream(boolean incrementCounter)
+		throws PortalException {
+
+		return DLFileEntryLocalServiceUtil.getTempFileAsStream(
+			getFileEntryId(), getVersion(), incrementCounter);
+	}
+
+	@Override
 	public void setExtraSettings(String extraSettings) {
 		_extraSettingsUnicodeProperties = null;
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1323,6 +1323,33 @@ public class DLFileEntryLocalServiceImpl
 	}
 
 	@Override
+	public InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter)
+		throws PortalException {
+
+		return getTempFileAsStream(fileEntryId, version, incrementCounter, 1);
+	}
+
+	@Override
+	public InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter,
+			int increment)
+		throws PortalException {
+
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
+			fileEntryId);
+
+		if (incrementCounter) {
+			dlFileEntryLocalService.incrementViewCounter(
+				dlFileEntry, increment);
+		}
+
+		return DLStoreUtil.getTempFileAsStream(
+			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+			dlFileEntry.getName(), version);
+	}
+
+	@Override
 	public String getUniqueTitle(
 			long groupId, long folderId, long fileEntryId, String title,
 			String extension)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -329,6 +329,20 @@ public class DLStoreImpl implements DLStore {
 	}
 
 	@Override
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		validate(fileName, false, versionLabel);
+
+		Store store = _storeFactory.getStore();
+
+		return store.getTempFileAsStream(
+			companyId, repositoryId, fileName, versionLabel);
+	}
+
+	@Override
 	public boolean hasFile(long companyId, long repositoryId, String fileName)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersion.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersion.java
@@ -91,4 +91,7 @@ public interface DLFileVersion
 		com.liferay.portal.kernel.util.UnicodeProperties
 			extraSettingsUnicodeProperties);
 
+	public java.io.InputStream getTempContentStream(boolean incrementCounter)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 }

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionWrapper.java
@@ -583,6 +583,13 @@ public class DLFileVersionWrapper
 		return model.getStatusDate();
 	}
 
+	@Override
+	public java.io.InputStream getTempContentStream(boolean incrementCounter)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getTempContentStream(incrementCounter);
+	}
+
 	/**
 	 * Returns the title of this document library file version.
 	 *

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -571,6 +571,17 @@ public interface DLFileEntryLocalService
 	public int getRepositoryFileEntriesCount(long repositoryId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter,
+			int increment)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getUniqueTitle(
 			long groupId, long folderId, long fileEntryId, String title,
 			String extension)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -853,6 +853,23 @@ public class DLFileEntryLocalServiceUtil {
 		return getService().getRepositoryFileEntriesCount(repositoryId);
 	}
 
+	public static java.io.InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getTempFileAsStream(
+			fileEntryId, version, incrementCounter);
+	}
+
+	public static java.io.InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter,
+			int increment)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getTempFileAsStream(
+			fileEntryId, version, incrementCounter, increment);
+	}
+
 	public static String getUniqueTitle(
 			long groupId, long folderId, long fileEntryId, String title,
 			String extension)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -870,6 +870,25 @@ public class DLFileEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.io.InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlFileEntryLocalService.getTempFileAsStream(
+			fileEntryId, version, incrementCounter);
+	}
+
+	@Override
+	public java.io.InputStream getTempFileAsStream(
+			long fileEntryId, String version, boolean incrementCounter,
+			int increment)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlFileEntryLocalService.getTempFileAsStream(
+			fileEntryId, version, incrementCounter, increment);
+	}
+
+	@Override
 	public String getUniqueTitle(
 			long groupId, long folderId, long fileEntryId, String title,
 			String extension)

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/DLStore.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/DLStore.java
@@ -101,6 +101,11 @@ public interface DLStore {
 	public long getFileSize(long companyId, long repositoryId, String fileName)
 		throws PortalException;
 
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException;
+
 	public boolean hasFile(long companyId, long repositoryId, String fileName)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/DLStoreUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/DLStoreUtil.java
@@ -362,6 +362,31 @@ public class DLStoreUtil {
 	}
 
 	/**
+	 * Returns the file as an {@link InputStream} object.
+	 *
+	 * <p>
+	 * If using an S3 store, it is preferable for performance reasons to use
+	 * this method to get the file as an {@link InputStream} instead of using
+	 * other methods to get the file as a {@link File}.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the company
+	 * @param  repositoryId the primary key of the data repository (optionally
+	 *         {@link com.liferay.portal.kernel.model.CompanyConstants#SYSTEM})
+	 * @param  fileName the file's name
+	 * @param  versionLabel the file's version label
+	 * @return Returns the {@link InputStream} object with the file's name
+	 */
+	public static InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		return getStore().getTempFileAsStream(
+			companyId, repositoryId, fileName, versionLabel);
+	}
+
+	/**
 	 * Returns <code>true</code> if the file exists.
 	 *
 	 * @param  companyId the primary key of the company

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/Store.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/Store.java
@@ -117,6 +117,21 @@ public interface Store {
 		long companyId, long repositoryId, String fileName);
 
 	/**
+	 * Returns the file as an {@link InputStream} object.
+	 *
+	 * @param  companyId the primary key of the company
+	 * @param  repositoryId the primary key of the data repository (optionally
+	 *         {@link com.liferay.portal.kernel.model.CompanyConstants#SYSTEM})
+	 * @param  fileName the file's name
+	 * @param  versionLabel the file's version label
+	 * @return Returns the {@link InputStream} object with the file's name
+	 */
+	public InputStream getTempFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException;
+
+	/**
 	 * Returns <code>true</code> if the file exists.
 	 *
 	 * @param  companyId the primary key of the company


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122233

The issue here was that a copy of the S3 Store document library was being stored in the temp folder each time a re-indexing occurred.
The solution was to create the file stream using AutoDeleteFileInputStream instead of FileInputStream with a condition that the files are being created in the temp folder. This will automatically delete the created files when the input stream is closed.