### PR TITLE
LPS-127071

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
@@ -29,7 +29,10 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Map;
 
 /**
  * @author Rubén Pulido
@@ -91,11 +94,16 @@ public class LayoutDataConverter {
 					inputRowJSONObject.getJSONObject("config");
 
 				if (inputRowConfigJSONObject != null) {
+					String backgroundColorCssClass =
+						inputRowConfigJSONObject.getString(
+							"backgroundColorCssClass");
+
 					outerContainerStyledLayoutStructureItem.updateItemConfig(
 						JSONUtil.put(
 							"backgroundColorCssClass",
-							inputRowConfigJSONObject.getString(
-								"backgroundColorCssClass")
+							_colors.getOrDefault(
+								backgroundColorCssClass,
+								backgroundColorCssClass)
 						).put(
 							"styles",
 							JSONUtil.put(
@@ -239,5 +247,29 @@ public class LayoutDataConverter {
 
 		return JSONUtil.put("url", backgroundImage);
 	}
+
+	private static final Map<String, String> _colors = HashMapBuilder.put(
+		"danger", "dangerColor"
+	).put(
+		"dark", "darkColor"
+	).put(
+		"gray-dark", "gray800Color"
+	).put(
+		"info", "infoColor"
+	).put(
+		"light", "lightColor"
+	).put(
+		"lighter", "gray100Color"
+	).put(
+		"primary", "primaryColor"
+	).put(
+		"secondary", "secondaryColor"
+	).put(
+		"success", "successColor"
+	).put(
+		"warning", "warningColor"
+	).put(
+		"white", "whiteColor"
+	).build();
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_1/UpgradeFragmentEntryLinkEditableValues.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_1/UpgradeFragmentEntryLinkEditableValues.java
@@ -189,27 +189,27 @@ public class UpgradeFragmentEntryLinkEditableValues extends UpgradeProcess {
 			"sm", "0.1875rem"
 		).build();
 	private static final Map<String, String> _colors = HashMapBuilder.put(
-		"danger", "#DA1414"
+		"danger", "dangerColor"
 	).put(
-		"dark", "#272833"
+		"dark", "darkColor"
 	).put(
-		"gray-dark", "#393A4A"
+		"gray-dark", "gray800Color"
 	).put(
-		"info", "#2E5AAC"
+		"info", "infoColor"
 	).put(
-		"light", "#F1F2F5"
+		"light", "lightColor"
 	).put(
-		"lighter", "#F7F8F9"
+		"lighter", "gray100Color"
 	).put(
-		"primary", "#0B5FFF"
+		"primary", "primaryColor"
 	).put(
-		"secondary", "#6B6C7E"
+		"secondary", "secondaryColor"
 	).put(
-		"success", "#287D3C"
+		"success", "successColor"
 	).put(
-		"warning", "#B95000"
+		"warning", "warningColor"
 	).put(
-		"white", "#FFFFFF"
+		"white", "whiteColor"
 	).build();
 	private static final Map<String, String> _shadows = HashMapBuilder.put(
 		"lg", "0 1rem 3rem rgba(0, 0, 0, .175)"

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/UpgradeLayoutPageTemplateStructureRel.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/UpgradeLayoutPageTemplateStructureRel.java
@@ -311,27 +311,27 @@ public class UpgradeLayoutPageTemplateStructureRel extends UpgradeProcess {
 			"sm", "0.1875rem"
 		).build();
 	private static final Map<String, String> _colors = HashMapBuilder.put(
-		"danger", "#DA1414"
+		"danger", "dangerColor"
 	).put(
-		"dark", "#272833"
+		"dark", "darkColor"
 	).put(
-		"gray-dark", "#393A4A"
+		"gray-dark", "gray800Color"
 	).put(
-		"info", "#2E5AAC"
+		"info", "infoColor"
 	).put(
-		"light", "#F1F2F5"
+		"light", "lightColor"
 	).put(
-		"lighter", "#F7F8F9"
+		"lighter", "gray100Color"
 	).put(
-		"primary", "#0B5FFF"
+		"primary", "primaryColor"
 	).put(
-		"secondary", "#6B6C7E"
+		"secondary", "secondaryColor"
 	).put(
-		"success", "#287D3C"
+		"success", "successColor"
 	).put(
-		"warning", "#B95000"
+		"warning", "warningColor"
 	).put(
-		"white", "#FFFFFF"
+		"white", "whiteColor"
 	).build();
 	private static final Map<String, String> _shadows = HashMapBuilder.put(
 		"lg", "0 1rem 3rem rgba(0, 0, 0, .175)"


### PR DESCRIPTION
**Tickets**
<https://issues.liferay.com/browse/LPS-127071>

**Notes**
The issue occurs because the upgrade does not update the `backgroundColorCssClass` values to the ones found in later versions. As a result, the color picker field in the side menu editor does not recognize the background color and RGB values are used. This issue occurs for text color (`cssClass` values) as well.

To resolve this issue, we need to use the CSS color classes found in `frontend-token-definition.json` in `frontend-theme/frontend-theme-classic` module:

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/frontend-theme/frontend-theme-classic/src/WEB-INF/frontend-token-definition.json>

The portal refers to the CSS color classes found in `frontend-token-definition.json` when rendering layouts, as seen in the following:

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java#L694-L712>

I used `UpgradeFragmentEntryLinkEditableValues.java` to determine which CSS color class to use from `frontend-token-definition.json`.

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_1/UpgradeFragmentEntryLinkEditableValues.java#L191-L213>

Let me know if you have any questions or if I need to revise my solution.