### PR TITLE
LPS-123120 Clear keyword rather than using existing portletURL.

### DIFF
--- a/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -166,11 +166,14 @@ String methodName = null;
 </liferay-util:buffer>
 
 <%
+PortletURL clearResultsURL = (PortletURL)request.getAttribute("edit_roles.jsp-portletURL");
+clearResultsURL.setParameter("keywords", StringPool.BLANK);
+
 SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("liferay-ui:search:searchContainer");
 %>
 
 <clay:management-toolbar
-	clearResultsURL="<%= portletURL.toString() %>"
+	clearResultsURL="<%= clearResultsURL.toString() %>"
 	itemsTotal="<%= searchContainer.getTotal() %>"
 	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	searchActionURL="<%= portletURL.toString() %>"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123120

See issue for description. Solution is to clear the keyword parameter from the request so that the clearResultsURL actually functions as expected.

Sincerely,
Brian