### PR TITLE
LPS-127800 Use instance id when editing web content display

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -20,8 +20,7 @@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.journal.constants.JournalContentPortletKeys" %><%@
-page import="com.liferay.journal.content.web.internal.constants.JournalContentWebKeys" %><%@
+<%@ page import="com.liferay.journal.content.web.internal.constants.JournalContentWebKeys" %><%@
 page import="com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext" %><%@
 page import="com.liferay.journal.content.web.internal.security.permission.resource.JournalArticlePermission" %><%@
 page import="com.liferay.journal.model.JournalArticle" %><%@

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -20,7 +20,7 @@
 JournalArticle article = journalContentDisplayContext.getArticle();
 %>
 
-<liferay-ui:success key='<%= JournalContentPortletKeys.JOURNAL_CONTENT + "requestProcessed" %>' message="your-request-completed-successfully" />
+<liferay-ui:success key='<%= portletDisplay.getId() + "requestProcessed" %>' message="your-request-completed-successfully" />
 
 <div class="visible-interaction">
 	<liferay-ui:icon-menu

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -401,8 +401,19 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 		int workflowAction = ParamUtil.getInteger(
 			actionRequest, "workflowAction", WorkflowConstants.ACTION_PUBLISH);
 
-		if (Validator.isNotNull(portletResource) &&
-			(workflowAction != WorkflowConstants.ACTION_SAVE_DRAFT)) {
+		if (workflowAction != WorkflowConstants.ACTION_SAVE_DRAFT) {
+			String referringPortletResource = ParamUtil.getString(
+				actionRequest, "referringPortletResource");
+
+			if (Validator.isNotNull(referringPortletResource)) {
+				MultiSessionMessages.add(
+					actionRequest,
+					referringPortletResource + "requestProcessed");
+			}
+			else if (Validator.isNotNull(portletResource)) {
+				MultiSessionMessages.add(
+					actionRequest, portletResource + "requestProcessed");
+			}
 
 			MultiSessionMessages.add(
 				actionRequest, portletResource + "requestProcessed");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-127800

The issue here was that multiple success messages were being displayed when editing a web content display. The number of display messages were dependent on how many web content displays were added to a page.
To fix the issue, the instance id of the web content display is passed into the request.