### PR TITLE
LPS-124518 Data Clean-up app: provide a way to remove expired journal articles

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-test/build.gradle
+++ b/modules/apps/data-cleanup/data-cleanup-test/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile project(":apps:journal:journal-api")
+	testIntegrationCompile project(":apps:journal:journal-test-util")
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/test/UpgradeExpiredJournalArticleTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/test/UpgradeExpiredJournalArticleTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.cleanup.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Dictionary;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kevin Lee
+ */
+@RunWith(Arquillian.class)
+public class UpgradeExpiredJournalArticleTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgradeExpiredJournalArticle() throws Exception {
+		JournalArticle expiredJournalArticleA = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle expiredJournalArticleB = JournalTestUtil.updateArticle(
+			expiredJournalArticleA);
+
+		JournalArticle unexpiredJournalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalTestUtil.expireArticle(
+			expiredJournalArticleB.getGroupId(), expiredJournalArticleB);
+
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put("cleanUpExpiredJournalArticleModuleData", true);
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					_CONFIGURATION_PID, properties)) {
+
+			FinderCacheUtil.clearLocalCache();
+
+			Assert.assertNull(
+				_journalArticleLocalService.fetchArticle(
+					expiredJournalArticleA.getId()));
+
+			Assert.assertNull(
+				_journalArticleLocalService.fetchArticle(
+					expiredJournalArticleB.getId()));
+
+			Assert.assertNotNull(
+				_journalArticleLocalService.fetchArticle(
+					unexpiredJournalArticle.getId()));
+		}
+	}
+
+	private static final String _CONFIGURATION_PID =
+		"com.liferay.data.cleanup.internal.configuration." +
+			"DataCleanupConfiguration";
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+}

--- a/modules/apps/data-cleanup/data-cleanup/build.gradle
+++ b/modules/apps/data-cleanup/data-cleanup/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/configuration/DataCleanupConfiguration.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/configuration/DataCleanupConfiguration.java
@@ -34,12 +34,6 @@ public interface DataCleanupConfiguration {
 	public boolean cleanUpChatModuleData();
 
 	@Meta.AD(
-		deflt = "false", name = "clean-up-image-editor-module-data",
-		required = false
-	)
-	public boolean cleanUpImageEditorModuleData();
-
-	@Meta.AD(
 		deflt = "false", name = "clean-up-dictionary-module-data",
 		required = false
 	)
@@ -56,6 +50,12 @@ public interface DataCleanupConfiguration {
 		required = false
 	)
 	public boolean cleanUpExpiredJournalArticleModuleData();
+
+	@Meta.AD(
+		deflt = "false", name = "clean-up-image-editor-module-data",
+		required = false
+	)
+	public boolean cleanUpImageEditorModuleData();
 
 	@Meta.AD(
 		deflt = "false", name = "clean-up-invitation-module-data",

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/configuration/DataCleanupConfiguration.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/configuration/DataCleanupConfiguration.java
@@ -52,6 +52,12 @@ public interface DataCleanupConfiguration {
 	public boolean cleanUpDirectoryModuleData();
 
 	@Meta.AD(
+		deflt = "false", name = "clean-up-expired-journal-article-module-data",
+		required = false
+	)
+	public boolean cleanUpExpiredJournalArticleModuleData();
+
+	@Meta.AD(
 		deflt = "false", name = "clean-up-invitation-module-data",
 		required = false
 	)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/DataCleanup.java
@@ -15,6 +15,7 @@
 package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.data.cleanup.internal.configuration.DataCleanupConfiguration;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -56,6 +57,13 @@ public class DataCleanup implements UpgradeStepRegistrator {
 			_cleanUpModuleData(
 				_dataCleanupConfiguration::cleanUpDirectoryModuleData,
 				"com.liferay.directory.web", UpgradeDirectory::new);
+
+			_cleanUpModuleData(
+				_dataCleanupConfiguration::
+					cleanUpExpiredJournalArticleModuleData,
+				"com.liferay.journal.service",
+				() -> new UpgradeExpiredJournalArticle(
+					_journalArticleLocalService));
 
 			_cleanUpModuleData(
 				_dataCleanupConfiguration::cleanUpImageEditorModuleData,
@@ -118,6 +126,9 @@ public class DataCleanup implements UpgradeStepRegistrator {
 
 	@Reference
 	private ImageLocalService _imageLocalService;
+
+	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Reference
 	private MBThreadLocalService _mbThreadLocalService;

--- a/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/UpgradeExpiredJournalArticle.java
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/java/com/liferay/data/cleanup/internal/upgrade/UpgradeExpiredJournalArticle.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.cleanup.internal.upgrade;
+
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.List;
+
+/**
+ * @author Kevin Lee
+ */
+public class UpgradeExpiredJournalArticle extends UpgradeProcess {
+
+	public UpgradeExpiredJournalArticle(
+		JournalArticleLocalService journalArticleLocalService) {
+
+		_journalArticleLocalService = journalArticleLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DynamicQuery dynamicQuery = _journalArticleLocalService.dynamicQuery();
+
+		Property property = PropertyFactoryUtil.forName("status");
+
+		dynamicQuery.add(property.eq(WorkflowConstants.STATUS_EXPIRED));
+
+		List<JournalArticle> journalArticles =
+			_journalArticleLocalService.dynamicQuery(dynamicQuery);
+
+		for (JournalArticle journalArticle : journalArticles) {
+			_journalArticleLocalService.deleteArticle(journalArticle);
+		}
+	}
+
+	private final JournalArticleLocalService _journalArticleLocalService;
+
+}

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data.
 clean-up-dictionary-module-data=Clean up dictionary module data.
 clean-up-directory-module-data=Clean up directory module data.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data.
 clean-up-image-editor-module-data=Clean up image editor module data.
 clean-up-invitation-module-data=Clean up invitation module data.
 clean-up-mail-reader-module-data=Clean up mail reader module data.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ar.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=مسح بيانات وحدة الدردشة.
 clean-up-dictionary-module-data=مسح بيانات وحدة القاموس.
 clean-up-directory-module-data=مسح بيانات وحدة الدليل.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=مسح بيانات وحدة الدعوة.
 clean-up-mail-reader-module-data=مسح بيانات وحدة قارئ البريد.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_bg.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ca.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Neteja les dades del mòdul del xat.
 clean-up-dictionary-module-data=Neteja les dades del mòdul del diccionari.
 clean-up-directory-module-data=Neteja les dades del mòdul del directori.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Neteja les dades del mòdul d'invitacions.
 clean-up-mail-reader-module-data=Neteja les dades del mòdul del lector de correu.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_cs.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_da.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_da.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_de.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_de.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Daten des Chat-Moduls bereinigen.
 clean-up-dictionary-module-data=Daten des Wörterbuch-Moduls bereinigen.
 clean-up-directory-module-data=Daten des Verzeichnis-Moduls bereinigen.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Daten des Einladungsmoduls bereinigen.
 clean-up-mail-reader-module-data=Daten des E-Mail-Programm-Moduls bereinigen.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_el.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_el.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_en.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_en.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data.
 clean-up-dictionary-module-data=Clean up dictionary module data.
 clean-up-directory-module-data=Clean up directory module data.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data.
 clean-up-image-editor-module-data=Clean up image editor module data.
 clean-up-invitation-module-data=Clean up invitation module data.
 clean-up-mail-reader-module-data=Clean up mail reader module data.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_en_AU.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_en_GB.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_es.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_es.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Limpia los datos del módulo de chat.
 clean-up-dictionary-module-data=Limpia los datos del módulo del diccionario.
 clean-up-directory-module-data=Limpia los datos del módulo del directorio.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Limpia los datos del módulo de invitaciones.
 clean-up-mail-reader-module-data=Limpia los datos del módulo del lector de correo.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_et.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_et.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_eu.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fa.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fi.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Puhdista chat-moduulin tiedot.
 clean-up-dictionary-module-data=Puhdista sanakirjamoduulin tiedot.
 clean-up-directory-module-data=Puhdista hakemistomoduulin tiedot.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Puhdista kutsumoduulin tiedot.
 clean-up-mail-reader-module-data=Puhdista postinlukijamoduulin tiedot.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fr.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Nettoyez les données du module de chat.
 clean-up-dictionary-module-data=Nettoyez les données du module de dictionnaire.
 clean-up-directory-module-data=Nettoyez les données du module d'annuaire.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Nettoyez les données du module d'invitation.
 clean-up-mail-reader-module-data=Nettoyez les données du module de lecture d'e-mail.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_fr_CA.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_gl.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_hi_IN.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_hr.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_hu.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Tisztítsa ki a csevegés modul adatait.
 clean-up-dictionary-module-data=Tisztítsa ki a szótár modul adatait.
 clean-up-directory-module-data=Tisztítsa ki a könyvtár modul adatait.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Tisztítsa ki a meghívás modul adatait.
 clean-up-mail-reader-module-data=Tisztítsa ki a mail-olvasó modul adatait.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_in.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_in.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_it.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_it.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_iw.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ja.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=チャットモジュールのデータを初期化します。
 clean-up-dictionary-module-data=辞書モジュールのデータを初期化します。
 clean-up-directory-module-data=ディレクトリモジュールのデータを初期化します。
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=招待モジュールのデータを初期化します。
 clean-up-mail-reader-module-data=メールリーダーモジュールのデータを初期化します。

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_kk.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ko.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_lo.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_lt.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ms.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_nb.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_nl.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Gegevens chatmodule opschonen.
 clean-up-dictionary-module-data=Gegevens woordenboekmodule opschonen.
 clean-up-directory-module-data=Gegevens foldermodule opschonen.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Gegevens uitnodigingsmodule opschonen.
 clean-up-mail-reader-module-data=Gegevens leesmodule berichten opschonen.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_nl_BE.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_pl.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_pt_BR.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Remover os dados do módulo de bate-papo.
 clean-up-dictionary-module-data=Remover os dados do módulo de dicionário.
 clean-up-directory-module-data=Remover os dados do módulo de diretório.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Remover os dados do módulo de convite.
 clean-up-mail-reader-module-data=Remover os dados do módulo de leitor de e-mail.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_pt_PT.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ro.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ru.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sk.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sl.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sr_RS.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_sv.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Moduldata för att rensa chatt.
 clean-up-dictionary-module-data=Moduldata för att rensa ordlista.
 clean-up-directory-module-data=Moduldata för att rensa katalog.
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Moduldata för att rensa inbjudan.
 clean-up-mail-reader-module-data=Moduldata för att rensa e-postläsare.

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_ta_IN.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_th.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_th.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_tr.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_uk.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_vi.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=Clean up chat module data. (Automatic Copy)
 clean-up-dictionary-module-data=Clean up dictionary module data. (Automatic Copy)
 clean-up-directory-module-data=Clean up directory module data. (Automatic Copy)
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=Clean up invitation module data. (Automatic Copy)
 clean-up-mail-reader-module-data=Clean up mail reader module data. (Automatic Copy)

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_zh_CN.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=清理聊天模块数据。
 clean-up-dictionary-module-data=清理字典模块数据。
 clean-up-directory-module-data=清理目录模块数据。
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=清理邀请模块数据。
 clean-up-mail-reader-module-data=清理邮件阅读器模块数据。

--- a/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/data-cleanup/data-cleanup/src/main/resources/content/Language_zh_TW.properties
@@ -1,6 +1,7 @@
 clean-up-chat-module-data=清除聊天模組資料。
 clean-up-dictionary-module-data=清除字典模組資料
 clean-up-directory-module-data=清除目錄模組資料。
+clean-up-expired-journal-article-module-data=Clean up expired journal article module data. (Automatic Copy)
 clean-up-image-editor-module-data=Clean up image editor module data. (Automatic Copy)
 clean-up-invitation-module-data=清除邀請模組資料。
 clean-up-mail-reader-module-data=清除郵件閱讀器模組資料。


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-124518>

**Previous Pull Request:**
<https://github.com/SamZiemer/liferay-portal/pull/788>

**Notes:**
These changes allow users to delete expired journal articles via the Data Cleanup app. Compared to previous changes from <https://github.com/SamZiemer/liferay-portal/pull/788>, I've squashed commits <https://github.com/SamZiemer/liferay-portal/pull/788/commits/631045ac69c2f10f30dc5e0bee01004e3f9913f3> and <https://github.com/SamZiemer/liferay-portal/pull/788/commits/259efb1f92960206d6d2f519d4cdd4bd3b541562> together into one commit: <https://github.com/SamZiemer/liferay-portal/commit/a6c8751c2f21dd18d46bee06ecbeec47264e356d>. I also added an additional commit that's unrelated to [LPS-124518](https://issues.liferay.com/browse/LPS-124518) for source formatting: <https://github.com/SamZiemer/liferay-portal/commit/66a93349cd0997e8522b786e12b7938c42760cb3>.