### PR TITLE
LPS-125764 Calendar portlet appears 'squished' when placed on narrow layout columns

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -808,6 +808,8 @@
 
 		.calendar-portlet-column-grid,
 		.calendar-portlet-column-options {
+			flex: 0 0 100%;
+			max-width: 100%;
 			width: 100%;
 		}
 
@@ -871,6 +873,8 @@
 @mixin col-md-6 {
 	.calendar-portlet-column-parent {
 		.calendar-portlet-column-grid {
+			flex: 0 0 60%;
+			max-width: 60%;
 			width: 60%;
 
 			.scheduler-base-content .scheduler-base-hd {
@@ -923,6 +927,8 @@
 		}
 
 		.calendar-portlet-column-options {
+			flex: 0 0 40%;
+			max-width: 40%;
 			width: 40%;
 		}
 	}
@@ -931,6 +937,8 @@
 @mixin col-md-8 {
 	.calendar-portlet-column-parent {
 		.calendar-portlet-column-grid {
+			flex: 0 0 65%;
+			max-width: 65%;
 			width: 65%;
 
 			.scheduler-base-content .scheduler-base-hd {
@@ -979,6 +987,8 @@
 		}
 
 		.calendar-portlet-column-options {
+			flex: 0 0 35%;
+			max-width: 35%;
 			width: 35%;
 		}
 	}


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-125764>

**Notes:**
The issue is primarily caused by the `col-xs` CSS grid classes, which is not providing spacing for elements within `calendar-portlet-column-grid` and `calendar-portlet-column-options`. My solution attempts to overwrite these properties. I've attempted to match the styling found in [LPS-69112](https://issues.liferay.com/browse/LPS-69112).

Let me know if you have any questions or if some revisions need to be made (especially since this is a styling issue).