### PR TITLE
LPS-127157 Style Books temporarily unavailable after upgrading from 7.2

### DIFF
--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -29,6 +29,7 @@ import com.liferay.portal.deploy.hot.ServiceWrapperRegistry;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
+import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
 import com.liferay.portal.kernel.exception.LoggedExceptionInInitializerError;
 import com.liferay.portal.kernel.log.Log;
@@ -366,6 +367,8 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 				StartupHelperUtil.setUpgrading(false);
 			}
 			else {
+				DependencyManagerSyncUtil.sync();
+
 				ModuleFrameworkUtilAdapter.registerContext(applicationContext);
 			}
 		}


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-127157>

**Notes:**
The issue is that the necessary resource permissions are not being created in the database during startup. This issue also affects other components besides Style Books (e.g. [LPS-125389](https://issues.liferay.com/browse/LPS-125389)). Upon further examination, the issue does not occur on auto-upgrade startups (when `upgrade.database.auto.run=true`). The reason for this is that when auto-upgrade is disabled, the portal startup does not run `DependencyManagerSyncUtil.sync()`, which is preventing the resource actions/permissions from being properly initialized. See the following links:

- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java#L363-L370>
- <https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java#L147-L159>

Let me know if you have any questions or thoughts.