### PR TITLE
LPS-129407 Site Memberships is temporarily unavailable When trying to assign a site role to a Site Owner / Site Administrator

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.membershippolicy.MembershipPolicyException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.MembershipRequestService;
 import com.liferay.portal.kernel.service.OrganizationService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -39,14 +40,17 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.site.memberships.constants.SiteMembershipsPortletKeys;
 import com.liferay.site.memberships.web.internal.display.context.SiteMembershipsDisplayContext;
 import com.liferay.users.admin.kernel.util.UsersAdmin;
+import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
 import java.io.IOException;
 
@@ -252,9 +256,18 @@ public class SiteMembershipsPortlet extends MVCPortlet {
 
 		long[] roleIds = ParamUtil.getLongValues(actionRequest, "rowIds");
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
 		List<UserGroupRole> userGroupRoles =
 			_userGroupRoleLocalService.getUserGroupRoles(
 				user.getUserId(), group.getGroupId());
+
+		userGroupRoles = UsersAdminUtil.filterUserGroupRoles(
+			permissionChecker, userGroupRoles);
 
 		List<Long> curRoleIds = ListUtil.toList(
 			userGroupRoles, UsersAdmin.USER_GROUP_ROLE_ID_ACCESSOR);


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-129407>

**Notes:**
When the "Select Roles" form is submitted, the action request passes back the IDs of the selected roles. The selected roles are used to determine what site roles to add and remove from the user being edited. However, the issue is that the portal treats the roles that are not included in the selected roles as roles to remove, including **the roles that the user being edited has**:

<https://github.com/liferay/liferay-portal/blob/7.3.6-ga7/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java#L255-L268>

This can lead to the portal attempting to remove the wrong site roles from the user being edited, which can cause permission issues that break the Site Memberships portlet. 

My solution is to filter out the roles that the current user does not have permission to remove from users. I based my solution on the filtering that is performed when displaying the site roles in the Select Roles modal window:

<https://github.com/liferay/liferay-portal/blob/7.3.6-ga7/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesDisplayContext.java#L117-L118>

Let me know if you have any questions/thoughts.