### PR TITLE
LPS-127135

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -173,8 +173,8 @@ public class OrganizationResourceImpl
 				ServiceContextFactory.getInstance(contextHttpServletRequest));
 
 		return _organizationResourceDTOConverter.toDTO(
-			_getDTOConverterContext(String.valueOf(serviceBuilderOrganization)),
-			serviceBuilderOrganization);
+			_getDTOConverterContext(
+				serviceBuilderOrganization.getExternalReferenceCode()));
 	}
 
 	@Override


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-127135>

**Notes:**
Users are not able to create a new organization via the Headless Admin API because `_getDTOConverterContext()` expects an organization ID, not the organization as an object string. Doing this causes an exception, resulting in a 404 error. This fix was originally developed by @javierdearcos from the Liferay Headless Team. I am simply pushing his changes to `master`.

cc: @javierdearcos