### PR TITLE
Lps 127072

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstanceSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstanceSettings.java
@@ -149,9 +149,9 @@ public interface DDMFormInstanceSettings {
 	public String storageType();
 
 	@DDMFormField(
-			label = "%submit-button-label",
-			properties = "placeholder=%submit-form",
-			type = "localizable_text")
+		label = "%submit-button-label", properties = "placeholder=%submit-form",
+		type = "localizable_text"
+	)
 	public String submitLabel();
 
 	@DDMFormField(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstanceSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstanceSettings.java
@@ -148,7 +148,10 @@ public interface DDMFormInstanceSettings {
 	)
 	public String storageType();
 
-	@DDMFormField(label = "%submit-button-label", type = "localizable_text")
+	@DDMFormField(
+			label = "%submit-button-label",
+			properties = "placeholder=%submit-form",
+			type = "localizable_text")
 	public String submitLabel();
 
 	@DDMFormField(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -50,6 +50,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -61,6 +63,7 @@ import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil;
 import com.liferay.portal.kernel.template.comparator.TemplateHandlerComparator;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -1003,6 +1006,18 @@ public class DDMDisplayContext {
 
 		if (showAncestorScopes()) {
 			groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds);
+		}
+
+		Layout layout = _ddmWebRequestHelper.getLayout();
+
+		Group group = null;
+
+		if (layout != null) {
+			group = layout.getGroup();
+		}
+
+		if ((group != null) && !group.isStagingGroup()) {
+			groupIds = ArrayUtil.append(groupIds, group.getGroupId());
 		}
 
 		List<DDMStructure> results = null;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1246,7 +1246,7 @@ public class JournalArticleStagedModelDataHandler
 	protected String[] getSkipImportReferenceStagedModelNames() {
 		return new String[] {
 			AssetDisplayPageEntry.class.getName(),
-			FriendlyURLEntry.class.getName(), Layout.class.getName()
+			FriendlyURLEntry.class.getName()
 		};
 	}
 

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/edit_instance.jsp
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/edit_instance.jsp
@@ -34,7 +34,7 @@ catch (Exception e) {
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
 
-renderResponse.setTitle((selCompany == null) ? LanguageUtil.get(request, "new-instance") : HtmlUtil.escape(selCompany.getName()));
+renderResponse.setTitle((selCompany == null) ? LanguageUtil.get(request, "new-instance") : HtmlUtil.escape(selCompany.getWebId()));
 %>
 
 <portlet:actionURL name="/portal_instances/edit_instance" var="editInstanceURL" />

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
@@ -180,7 +180,8 @@ public class MetadataManagerImpl
 
 		try {
 			String portalURL = _portal.getPortalURL(
-				httpServletRequest, isSSLRequired());
+				httpServletRequest,
+				isSSLRequired() | _portal.isSecure(httpServletRequest));
 			String localEntityId = _localEntityManager.getLocalEntityId();
 
 			if (_samlProviderConfigurationHelper.isRoleIdp()) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagesadmin/ContentPageConverter.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagesadmin/ContentPageConverter.testcase
@@ -279,6 +279,8 @@ definition {
 	@description = "This is a test for LPS-98325. If there is a site with several widget pages(that can be converted) and some content pages and an api to convert bulk widget pages to content pages is executed, you should be able to convert the widget pages."
 	@priority = "2"
 	test ConvertMultipleWidgetPagesWithContentPagesViaAPI {
+		property test.name.skip.portal.instance = "ContentPageConverter#ConvertMultipleWidgetPagesWithContentPagesViaAPI";
+
 		task ("Add 10 widget pages") {
 			for (var n : list "1,2,3,4,5,6,7,8,9,10") {
 				JSONLayout.addPublicLayout(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-127072

Hello @SamZiemer ,

The issue occurs here due to to the call here: [DDMDisplayContext](https://github.com/liferay/liferay-portal/blob/fa6ecdb8ad0e059654aff51e1216a57a8ddd272a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java#L998). When staging is enabled, but DDL is not staged, the groupId returned only has the staging group id. The intended behavior, as established, by [PTR-2198](https://issues.liferay.com/browse/PTR-2198) is to also include the liveGroupId.

The solution was implemented after an approval from the product team in the PTR.