### PR TITLE
LPS-128446 Allow journal articale display to be retrieved for schedul…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -205,6 +205,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -2399,7 +2401,13 @@ public class JournalArticleLocalServiceImpl
 
 		Date displayDate = article.getDisplayDate();
 
-		if ((displayDate != null) && displayDate.after(now)) {
+		HttpServletRequest httpServletRequest = themeDisplay.getRequest();
+
+		String view_mode = httpServletRequest.getParameter("p_l_mode");
+
+		if ((displayDate != null) && displayDate.after(now) &&
+			!view_mode.equals("preview")) {
+
 			return null;
 		}
 


### PR DESCRIPTION
…ed articles when being previewed

Notes from @Noornajj:

https://issues.liferay.com/browse/LPS-128446

> 
> The issue here is that getArticleDisplay is being called from JournalArticleLocalService when web contents are linked to display page templates. This method does not return scheduled web content displays which did not apply the user to preview the web content.
> To fix the issue, I added a condition to the if statement that the view mode is not equal to "preview".