### PR TITLE
LPS-130936

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Localizable.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Localizable.testcase
@@ -215,6 +215,124 @@ definition {
 			webContentText = "This is a text field");
 	}
 
+	@description = "This is a test for LRQA-66428. This test checks if Localizable property is successfully set when the Portal Instance language is not English US and if it persists for Structures created before changing Portal Instance language"
+	@priority = "5"
+	test LocalizableWithDifferentInstanceLanguage {
+		DataEngine.addFields(fieldNameList = "Text,Numeric");
+
+		DataEngine.addFieldNested(
+			fieldFieldLabel = "Date",
+			fieldName = "Date",
+			targetFieldLabel = "Numeric");
+
+		for (var fieldFieldLabel : list "Text,Numeric,Date") {
+			DataEngine.editFieldLocalizable(fieldFieldLabel = "${fieldFieldLabel}");
+		}
+
+		WebContentStructures.saveCP();
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "Instance Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Localization",
+			configurationName = "Language",
+			configurationScope = "Virtual Instance Scope");
+
+		PortalSettings.configureCurrentLanguagesCP(defaultPortalLanguage = "Portuguese (Brazil)");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+		NavItem.gotoStructures();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		for (var fieldFieldLabel : list "Text,Numeric,Date") {
+			DataEngine.assertLocalizableFieldUnchecked(fieldFieldLabel = "${fieldFieldLabel}");
+		}
+
+		Navigator.gotoBack();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		WebContent.addCP(webContentTitle = "Web Content Title");
+
+		PortletEntry.changeLocale(locale = "ca-ES");
+
+		WebContent.addCP(webContentTitle = "Web Content Title - ca-ES");
+
+		for (var fieldFieldName : list "Text,Numeric,Date") {
+			DataEngine.assertNonLocalizableField(fieldFieldName = "${fieldFieldName}");
+		}
+
+		PortletEntry.publish();
+
+		NavItem.gotoStructures();
+
+		WebContentStructures.addCP(structureName = "WC Structure Title 2");
+
+		DataEngine.addFields(fieldNameList = "Text,Numeric");
+
+		DataEngine.addFieldNested(
+			fieldFieldLabel = "Date",
+			fieldName = "Date",
+			targetFieldLabel = "Numeric");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title 2");
+
+		WebContent.addWithStructureCP(
+			webContentDate = "04/01/2021",
+			webContentNumeric = "10",
+			webContentText = "This is a Text field - pt-BR",
+			webContentTitle = "Web Content Title - pt-BR");
+
+		PortletEntry.changeLocale(locale = "ca-ES");
+
+		WebContent.addWithStructureCP(
+			webContentDate = "03/05/2021",
+			webContentNumeric = "20",
+			webContentText = "This is a Text field - ca-ES",
+			webContentTitle = "Web Content Title - ca-ES");
+
+		PortletEntry.publish();
+
+		WebContent.viewWithStructureCP(
+			webContentDate = "04/01/2021",
+			webContentNumeric = "10",
+			webContentText = "This is a Text field - pt-BR",
+			webContentTitle = "Web Content Title - pt-BR");
+
+		WebContent.viewWithStructureCP(
+			skipGotoEditCP = "true",
+			webContentDate = "03/05/2021",
+			webContentLocaleFieldLabel = "ca-ES",
+			webContentNumeric = "20",
+			webContentText = "This is a Text field - ca-ES",
+			webContentTitle = "Web Content Title - ca-ES");
+
+		Navigator.gotoBack();
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "Instance Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Localization",
+			configurationName = "Language",
+			configurationScope = "Virtual Instance Scope");
+
+		PortalSettings.configureCurrentLanguagesCP(defaultPortalLanguage = "English (United States)");
+	}
+
 	@description = "This test ensures that it's possible to translate the content of the fields in a fieldset"
 	@priority = "5"
 	test TranslateFieldSetLocalizableOn {

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Localizable.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Localizable.testcase
@@ -317,20 +317,6 @@ definition {
 			webContentNumeric = "20",
 			webContentText = "This is a Text field - ca-ES",
 			webContentTitle = "Web Content Title - ca-ES");
-
-		Navigator.gotoBack();
-
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Instance Settings");
-
-		SystemSettings.gotoConfiguration(
-			configurationCategory = "Localization",
-			configurationName = "Language",
-			configurationScope = "Virtual Instance Scope");
-
-		PortalSettings.configureCurrentLanguagesCP(defaultPortalLanguage = "English (United States)");
 	}
 
 	@description = "This test ensures that it's possible to translate the content of the fields in a fieldset"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -78,6 +78,8 @@ body .ddm-user-view-content {
 .portlet-forms .ddm-form-basic-info .ddm-form-name {
 	color: #000;
 	font-weight: 500;
+	margin-top: 40px;
+	padding: 0;
 }
 
 .lfr-ddm-form-field-container label,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -684,7 +684,7 @@ public class DDMFormAdminDisplayContext {
 		DDMFormInstance formInstance = getDDMFormInstance();
 
 		if (formInstance == null) {
-			jsonObject.put(getDefaultLanguageId(), "");
+			jsonObject.put(getDefaultLanguageId(), getFormDescription());
 		}
 		else {
 			Map<Locale, String> descriptionMap =
@@ -707,7 +707,7 @@ public class DDMFormAdminDisplayContext {
 		JSONObject jsonObject = jsonFactory.createJSONObject();
 
 		if (formInstance == null) {
-			jsonObject.put(getDefaultLanguageId(), "");
+			jsonObject.put(getDefaultLanguageId(), getFormName());
 		}
 		else {
 			Map<Locale, String> nameMap = formInstance.getNameMap();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/autosize/autosize.es.js
@@ -24,6 +24,10 @@ class AutoSize {
 			10
 		);
 
+		this.paddingHeight =
+			parseInt(this.computedStyle.paddingTop.replace('px', ''), 10) +
+			parseInt(this.computedStyle.paddingBottom.replace('px', ''), 10);
+
 		this.template = this.createTemplate(this.computedStyle);
 		document.body.appendChild(this.template);
 
@@ -74,9 +78,9 @@ class AutoSize {
 			DEFAULT_APPEND_CONTENT;
 
 		inputElement.style.height = `${
-			this.template.scrollHeight < this.minHeight
+			this.template.scrollHeight + this.paddingHeight < this.minHeight
 				? this.minHeight
-				: this.template.scrollHeight
+				: this.template.scrollHeight + this.paddingHeight
 		}px`;
 	}
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -19,6 +19,39 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
+function addSeparators(items) {
+
+	// We need at least two non-empty items to consider adding separators
+	// between them.
+
+	if (items.length < 2) {
+		return items;
+	}
+
+	const separatedItems = [items[0]];
+
+	for (let i = 1; i < items.length; i++) {
+		const item = items[i];
+
+		if (item.type === 'group' && item.separator) {
+			separatedItems.push({type: 'divider'});
+		}
+
+		separatedItems.push(item);
+	}
+
+	return separatedItems.map((item) => {
+		if (item.type === 'group') {
+			return {
+				...item,
+				items: addSeparators(item.items),
+			};
+		}
+
+		return item;
+	});
+}
+
 function spreadDataAttributes(item) {
 	const {data, ...rest} = item;
 
@@ -60,7 +93,7 @@ export default function DropdownMenu({
 				className={classNames({
 					'dropdown-action': actionsDropdown,
 				})}
-				items={items.map(spreadDataAttributes)}
+				items={addSeparators(items.map(spreadDataAttributes))}
 				trigger={
 					<ClayButton
 						className={classNames(cssClass, {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -19,6 +19,28 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
+function spreadDataAttributes(item) {
+	const {data, ...rest} = item;
+
+	const dataAttributes = data
+		? Object.entries(data).reduce((acc, [key, value]) => {
+				acc[`data-${key}`] = value;
+
+				return acc;
+		  }, {})
+		: {};
+
+	const items = Array.isArray(item.items)
+		? item.items.map(spreadDataAttributes)
+		: item.items;
+
+	return {
+		...dataAttributes,
+		...rest,
+		items,
+	};
+}
+
 export default function DropdownMenu({
 	actionsDropdown = false,
 	additionalProps: _additionalProps,
@@ -38,20 +60,7 @@ export default function DropdownMenu({
 				className={classNames({
 					'dropdown-action': actionsDropdown,
 				})}
-				items={items.map(({data, ...rest}) => {
-					const dataAttributes = data
-						? Object.entries(data).reduce((acc, [key, value]) => {
-								acc[`data-${key}`] = value;
-
-								return acc;
-						  }, {})
-						: {};
-
-					return {
-						...dataAttributes,
-						...rest,
-					};
-				})}
+				items={items.map(spreadDataAttributes)}
 				trigger={
 					<ClayButton
 						className={classNames(cssClass, {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -20,10 +20,6 @@ import classNames from 'classnames';
 import React from 'react';
 
 function addSeparators(items) {
-
-	// We need at least two non-empty items to consider adding separators
-	// between them.
-
 	if (items.length < 2) {
 		return items;
 	}
@@ -53,11 +49,6 @@ function addSeparators(items) {
 }
 
 function filterEmptyGroups(items) {
-
-	// We might expect getting empty groups if, for example, some of the
-	// DropdownItems being available depends on permission checking
-	// (`JournalArticleActionDropdownItemsProvider.getActionDropdownItems()`).
-
 	return items
 		.filter(
 			(item) =>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -52,6 +52,25 @@ function addSeparators(items) {
 	});
 }
 
+function filterEmptyGroups(items) {
+
+	// We might expect getting empty groups if, for example, some of the
+	// DropdownItems being available depends on permission checking
+	// (`JournalArticleActionDropdownItemsProvider.getActionDropdownItems()`).
+
+	return items
+		.filter(
+			(item) =>
+				item.type !== 'group' ||
+				(Array.isArray(item.items) && item.items.length)
+		)
+		.map((item) =>
+			item.type === 'group'
+				? {...item, items: filterEmptyGroups(item.items)}
+				: item
+		);
+}
+
 function spreadDataAttributes(item) {
 	const {data, ...rest} = item;
 
@@ -93,7 +112,9 @@ export default function DropdownMenu({
 				className={classNames({
 					'dropdown-action': actionsDropdown,
 				})}
-				items={addSeparators(items.map(spreadDataAttributes))}
+				items={addSeparators(
+					filterEmptyGroups(items).map(spreadDataAttributes)
+				)}
 				trigger={
 					<ClayButton
 						className={classNames(cssClass, {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -128,79 +128,125 @@ public class JournalArticleActionDropdownItemsProvider {
 
 		boolean singleLanguageSite = _isSingleLanguageSite();
 
-		return DropdownItemListBuilder.add(
-			() -> hasUpdatePermission, _getEditArticleActionUnsafeConsumer()
-		).add(
-			() -> hasUpdatePermission, _getMoveArticleActionUnsafeConsumer()
-		).add(
-			() -> JournalArticlePermission.contains(
-				_themeDisplay.getPermissionChecker(), _article,
-				ActionKeys.PERMISSIONS),
-			_getPermissionsArticleActionUnsafeConsumer()
-		).add(
-			() ->
-				hasViewPermission &&
-				JournalArticlePermission.contains(
-					_themeDisplay.getPermissionChecker(), _article,
-					ActionKeys.SUBSCRIBE),
-			_getSubscribeArticleActionUnsafeConsumer()
-		).add(
-			() -> hasViewPermission && (viewContentArticleAction != null),
-			viewContentArticleAction
-		).add(
-			() -> hasViewPermission && (previewContentArticleAction != null),
-			previewContentArticleAction
-		).add(
-			() ->
-				hasTranslatePermission && hasViewPermission &&
-				!singleLanguageSite,
-			_getTranslateActionUnsafeConsumer()
-		).add(
-			() ->
-				hasTranslatePermission && hasViewPermission &&
-				!singleLanguageSite,
-			_getExportForTranslationActionUnsafeConsumer()
-		).add(
-			() -> hasUpdatePermission && !singleLanguageSite,
-			_getImportTranslationActionUnsafeConsumer()
-		).add(
-			() -> hasUpdatePermission && (availableLanguageIds.length > 1),
-			_getDeleteArticleTranslationsActionUnsafeConsumer()
-		).add(
-			() -> hasViewPermission && hasUpdatePermission,
-			_getViewHistoryArticleActionUnsafeConsumer()
-		).add(
-			_getViewUsagesArticleActionUnsafeConsumer()
-		).add(
-			() -> JournalFolderPermission.contains(
-				_themeDisplay.getPermissionChecker(),
-				_themeDisplay.getScopeGroupId(), _article.getFolderId(),
-				ActionKeys.ADD_ARTICLE),
-			_getCopyArticleActionUnsafeConsumer()
-		).add(
-			() ->
-				JournalArticlePermission.contains(
-					_themeDisplay.getPermissionChecker(), _article,
-					ActionKeys.EXPIRE) &&
-				(_article.hasApprovedVersion() || _article.isScheduled()),
-			_getExpireArticleActionConsumer(_article.getArticleId())
-		).add(
-			() -> hasDeletePermission && trashEnabled,
-			_getMoveToTrashArticleActionUnsafeConsumer()
-		).add(
-			() -> hasDeletePermission && !trashEnabled,
-			_getDeleteArticleAction(_article.getArticleId())
-		).add(
-			() -> {
-				Group group = _themeDisplay.getScopeGroup();
+		return DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() -> hasUpdatePermission,
+						_getEditArticleActionUnsafeConsumer()
+					).add(
+						() -> {
+							Group group = _themeDisplay.getScopeGroup();
 
-				if (_isShowPublishArticleAction() && !group.isLayout()) {
-					return true;
-				}
+							if (_isShowPublishArticleAction() &&
+								!group.isLayout()) {
 
-				return false;
-			},
-			_getPublishToLiveArticleActionUnsafeConsumer()
+								return true;
+							}
+
+							return false;
+						},
+						_getPublishToLiveArticleActionUnsafeConsumer()
+					).add(
+						() ->
+							hasTranslatePermission && hasViewPermission &&
+							!singleLanguageSite,
+						_getTranslateActionUnsafeConsumer()
+					).add(
+						() ->
+							hasViewPermission &&
+							(previewContentArticleAction != null),
+						previewContentArticleAction
+					).add(
+						() ->
+							hasViewPermission &&
+							(viewContentArticleAction != null),
+						viewContentArticleAction
+					).build());
+
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() ->
+							JournalArticlePermission.contains(
+								_themeDisplay.getPermissionChecker(), _article,
+								ActionKeys.EXPIRE) &&
+							(_article.hasApprovedVersion() ||
+							 _article.isScheduled()),
+						_getExpireArticleActionConsumer(_article.getArticleId())
+					).add(
+						() ->
+							hasViewPermission &&
+							JournalArticlePermission.contains(
+								_themeDisplay.getPermissionChecker(), _article,
+								ActionKeys.SUBSCRIBE),
+						_getSubscribeArticleActionUnsafeConsumer()
+					).add(
+						() -> hasViewPermission && hasUpdatePermission,
+						_getViewHistoryArticleActionUnsafeConsumer()
+					).add(
+						_getViewUsagesArticleActionUnsafeConsumer()
+					).build());
+
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() -> JournalFolderPermission.contains(
+							_themeDisplay.getPermissionChecker(),
+							_themeDisplay.getScopeGroupId(),
+							_article.getFolderId(), ActionKeys.ADD_ARTICLE),
+						_getCopyArticleActionUnsafeConsumer()
+					).add(
+						() -> hasUpdatePermission,
+						_getMoveArticleActionUnsafeConsumer()
+					).add(
+						() ->
+							hasTranslatePermission && hasViewPermission &&
+							!singleLanguageSite,
+						_getExportForTranslationActionUnsafeConsumer()
+					).add(
+						() -> hasUpdatePermission && !singleLanguageSite,
+						_getImportTranslationActionUnsafeConsumer()
+					).add(
+						() ->
+							hasUpdatePermission &&
+							(availableLanguageIds.length > 1),
+						_getDeleteArticleTranslationsActionUnsafeConsumer()
+					).build());
+
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() -> JournalArticlePermission.contains(
+							_themeDisplay.getPermissionChecker(), _article,
+							ActionKeys.PERMISSIONS),
+						_getPermissionsArticleActionUnsafeConsumer()
+					).build());
+
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() -> hasDeletePermission && trashEnabled,
+						_getMoveToTrashArticleActionUnsafeConsumer()
+					).add(
+						() -> hasDeletePermission && !trashEnabled,
+						_getDeleteArticleAction(_article.getArticleId())
+					).build());
+
+				dropdownGroupItem.setSeparator(true);
+			}
 		).build();
 	}
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -163,7 +163,6 @@ public class JournalArticleActionDropdownItemsProvider {
 							(viewContentArticleAction != null),
 						viewContentArticleAction
 					).build());
-
 				dropdownGroupItem.setSeparator(true);
 			}
 		).addGroup(
@@ -190,7 +189,6 @@ public class JournalArticleActionDropdownItemsProvider {
 					).add(
 						_getViewUsagesArticleActionUnsafeConsumer()
 					).build());
-
 				dropdownGroupItem.setSeparator(true);
 			}
 		).addGroup(
@@ -219,7 +217,6 @@ public class JournalArticleActionDropdownItemsProvider {
 							(availableLanguageIds.length > 1),
 						_getDeleteArticleTranslationsActionUnsafeConsumer()
 					).build());
-
 				dropdownGroupItem.setSeparator(true);
 			}
 		).addGroup(
@@ -231,7 +228,6 @@ public class JournalArticleActionDropdownItemsProvider {
 							ActionKeys.PERMISSIONS),
 						_getPermissionsArticleActionUnsafeConsumer()
 					).build());
-
 				dropdownGroupItem.setSeparator(true);
 			}
 		).addGroup(
@@ -244,7 +240,6 @@ public class JournalArticleActionDropdownItemsProvider {
 						() -> hasDeletePermission && !trashEnabled,
 						_getDeleteArticleAction(_article.getArticleId())
 					).build());
-
 				dropdownGroupItem.setSeparator(true);
 			}
 		).build();

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
@@ -161,25 +161,32 @@ export default function propsTransformer({
 	portletNamespace,
 	...props
 }) {
+	const bindAction = (item) => {
+		const action = ACTIONS[item.data?.action];
+
+		const transformedItem = {...item};
+
+		if (typeof action === 'function') {
+			transformedItem.onClick = (event) => {
+				event.preventDefault();
+
+				action({
+					itemData: item.data,
+					portletNamespace,
+					trashEnabled,
+				});
+			};
+		}
+
+		if (Array.isArray(item.items)) {
+			transformedItem.items = item.items.map(bindAction);
+		}
+
+		return transformedItem;
+	};
+
 	return {
 		...props,
-		items: items.map((item) => {
-			return {
-				...item,
-				onClick(event) {
-					const action = item.data?.action;
-
-					if (action) {
-						event.preventDefault();
-
-						ACTIONS[action]({
-							itemData: item.data,
-							portletNamespace,
-							trashEnabled,
-						});
-					}
-				},
-			};
-		}),
+		items: items.map(bindAction),
 	};
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
@@ -170,7 +170,7 @@ export default function propsTransformer({
 			transformedItem.onClick = (event) => {
 				event.preventDefault();
 
-				action({
+				action.call(ACTIONS, {
 					itemData: item.data,
 					portletNamespace,
 					trashEnabled,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/SearchContents.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/SearchContents.js
@@ -30,7 +30,7 @@ export default function SearchContents() {
 				{Liferay.Language.get('content-filtering-help')}
 			</p>
 
-			<SearchForm className="mb-2" />
+			<SearchForm className="mb-2" onChange={() => {}} />
 
 			<ClayDropDown
 				active={active}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/ContentsSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/ContentsSidebar.test.js
@@ -17,7 +17,7 @@ import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
-import {StoreContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store';
+import {StoreContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import ContentsSidebar from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/ContentsSidebar';
 
 const pageContents = [

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/ContentsSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/ContentsSidebar.test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {StoreContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store';
+import ContentsSidebar from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/ContentsSidebar';
+
+const pageContents = [
+	{
+		subtype: 'Basic Web Content',
+		title: 'WC1',
+		type: 'Web Content Article',
+	},
+	{
+		subtype: 'Basic Web Content',
+		title: 'WC2',
+		type: 'Web Content Article',
+	},
+];
+
+const renderPageContent = ({pageContents}) =>
+	render(
+		<StoreContextProvider
+			initialState={{fragmentEntryLinks: {}, pageContents}}
+		>
+			<ContentsSidebar></ContentsSidebar>
+		</StoreContextProvider>
+	);
+
+describe('ContentsSidebar', () => {
+	afterEach(cleanup);
+
+	it('shows the content list', () => {
+		const {getByText} = renderPageContent({pageContents});
+
+		expect(getByText('WC1')).toBeInTheDocument();
+		expect(getByText('WC2')).toBeInTheDocument();
+	});
+
+	it('shows an alert when there is no content', () => {
+		const {getByText} = renderPageContent({pageContents: []});
+
+		expect(
+			getByText('there-is-no-content-on-this-page')
+		).toBeInTheDocument();
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/PageContent.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/PageContent.test.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {StoreContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store';
+import PageContent from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/PageContent';
+
+const renderPageContent = (props) =>
+	render(
+		<StoreContextProvider initialState={[{}, {}]}>
+			<PageContent
+				actions={{
+					editURL: 'editURL',
+					permissionsURL: 'permissionsURL',
+					viewUsagesURL: 'viewUsagesURL',
+				}}
+				subtype="Web Content Article"
+				title="Test Web Content"
+				{...props}
+			></PageContent>
+		</StoreContextProvider>
+	);
+
+describe('PageContent', () => {
+	afterEach(cleanup);
+
+	it('shows properly the title of the content', () => {
+		const {getByText} = renderPageContent();
+
+		expect(getByText('Test Web Content')).toBeInTheDocument();
+	});
+
+	it('shows properly the content subtype', () => {
+		const {getByText} = renderPageContent();
+
+		expect(getByText('Web Content Article')).toBeInTheDocument();
+	});
+
+	it('shows Edit action in dropdown menu if receives an Edit URL', () => {
+		const {getByText} = renderPageContent();
+
+		fireEvent.click(getByText('open-actions-menu'));
+
+		expect(getByText('edit')).toBeInTheDocument();
+	});
+
+	it('shows Permissions action in dropdown menu if receives a Permissions URL', () => {
+		const {getByText} = renderPageContent();
+
+		fireEvent.click(getByText('open-actions-menu'));
+
+		expect(getByText('permissions')).toBeInTheDocument();
+	});
+
+	it('shows View Usages action in dropdown menu if receives a View Usages URL', () => {
+		const {getByText} = renderPageContent();
+
+		fireEvent.click(getByText('open-actions-menu'));
+
+		expect(getByText('view-usages')).toBeInTheDocument();
+	});
+
+	it('shows Edit action if the content is inline text', () => {
+		const {getByText} = renderPageContent({actions: {}});
+
+		expect(getByText('edit-inline-text')).toBeInTheDocument();
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/PageContent.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/contents/components/PageContent.test.js
@@ -17,7 +17,7 @@ import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
-import {StoreContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store';
+import {StoreContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import PageContent from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/PageContent';
 
 const renderPageContent = (props) =>

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/ItemConfiguration.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/ItemConfiguration.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
-import {StoreAPIContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store';
+import {StoreAPIContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import ItemConfiguration from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/ItemConfiguration';
 
 const renderComponent = () =>

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/ItemConfiguration.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/ItemConfiguration.test.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {StoreAPIContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store';
+import ItemConfiguration from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/ItemConfiguration';
+
+const renderComponent = () =>
+	render(
+		<StoreAPIContextProvider>
+			<ItemConfiguration />
+		</StoreAPIContextProvider>
+	);
+
+describe('ItemConfiguration', () => {
+	afterEach(cleanup);
+
+	it('renders a warning message if no item is selected', () => {
+		const {getByText} = renderComponent();
+
+		expect(
+			getByText('select-an-element-of-the-page-to-show-this-panel')
+		).toBeInTheDocument();
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/PageStructureSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/PageStructureSidebar.test.js
@@ -19,12 +19,12 @@ import React from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
-import {ControlsProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/components/Controls';
 import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
 import {LAYOUT_DATA_ITEM_TYPE_LABELS} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/layoutDataItemTypeLabels';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/layoutDataItemTypes';
 import {VIEWPORT_SIZES} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
-import {StoreAPIContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {ControlsProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext';
+import {StoreAPIContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import PageStructureSidebar from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/PageStructureSidebar';
 
 jest.mock(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/PageStructureSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/PageStructureSidebar.test.js
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import {DndProvider} from 'react-dnd';
+import {HTML5Backend} from 'react-dnd-html5-backend';
+
+import {ControlsProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/components/Controls';
+import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
+import {LAYOUT_DATA_ITEM_TYPE_LABELS} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/layoutDataItemTypeLabels';
+import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/layoutDataItemTypes';
+import {VIEWPORT_SIZES} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
+import {StoreAPIContextProvider} from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import PageStructureSidebar from '../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/PageStructureSidebar';
+
+jest.mock(
+	'../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({config: {layoutType: 'content'}})
+);
+
+const renderComponent = ({
+	activeItemId = null,
+	hasUpdatePermissions = true,
+	lockedExperience = false,
+	masterRootItemChildren = ['11-container'],
+	rootItemChildren = ['01-container'],
+	viewportSize = VIEWPORT_SIZES.desktop,
+} = {}) => {
+	Liferay.Util.sub.mockImplementation((langKey, args) =>
+		[langKey, ...args].join('-')
+	);
+
+	return render(
+		<DndProvider backend={HTML5Backend}>
+			<ControlsProvider
+				activeInitialState={{
+					activationOrigin: null,
+					activeItemId,
+					activeItemType: null,
+				}}
+				hoverInitialState={{
+					hoveredItemId: null,
+				}}
+			>
+				<StoreAPIContextProvider
+					getState={() => ({
+						fragmentEntryLinks: {
+							'001': {
+								content:
+									'<div>001<span data-lfr-editable-id="05-editable">editable</span></div>',
+								editableTypes: {
+									'05-editable': 'text',
+								},
+								editableValues: {
+									[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {
+										'05-editable': {
+											defaultValue: 'defaultValue',
+										},
+									},
+								},
+								fragmentEntryLinkId: '001',
+								name: 'Fragment 1',
+							},
+						},
+
+						layoutData: {
+							items: {
+								'00-main': {
+									children: rootItemChildren,
+									config: {},
+									itemId: '00-main',
+									parentId: null,
+									type: LAYOUT_DATA_ITEM_TYPES.root,
+								},
+								'01-container': {
+									children: ['02-row'],
+									config: {},
+									itemId: '01-container',
+									parentId: 'main',
+									type: LAYOUT_DATA_ITEM_TYPES.container,
+								},
+								'02-row': {
+									children: ['03-column'],
+									config: {},
+									itemId: '02-row',
+									parentId: '01-container',
+									type: LAYOUT_DATA_ITEM_TYPES.row,
+								},
+								'03-column': {
+									children: ['04-fragment'],
+									config: {},
+									itemId: '03-column',
+									parentId: '02-row',
+									type: LAYOUT_DATA_ITEM_TYPES.column,
+								},
+								'04-fragment': {
+									children: [],
+									config: {
+										fragmentEntryLinkId: '001',
+									},
+									itemId: '04-fragment',
+									parentId: '03-column',
+									type: LAYOUT_DATA_ITEM_TYPES.fragment,
+								},
+								'05-row': {
+									children: [],
+									config: {
+										fragmentEntryLinkId: '001',
+									},
+									itemId: '05-row',
+									parentId: '03-column',
+									type: LAYOUT_DATA_ITEM_TYPES.fragment,
+								},
+							},
+
+							rootItems: {main: '00-main'},
+							version: 1,
+						},
+
+						masterLayout: {
+							masterLayoutData: {
+								items: {
+									'10-main': {
+										children: masterRootItemChildren,
+										config: {},
+										itemId: '10-main',
+										parentId: null,
+										type: LAYOUT_DATA_ITEM_TYPES.root,
+									},
+									'11-container': {
+										children: ['12-dropzone'],
+										config: {},
+										itemId: '11-container',
+										parentId: '10-main',
+										type: LAYOUT_DATA_ITEM_TYPES.container,
+									},
+									'12-dropzone': {
+										children: [],
+										config: {},
+										itemId: '12-dropzone',
+										parentId: '11-container',
+										type: LAYOUT_DATA_ITEM_TYPES.dropZone,
+									},
+								},
+
+								rootItems: {main: '10-main'},
+								version: 1,
+							},
+							masterLayoutPlid: '0',
+						},
+
+						permissions: {
+							LOCKED_SEGMENTS_EXPERIMENT: lockedExperience,
+							UPDATE: hasUpdatePermissions,
+						},
+
+						selectedViewportSize: viewportSize,
+					})}
+				>
+					<PageStructureSidebar />
+				</StoreAPIContextProvider>
+			</ControlsProvider>
+		</DndProvider>
+	);
+};
+
+describe('PageStructureSidebar', () => {
+	afterEach(cleanup);
+
+	it('has a warning message when there is no content', () => {
+		const {getByText} = renderComponent({
+			masterRootItemChildren: [],
+			rootItemChildren: [],
+		});
+
+		expect(
+			getByText('there-is-no-content-on-this-page')
+		).toBeInTheDocument();
+	});
+
+	it('uses fragments names as labels', () => {
+		const {getByText} = renderComponent({
+			activeItemId: '11-container',
+			rootItemChildren: ['04-fragment'],
+		});
+
+		expect(getByText('Fragment 1')).toBeInTheDocument();
+	});
+
+	it('uses default labels for containers, columns, rows', () => {
+		const {getAllByText} = renderComponent({
+			activeItemId: '11-container',
+			rootItemChildren: ['01-container', '02-row', '03-column'],
+		});
+
+		['container', 'row', 'column'].forEach((itemLabel) =>
+			getAllByText(
+				LAYOUT_DATA_ITEM_TYPE_LABELS[itemLabel]
+			).forEach((element) => expect(element).toBeInTheDocument())
+		);
+	});
+
+	it('sets activeItemId as selected item', () => {
+		const {getByLabelText} = renderComponent({
+			activeItemId: '11-container',
+		});
+
+		expect(getByLabelText('Collapse container')).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+	});
+
+	it('disables items that are in masterLayout', () => {
+		const {getByLabelText} = renderComponent();
+		const button = getByLabelText('select-x-container');
+		expect(button.parentElement).toHaveAttribute('aria-disabled', 'true');
+	});
+
+	it('allows removing items of certain types', () => {
+		const {queryByLabelText} = renderComponent({
+			activeItemId: '11-container',
+			rootItemChildren: [
+				'01-container',
+				'02-row',
+				'03-column',
+				'04-fragment',
+			],
+		});
+
+		expect(queryByLabelText('remove-x-container')).toBeInTheDocument();
+		expect(queryByLabelText('remove-x-grid')).toBeInTheDocument();
+		expect(queryByLabelText('remove-x-module')).toBe(null);
+		expect(queryByLabelText('remove-x-Fragment 1')).toBeInTheDocument();
+	});
+
+	it('scans fragments editables', () => {
+		const {queryByLabelText} = renderComponent({
+			activeItemId: '04-fragment',
+			rootItemChildren: ['04-fragment'],
+		});
+
+		expect(queryByLabelText('select-x-05-editable')).toBeInTheDocument();
+		expect(queryByLabelText('remove-x-05-editable')).toBe(null);
+	});
+
+	it('sets element as active item', () => {
+		const {getByLabelText} = renderComponent({
+			activeItemId: '03-column',
+		});
+		const button = getByLabelText('select-x-grid');
+
+		userEvent.click(button);
+
+		expect(button.parentElement).toHaveAttribute('aria-selected', 'true');
+	});
+
+	it('sets element as active item when it is a fragment', () => {
+		const {getByLabelText} = renderComponent({
+			activeItemId: '03-column',
+		});
+		const button = getByLabelText('select-x-Fragment 1');
+
+		userEvent.click(button);
+
+		expect(button.parentElement).toHaveAttribute('aria-selected', 'true');
+	});
+
+	it('sets element as active item when it is a column', () => {
+		const {getByLabelText} = renderComponent({
+			activeItemId: '02-row',
+		});
+		const button = getByLabelText('select-x-module');
+
+		userEvent.click(button);
+
+		expect(button.parentElement).toHaveAttribute('aria-selected', 'false');
+	});
+
+	it('does not allow removing items if user has no permissions', () => {
+		const {queryByLabelText} = renderComponent({
+			hasUpdatePermissions: false,
+			rootItemChildren: ['01-container', '02-row', '04-fragment'],
+		});
+
+		expect(queryByLabelText('remove-x-container')).toBe(null);
+		expect(queryByLabelText('remove-x-grid')).toBe(null);
+		expect(queryByLabelText('remove-x-Fragment 1')).toBe(null);
+	});
+
+	it('does not allow removing items if viewport is not desktop', () => {
+		const {queryByLabelText} = renderComponent({
+			activeItemId: '11-container',
+			rootItemChildren: ['01-container', '02-row', '04-fragment'],
+			viewportSize: VIEWPORT_SIZES.portraitMobile,
+		});
+
+		expect(queryByLabelText('remove-x-container')).toBe(null);
+		expect(queryByLabelText('remove-x-grid')).toBe(null);
+		expect(queryByLabelText('remove-x-Fragment 1')).toBe(null);
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
@@ -16,7 +16,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
 import {CommonStyles} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles';
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
+import {CommonStyles} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles';
+
+const STATE = {
+	availableSegmentsExperiences: {
+		0: {
+			hasLockedSegmentsExperiment: false,
+			name: 'Default Experience',
+			priority: -1,
+			segmentsEntryId: 'test-segment-id-00',
+			segmentsExperienceId: '0',
+			segmentsExperimentStatus: undefined,
+			segmentsExperimentURL: 'https//:default-experience.com',
+		},
+	},
+	segmentsExperienceId: '0',
+	selectedViewportSize: 'desktop',
+};
+
+const renderComponent = ({
+	state = STATE,
+	dispatch = () => {},
+	itemConfig = {},
+	itemType = '',
+}) =>
+	render(
+		<StoreAPIContextProvider
+			dispatch={dispatch}
+			getState={() => ({...STATE, ...state})}
+		>
+			<CommonStyles
+				commonStylesValues={{}}
+				item={{
+					children: [],
+					config: {
+						styles: {},
+						tablet: {styles: {}},
+						...itemConfig,
+					},
+					itemId: '0',
+					parentId: '',
+					type: itemType,
+				}}
+			/>
+		</StoreAPIContextProvider>
+	);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableLanguages: {
+				ar_SA: {
+					default: false,
+					displayName: 'Arabic (Saudi Arabia)',
+					languageIcon: 'ar-sa',
+					languageId: 'ar_SA',
+					w3cLanguageId: 'ar-SA',
+				},
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+				es_ES: {
+					default: true,
+					displayName: 'Spanish (Spain)',
+					languageIcon: 'es-es',
+					languageId: 'es_ES',
+					w3cLanguageId: 'es-ES',
+				},
+			},
+			availableViewportSizes: {
+				desktop: {label: 'Desktop'},
+				tablet: {label: 'tablet'},
+			},
+			commonStyles: [
+				{
+					label: 'margin',
+					styles: [
+						{
+							dataType: 'string',
+							defaultValue: '0',
+							dependencies: [],
+							displaySize: 'small',
+							label: 'margin-left',
+							name: 'marginLeft',
+							responsive: true,
+							type: 'select',
+							validValues: [
+								{
+									label: '0',
+									value: '0',
+								},
+								{
+									label: '1',
+									value: '1',
+								},
+							],
+						},
+						{
+							dataType: 'string',
+							defaultValue: '0',
+							dependencies: [],
+							displaySize: 'small',
+							label: 'margin-right',
+							name: 'marginRight',
+							responsive: true,
+							type: 'select',
+							validValues: [
+								{
+									label: '0',
+									value: '0',
+								},
+								{
+									label: '1',
+									value: '1',
+								},
+							],
+						},
+					],
+				},
+			],
+			defaultLanguageId: 'es_ES',
+			defaultSegmentsExperienceId: '0',
+			responsiveEnabled: true,
+		},
+	})
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig',
+	() => jest.fn()
+);
+
+describe('CommonStyles', () => {
+	afterEach(() => {
+		cleanup();
+		updateItemConfig.mockClear();
+	});
+
+	it('shows common styles panel', async () => {
+		const {getByText} = renderComponent({});
+
+		expect(getByText('common-styles')).toBeInTheDocument();
+	});
+
+	it('allows changing common styles for a given viewport', async () => {
+		const {getByLabelText} = renderComponent({
+			state: {selectedViewportSize: 'tablet'},
+		});
+		const input = getByLabelText('margin-left');
+
+		await fireEvent.change(input, {
+			target: {value: '1'},
+		});
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {
+				tablet: {
+					styles: {
+						marginLeft: '1',
+					},
+				},
+			},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+
+	it('disables left and right margin selecting fixed width for containers', async () => {
+		const {getByLabelText} = renderComponent({
+			itemConfig: {widthType: 'fixed'},
+			itemType: 'container',
+		});
+
+		const marginLeftInput = getByLabelText('margin-left');
+
+		const marginRightInput = getByLabelText('margin-right');
+
+		expect(marginLeftInput.disabled).toBe(true);
+
+		expect(marginRightInput.disabled).toBe(true);
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerStylesPanel.test.js
@@ -18,7 +18,7 @@ import React from 'react';
 
 import {CONTAINER_DISPLAY_OPTIONS} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/containerDisplayOptions';
 import {VIEWPORT_SIZES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
 import {ContainerStylesPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerStylesPanel';
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerStylesPanel.test.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import {CONTAINER_DISPLAY_OPTIONS} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/containerDisplayOptions';
+import {VIEWPORT_SIZES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
+import {ContainerStylesPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerStylesPanel';
+
+const renderComponent = ({
+	dispatch = () => {},
+	itemConfig = {
+		tablet: {styles: {}},
+	},
+	selectedViewportSize = VIEWPORT_SIZES.desktop,
+} = {}) =>
+	render(
+		<StoreAPIContextProvider
+			dispatch={dispatch}
+			getState={() => ({
+				segmentsExperienceId: '0',
+				selectedViewportSize,
+			})}
+		>
+			<ContainerStylesPanel
+				item={{
+					children: [],
+					config: itemConfig,
+					itemId: '0',
+					parentId: '',
+					type: '',
+				}}
+			/>
+		</StoreAPIContextProvider>
+	);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig',
+	() => jest.fn()
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableViewportSizes: {
+				desktop: {label: 'Desktop', sizeId: 'desktop'},
+				mobile: {label: 'Mobile', sizeId: 'mobile'},
+				tablet: {label: 'Tablet', sizeId: 'tablet'},
+			},
+			commonStyles: [],
+			defaultSegmentsExperienceId: '0',
+			marginOptions: [],
+			paddingOptions: [],
+		},
+	})
+);
+
+describe('ContainerStylesPanel', () => {
+	afterEach(() => {
+		cleanup();
+		updateItemConfig.mockClear();
+	});
+
+	it('renders correctly', () => {
+		const {getByLabelText} = renderComponent();
+
+		expect(getByLabelText('container-width')).toBeInTheDocument();
+	});
+
+	it('shows custom styles panel', async () => {
+		const {getByText} = renderComponent({});
+
+		expect(getByText('custom-styles')).toBeInTheDocument();
+	});
+
+	it('calls dispatch method when changing the container width', async () => {
+		const {getByLabelText} = renderComponent();
+
+		const containerWidthSelect = getByLabelText('container-width');
+
+		await fireEvent.change(containerWidthSelect, {
+			target: {value: 'fixed'},
+		});
+
+		expect(updateItemConfig).toBeCalledWith(
+			expect.objectContaining({
+				itemConfig: {
+					widthType: 'fixed',
+				},
+			})
+		);
+	});
+
+	it('calls dispatch method when changing the content display', async () => {
+		const {getByLabelText} = renderComponent();
+
+		const contentDisplaySelect = getByLabelText('content-display');
+
+		await fireEvent.change(contentDisplaySelect, {
+			target: {value: 'flex-row'},
+		});
+
+		expect(updateItemConfig).toBeCalledWith(
+			expect.objectContaining({
+				itemConfig: {
+					contentDisplay: 'flex-row',
+				},
+			})
+		);
+	});
+
+	it('shows Align and Justify selects when item is flex container', async () => {
+		const {getByLabelText} = renderComponent({
+			itemConfig: {contentDisplay: CONTAINER_DISPLAY_OPTIONS.flexRow},
+		});
+
+		expect(getByLabelText('align-items')).toBeInTheDocument();
+		expect(getByLabelText('justify-content')).toBeInTheDocument();
+	});
+
+	it('sets correct default values for Align and Justify when flex is selected', async () => {
+		const {getByLabelText} = renderComponent({
+			itemConfig: {contentDisplay: CONTAINER_DISPLAY_OPTIONS.flexRow},
+		});
+
+		const alignInput = getByLabelText('align-items');
+		const justifyInput = getByLabelText('justify-content');
+
+		expect(alignInput.value).toBe('align-items-stretch');
+		expect(justifyInput.value).toBe('justify-content-start');
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
@@ -77,6 +77,8 @@ function getStateWithConfig(config = {}) {
 		},
 		languageId: 'en_US',
 		mappedInfoItems: [],
+		mappingFields: {},
+		pageContents: [],
 		segmentsExperienceId: 0,
 	};
 }

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
@@ -25,8 +25,8 @@ import React from 'react';
 
 import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
 import {EDITABLE_TYPES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableTypes';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import serviceFetch from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/serviceFetch';
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
 import updateEditableValues from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues';
 import EditableLinkPanel from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel';
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {
+	act,
+	cleanup,
+	fireEvent,
+	getByLabelText,
+	render,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
+import {EDITABLE_TYPES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableTypes';
+import serviceFetch from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/serviceFetch';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import updateEditableValues from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues';
+import EditableLinkPanel from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel';
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/serviceFetch',
+	() => jest.fn(() => Promise.resolve({fieldValue: 'fieldValue'}))
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableLanguages: {
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+			},
+		},
+	})
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues',
+	() => jest.fn()
+);
+
+const getEditableConfig = (editableValues) => {
+	return editableValues[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]['editable-id-0']
+		.config;
+};
+
+function getStateWithConfig(config = {}) {
+	return {
+		fragmentEntryLinks: {
+			0: {
+				editableValues: {
+					[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {
+						'editable-id-0': {
+							config,
+						},
+					},
+				},
+			},
+		},
+		languageId: 'en_US',
+		mappedInfoItems: [],
+		segmentsExperienceId: 0,
+	};
+}
+
+function renderLinkPanel(
+	{state = getStateWithConfig(), type = EDITABLE_TYPES.text} = {},
+	dispatch = () => {}
+) {
+	return render(
+		<StoreAPIContextProvider dispatch={dispatch} getState={() => state}>
+			<EditableLinkPanel
+				item={{
+					editableId: 'editable-id-0',
+					fragmentEntryLinkId: '0',
+					itemId: '',
+					type,
+				}}
+			/>
+		</StoreAPIContextProvider>,
+		{
+			baseElement: document.body,
+		}
+	);
+}
+
+describe('EditableLinkPanel', () => {
+	afterEach(() => {
+		cleanup();
+
+		serviceFetch.mockClear();
+		updateEditableValues.mockClear();
+	});
+
+	it('renders manual selection panel', () => {
+		const {getByLabelText, getByText, queryByText} = renderLinkPanel();
+
+		expect(getByText('link')).toBeInTheDocument();
+		expect(getByLabelText('url')).toBeInTheDocument();
+		expect(getByText('open-in-a-new-tab')).toBeInTheDocument();
+
+		expect(queryByText('content')).not.toBeInTheDocument();
+	});
+
+	it('shows mapping panel when changing link source', async () => {
+		const {getByLabelText, queryByLabelText} = renderLinkPanel();
+
+		const sourceTypeInput = getByLabelText('link');
+
+		await act(async () => {
+			fireEvent.change(sourceTypeInput, {
+				target: {value: 'fromContentField'},
+			});
+		});
+
+		expect(getByLabelText('content')).toBeInTheDocument();
+
+		expect(queryByLabelText('url')).not.toBeInTheDocument();
+	});
+
+	it('shows the url and target values when previously saved', () => {
+		const {getByLabelText} = renderLinkPanel({
+			state: getStateWithConfig({
+				href: 'http://liferay.com',
+				target: '_blank',
+			}),
+		});
+
+		expect(getByLabelText('url')).toHaveValue('http://liferay.com');
+		expect(getByLabelText('open-in-a-new-tab')).toBeChecked();
+	});
+
+	it('does not check the target value when is different from _blank', () => {
+		const {getByLabelText} = renderLinkPanel({
+			state: getStateWithConfig({
+				target: '_self',
+			}),
+		});
+
+		expect(getByLabelText('open-in-a-new-tab')).not.toBeChecked();
+	});
+
+	it('shows mapping panel when editable link is mapped', async () => {
+		await act(async () => {
+			renderLinkPanel({
+				state: getStateWithConfig({
+					classNameId: 1,
+					classPK: 1,
+					fieldId: 'text',
+					target: '_blank',
+				}),
+			});
+		});
+
+		expect(getByLabelText(document.body, 'content')).toBeInTheDocument();
+		expect(
+			getByLabelText(document.body, 'open-in-a-new-tab')
+		).toBeChecked();
+	});
+
+	it('shows mapping panel when editable link is mapped', async () => {
+		await act(async () => {
+			renderLinkPanel({
+				state: getStateWithConfig({
+					classNameId: 1,
+					classPK: 1,
+					fieldId: 'text',
+					target: '_blank',
+				}),
+			});
+		});
+
+		expect(getByLabelText(document.body, 'content')).toBeInTheDocument();
+		expect(
+			getByLabelText(document.body, 'open-in-a-new-tab')
+		).toBeChecked();
+	});
+
+	it('shows mapped url when is available', async () => {
+		serviceFetch.mockImplementation(() =>
+			Promise.resolve({fieldValue: 'value'})
+		);
+
+		await act(async () => {
+			renderLinkPanel({
+				state: getStateWithConfig({
+					classNameId: 1,
+					classPK: 1,
+					fieldId: 'text',
+					target: '_blank',
+				}),
+			});
+		});
+
+		expect(getByLabelText(document.body, 'content')).toBeInTheDocument();
+		expect(getByLabelText(document.body, 'url')).toBeInTheDocument();
+		expect(getByLabelText(document.body, 'url')).toHaveValue('value');
+		expect(
+			getByLabelText(document.body, 'open-in-a-new-tab')
+		).toBeChecked();
+	});
+
+	it('clear the config when changing source type', async () => {
+		let editableConfig;
+
+		updateEditableValues.mockImplementation(({editableValues}) => {
+			editableConfig = getEditableConfig(editableValues);
+		});
+
+		await act(async () => {
+			renderLinkPanel({
+				state: getStateWithConfig({
+					classNameId: 1,
+					classPK: 1,
+					fieldId: 'text',
+					target: '_blank',
+				}),
+			});
+		});
+
+		await act(async () => {
+			const sourceTypeInput = getByLabelText(document.body, 'link');
+
+			fireEvent.change(sourceTypeInput, {
+				target: {value: 'manual'},
+			});
+		});
+
+		expect(editableConfig).toEqual({
+			alt: '',
+			imageConfiguration: {},
+			mapperType: 'link',
+		});
+
+		expect(getByLabelText(document.body, 'url')).toHaveValue('');
+		expect(
+			getByLabelText(document.body, 'open-in-a-new-tab')
+		).toBeChecked();
+	});
+
+	it('calls dispatch with the href value typed in manual mode', async () => {
+		let editableConfig;
+		updateEditableValues.mockImplementation(({editableValues}) => {
+			editableConfig = getEditableConfig(editableValues);
+		});
+
+		const {getByLabelText} = renderLinkPanel({
+			state: getStateWithConfig({}),
+		});
+
+		const hrefInput = getByLabelText('url');
+
+		userEvent.type(hrefInput, 'http://google.com');
+
+		fireEvent.blur(hrefInput);
+
+		expect(updateEditableValues).toHaveBeenCalled();
+
+		expect(editableConfig).toEqual({
+			en_US: {
+				href: 'http://google.com',
+				target: '',
+			},
+			mapperType: 'link',
+		});
+	});
+
+	it('calls dispatch without mapperType when editable type is link', async () => {
+		let editableConfig;
+		updateEditableValues.mockImplementation(({editableValues}) => {
+			editableConfig = getEditableConfig(editableValues);
+		});
+
+		const {getByLabelText} = renderLinkPanel({
+			state: getStateWithConfig({}),
+			type: EDITABLE_TYPES.link,
+		});
+
+		const hrefInput = getByLabelText('url');
+
+		userEvent.type(hrefInput, 'http://google.com');
+
+		fireEvent.blur(hrefInput);
+
+		expect(updateEditableValues).toHaveBeenCalled();
+
+		expect(editableConfig).toEqual({
+			en_US: {
+				href: 'http://google.com',
+				target: '',
+			},
+		});
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
@@ -21,8 +21,8 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 
 import {VIEWPORT_SIZES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import FragmentService from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/FragmentService';
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
 import {FragmentGeneralPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentGeneralPanel';
 
 jest.mock(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
@@ -1,0 +1,361 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+
+import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
+import {FREEMARKER_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/freemarkerFragmentEntryProcessor';
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+
+import {VIEWPORT_SIZES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
+import FragmentService from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/FragmentService';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {FragmentGeneralPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentGeneralPanel';
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableLanguages: {
+				ar_SA: {
+					default: false,
+					displayName: 'Arabic (Saudi Arabia)',
+					languageIcon: 'ar-sa',
+					languageId: 'ar_SA',
+					w3cLanguageId: 'ar-SA',
+				},
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+				es_ES: {
+					default: true,
+					displayName: 'Spanish (Spain)',
+					languageIcon: 'es-es',
+					languageId: 'es_ES',
+					w3cLanguageId: 'es-ES',
+				},
+			},
+			availableViewportSizes: {
+				desktop: {label: 'Desktop', sizeId: 'desktop'},
+				mobile: {label: 'Mobile', sizeId: 'mobile'},
+				tablet: {label: 'Tablet', sizeId: 'tablet'},
+			},
+			defaultLanguageId: 'es_ES',
+			defaultSegmentsExperienceId: '0',
+		},
+	})
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/serviceFetch',
+	() => jest.fn(() => Promise.resolve({}))
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/FragmentService',
+	() => ({
+		renderFragmentEntryLinkContent: jest.fn(() => Promise.resolve({})),
+		updateConfigurationValues: jest.fn(() => Promise.resolve({})),
+	})
+);
+
+const FRAGMENT_ENTRY_LINK_ID = '1';
+
+const defaultFragmentEntryLink = (localizable = false) => ({
+	comments: [],
+	configuration: {
+		fieldSets: [
+			{
+				fields: [
+					{
+						dataType: 'string',
+						defaultValue: 'h1',
+						description: '',
+						label: 'Heading Level',
+						localizable,
+						name: 'headingLevel',
+						type: 'select',
+						typeOptions: {
+							validValues: [
+								{label: 'H1', value: 'h1'},
+								{label: 'H2', value: 'h2'},
+								{label: 'H3', value: 'h3'},
+								{label: 'H4', value: 'h4'},
+							],
+						},
+					},
+				],
+				label: '',
+			},
+		],
+	},
+	defaultConfigurationValues: {
+		headingLevel: 'h1',
+	},
+	editableValues: {
+		[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+		[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {},
+	},
+	fragmentEntryLinkId: FRAGMENT_ENTRY_LINK_ID,
+	name: 'Heading',
+});
+
+const item = {
+	children: [],
+	config: {
+		fragmentEntryLinkId: FRAGMENT_ENTRY_LINK_ID,
+	},
+	itemId: '1',
+	parentId: '',
+	type: '',
+};
+
+const mockDispatch = jest.fn((a) => {
+	if (typeof a === 'function') {
+		return a(mockDispatch);
+	}
+});
+
+const renderGeneralPanel = ({
+	segmentsExperienceId,
+	fragmentEntryLink = defaultFragmentEntryLink(),
+}) => {
+	const state = {
+		availableSegmentsExperiences: {
+			0: {
+				hasLockedSegmentsExperiment: false,
+				name: 'Default Experience',
+				priority: -1,
+				segmentsEntryId: 'test-segment-id-00',
+				segmentsExperienceId: '0',
+				segmentsExperimentStatus: undefined,
+				segmentsExperimentURL: 'https//:default-experience.com',
+			},
+			1: {
+				hasLockedSegmentsExperiment: false,
+				languageIds: ['es_ES', 'en_US'],
+				name: 'Experience #1',
+				priority: 3,
+				segmentsEntryId: 'test-segment-id-00',
+				segmentsExperienceId: 'test-experience-id-01',
+				segmentsExperimentStatus: undefined,
+				segmentsExperimentURL: 'https//:experience-1.com',
+			},
+			2: {
+				hasLockedSegmentsExperiment: false,
+				languageIds: ['es_ES', 'en_US', 'ar_SA'],
+				name: 'Experience #2',
+				priority: 1,
+				segmentsEntryId: 'test-segment-id-01',
+				segmentsExperienceId: 'test-experience-id-02',
+				segmentsExperimentStatus: undefined,
+				segmentsExperimentURL: 'https//:experience-2.com',
+			},
+		},
+		defaultSegmentsExperienceId: '0',
+		fragmentEntryLinks: {[FRAGMENT_ENTRY_LINK_ID]: fragmentEntryLink},
+		languageId: 'en_US',
+		segmentsExperienceId,
+		selectedViewportSize: VIEWPORT_SIZES.desktop,
+	};
+
+	return render(
+		<StoreAPIContextProvider dispatch={mockDispatch} getState={() => state}>
+			<FragmentGeneralPanel item={item} />
+		</StoreAPIContextProvider>
+	);
+};
+
+describe('FragmentGeneralPanel', () => {
+	afterEach(() => {
+		cleanup();
+
+		FragmentService.updateConfigurationValues.mockClear();
+		FragmentService.renderFragmentEntryLinkContent.mockClear();
+	});
+
+	it('does not prefix values with segments if we do not have experiences', async () => {
+		const {getByLabelText} = renderGeneralPanel({
+			segmentsExperienceId: null,
+		});
+
+		const input = getByLabelText('Heading Level');
+
+		await fireEvent.change(input, {
+			target: {value: 'h2'},
+		});
+
+		expect(FragmentService.updateConfigurationValues).toBeCalledWith(
+			expect.objectContaining({
+				configurationValues: {
+					[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+					[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {
+						headingLevel: 'h2',
+					},
+				},
+			})
+		);
+	});
+
+	it('does not show flag icon when localizable property is false', async () => {
+		const {getByLabelText} = renderGeneralPanel({
+			fragmentEntryLink: defaultFragmentEntryLink(false),
+			segmentsExperienceId: null,
+		});
+
+		const input = getByLabelText('Heading Level');
+
+		const wrapperDiv = input.parentElement.parentElement.parentElement;
+
+		expect(wrapperDiv.querySelector('.sr-only')).toBeNull();
+	});
+
+	it('prefix values with segments when we have experiences', async () => {
+		const {getByLabelText} = renderGeneralPanel({
+			segmentsExperienceId: '1',
+		});
+
+		const input = getByLabelText('Heading Level');
+
+		await fireEvent.change(input, {
+			target: {value: 'h2'},
+		});
+
+		expect(FragmentService.updateConfigurationValues).toBeCalledWith(
+			expect.objectContaining({
+				configurationValues: {
+					[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+					[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {
+						headingLevel: 'h2',
+					},
+				},
+			})
+		);
+	});
+
+	it('prefix values with default experience when segmentsExperience is null', async () => {
+		const {getByLabelText} = renderGeneralPanel({
+			segmentsExperienceId: null,
+		});
+
+		const input = getByLabelText('Heading Level');
+
+		await fireEvent.change(input, {
+			target: {value: 'h2'},
+		});
+
+		expect(FragmentService.updateConfigurationValues).toBeCalledWith(
+			expect.objectContaining({
+				configurationValues: {
+					[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+					[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {
+						headingLevel: 'h2',
+					},
+				},
+			})
+		);
+	});
+
+	it('merges configuration values when a new one is added', async () => {
+		const fragmentEntryLink = {
+			comments: [],
+			configuration: {
+				fieldSets: [
+					{
+						fields: [
+							{
+								dataType: 'string',
+								defaultValue: 'h1',
+								description: '',
+								label: 'Heading Level',
+								name: 'headingLevel',
+								type: 'select',
+								typeOptions: {
+									validValues: [
+										{label: 'H1', value: 'h1'},
+										{label: 'H2', value: 'h2'},
+										{label: 'H3', value: 'h3'},
+										{label: 'H4', value: 'h4'},
+									],
+								},
+							},
+							{
+								dataType: 'string',
+								defaultValue: 'default',
+								description: '',
+								label: 'Another thing',
+								name: 'anotherThing',
+								type: 'text',
+							},
+						],
+						label: '',
+					},
+				],
+			},
+			defaultConfigurationValues: {
+				headingLevel: 'h1',
+			},
+			editableValues: {
+				[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+				[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {
+					anotherThing: 'test',
+				},
+			},
+			fragmentEntryLinkId: FRAGMENT_ENTRY_LINK_ID,
+			name: 'Heading',
+		};
+
+		const {getByLabelText} = renderGeneralPanel({
+			fragmentEntryLink,
+			segmentsExperienceId: '0',
+		});
+
+		const input = getByLabelText('Heading Level');
+
+		await fireEvent.change(input, {
+			target: {value: 'h2'},
+		});
+
+		expect(FragmentService.updateConfigurationValues).toBeCalledWith(
+			expect.objectContaining({
+				configurationValues: {
+					[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+					[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {
+						anotherThing: 'test',
+						headingLevel: 'h2',
+					},
+				},
+			})
+		);
+	});
+
+	it('shows corresponding flag icon when localizable property is true', async () => {
+		const {getByLabelText} = renderGeneralPanel({
+			fragmentEntryLink: defaultFragmentEntryLink(true),
+			segmentsExperienceId: null,
+		});
+
+		const input = getByLabelText('Heading Level');
+
+		const wrapperDiv = input.parentElement.parentElement.parentElement;
+
+		expect(wrapperDiv.querySelector('.sr-only')).toHaveTextContent('en-US');
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
@@ -19,7 +19,7 @@ import React from 'react';
 import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
 import {FREEMARKER_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/freemarkerFragmentEntryProcessor';
 import {VIEWPORT_SIZES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
 import {FragmentStylesPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel';
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/editableFragmentEntryProcessor';
+import {FREEMARKER_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/freemarkerFragmentEntryProcessor';
+import {VIEWPORT_SIZES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
+import {FragmentStylesPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel';
+
+const FRAGMENT_ENTRY_LINK_ID = '1';
+
+const fragmentEntryLinkWithStyles = {
+	comments: [],
+	configuration: {
+		fieldSets: [
+			{
+				configurationRole: 'style',
+				fields: [
+					{
+						dataType: 'string',
+						defaultValue: '1',
+						description: '',
+						label: 'Custom Style',
+						name: 'customStyle',
+						type: 'select',
+						typeOptions: {
+							validValues: [
+								{label: '0', value: '0'},
+								{label: '1', value: '1'},
+							],
+						},
+					},
+				],
+				label: '',
+			},
+		],
+	},
+	defaultConfigurationValues: {
+		customStyle: '1',
+	},
+	editableValues: {
+		[EDITABLE_FRAGMENT_ENTRY_PROCESSOR]: {},
+		[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: {},
+	},
+	fragmentEntryLinkId: FRAGMENT_ENTRY_LINK_ID,
+	name: 'Fragment',
+};
+
+const renderComponent = ({
+	dispatch = () => {},
+	fragmentEntryLink = {},
+	selectedViewportSize = VIEWPORT_SIZES.desktop,
+} = {}) =>
+	render(
+		<StoreAPIContextProvider
+			dispatch={dispatch}
+			getState={() => ({
+				availableSegmentsExperiences: {
+					0: {
+						hasLockedSegmentsExperiment: false,
+						name: 'Default Experience',
+						priority: -1,
+						segmentsEntryId: 'test-segment-id-00',
+						segmentsExperienceId: '0',
+						segmentsExperimentStatus: undefined,
+						segmentsExperimentURL: 'https//:default-experience.com',
+					},
+				},
+				fragmentEntryLinks: {
+					[FRAGMENT_ENTRY_LINK_ID]: fragmentEntryLink,
+				},
+				segmentsExperienceId: '0',
+				selectedViewportSize,
+			})}
+		>
+			<FragmentStylesPanel
+				item={{
+					children: [],
+					config: {
+						fragmentEntryLinkId: FRAGMENT_ENTRY_LINK_ID,
+						tablet: {styles: {}},
+					},
+					itemId: '0',
+					parentId: '',
+					type: '',
+				}}
+			/>
+		</StoreAPIContextProvider>
+	);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig',
+	() => jest.fn()
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableLanguages: {
+				ar_SA: {
+					default: false,
+					displayName: 'Arabic (Saudi Arabia)',
+					languageIcon: 'ar-sa',
+					languageId: 'ar_SA',
+					w3cLanguageId: 'ar-SA',
+				},
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+				es_ES: {
+					default: true,
+					displayName: 'Spanish (Spain)',
+					languageIcon: 'es-es',
+					languageId: 'es_ES',
+					w3cLanguageId: 'es-ES',
+				},
+			},
+			availableViewportSizes: {
+				desktop: {label: 'Desktop', sizeId: 'desktop'},
+				mobile: {label: 'Mobile', sizeId: 'mobile'},
+				tablet: {label: 'Tablet', sizeId: 'tablet'},
+			},
+			commonStyles: [
+				{
+					label: 'margin',
+					styles: [
+						{
+							dataType: 'string',
+							defaultValue: '0',
+							dependencies: [],
+							displaySize: 'small',
+							label: 'margin-top',
+							name: 'marginTop',
+							responsive: true,
+							responsiveTemplate: 'mt{viewport}{value}',
+							type: 'select',
+							validValues: [
+								{
+									label: '0',
+									value: '0',
+								},
+								{
+									label: '1',
+									value: '1',
+								},
+							],
+						},
+					],
+				},
+			],
+			defaultLanguageId: 'es_ES',
+			defaultSegmentsExperienceId: '0',
+			marginOptions: [],
+			paddingOptions: [],
+		},
+	})
+);
+
+describe('FragmentStylesPanel', () => {
+	afterEach(() => {
+		cleanup();
+		updateItemConfig.mockClear();
+	});
+
+	it('does not show custom styles panel when there are no custom styles', async () => {
+		const {queryByText} = renderComponent({});
+
+		expect(queryByText('custom-styles')).not.toBeInTheDocument();
+	});
+
+	it('shows custom styles panel when there is at least one custom style', async () => {
+		const {getByText} = renderComponent({
+			fragmentEntryLink: fragmentEntryLinkWithStyles,
+		});
+
+		expect(getByText('custom-styles')).toBeInTheDocument();
+	});
+
+	it('allows changing custom styles for a given viewport', async () => {
+		const {getByLabelText} = renderComponent({
+			selectedViewportSize: VIEWPORT_SIZES.tablet,
+		});
+		const input = getByLabelText('margin-top');
+
+		await fireEvent.change(input, {
+			target: {value: '1'},
+		});
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {
+				tablet: {
+					styles: {
+						marginTop: '1',
+					},
+				},
+			},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.test.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import {ResizeContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/components/ResizeContext';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
+import updateRowColumns from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns';
+import {RowGeneralPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel';
+
+const ITEM_CONFIG = {
+	gutters: true,
+	modulesPerRow: 2,
+	numberOfColumns: 2,
+	verticalAlignment: 'top',
+};
+
+const RESIZE_CONTEXT_STATE = {
+	customRow: false,
+	resizing: false,
+	setCustomRow: () => null,
+	setResizing: () => null,
+	setUpdatedLayoutData: () => null,
+	updatedLayoutData: null,
+};
+
+const STATE = {
+	segmentsExperienceId: '0',
+	selectedViewportSize: 'desktop',
+};
+
+const renderComponent = ({
+	config = ITEM_CONFIG,
+	state = STATE,
+	contextState = RESIZE_CONTEXT_STATE,
+	dispatch = () => {},
+}) =>
+	render(
+		<StoreAPIContextProvider
+			dispatch={dispatch}
+			getState={() => ({...STATE, ...state})}
+		>
+			<ResizeContextProvider
+				value={{...RESIZE_CONTEXT_STATE, ...contextState}}
+			>
+				<RowGeneralPanel
+					item={{
+						children: [],
+						config: {...ITEM_CONFIG, ...config},
+						itemId: '0',
+						parentId: '',
+						type: '',
+					}}
+				/>
+			</ResizeContextProvider>
+		</StoreAPIContextProvider>
+	);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableViewportSizes: {
+				desktop: {label: 'Desktop'},
+				landscapeMobile: {label: 'landscapeMobile'},
+			},
+		},
+	})
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig',
+	() => jest.fn()
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns',
+	() => jest.fn()
+);
+
+describe('RowGeneralPanel', () => {
+	afterEach(() => {
+		cleanup();
+		updateItemConfig.mockClear();
+		updateRowColumns.mockClear();
+	});
+
+	it('allows changing the number of modules of a grid', async () => {
+		const {getByLabelText} = renderComponent({});
+		const input = getByLabelText('number-of-modules');
+
+		await fireEvent.change(input, {
+			target: {value: '6'},
+		});
+
+		expect(updateRowColumns).toHaveBeenCalledWith({
+			itemId: '0',
+			numberOfColumns: 6,
+			segmentsExperienceId: '0',
+			viewportSizeId: 'desktop',
+		});
+	});
+
+	it('allows changing the gutter', async () => {
+		const {getByLabelText} = renderComponent({});
+		const input = getByLabelText('show-gutter');
+
+		await fireEvent.click(input);
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {gutters: false},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.test.js
@@ -16,8 +16,8 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
-import {ResizeContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/components/ResizeContext';
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {ResizeContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/ResizeContext';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
 import updateRowColumns from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns';
 import {RowGeneralPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel';

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel.test.js
@@ -16,9 +16,9 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
-import {ResizeContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/components/ResizeContext';
 import {config} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/index';
-import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import {ResizeContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/ResizeContext';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
 import updateRowColumns from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns';
 import {RowStylesPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel';

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel.test.js
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import {ResizeContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/components/ResizeContext';
+import {config} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/index';
+import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
+import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
+import updateRowColumns from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns';
+import {RowStylesPanel} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel';
+
+const ITEM_CONFIG = {
+	gutters: true,
+	modulesPerRow: 2,
+	numberOfColumns: 2,
+	styles: {},
+	tablet: {styles: {}},
+	verticalAlignment: 'top',
+};
+
+const RESIZE_CONTEXT_STATE = {
+	resizing: false,
+	setResizing: () => null,
+	setUpdatedLayoutData: () => null,
+	updatedLayoutData: null,
+};
+
+const STATE = {
+	layoutData: {
+		items: {
+			'item-1': {
+				config: {
+					size: 6,
+				},
+			},
+			'item-2': {
+				config: {
+					size: 6,
+				},
+			},
+		},
+	},
+	segmentsExperienceId: '0',
+	selectedViewportSize: 'desktop',
+};
+
+const renderComponent = ({
+	config = {},
+	state = STATE,
+	contextState = RESIZE_CONTEXT_STATE,
+	dispatch = () => {},
+}) =>
+	render(
+		<StoreAPIContextProvider
+			dispatch={dispatch}
+			getState={() => ({...STATE, ...state})}
+		>
+			<ResizeContextProvider
+				value={{...RESIZE_CONTEXT_STATE, ...contextState}}
+			>
+				<RowStylesPanel
+					item={{
+						children: ['item-1', 'item-2'],
+						config: {...ITEM_CONFIG, ...config},
+						itemId: '0',
+						parentId: '',
+						type: '',
+					}}
+				/>
+			</ResizeContextProvider>
+		</StoreAPIContextProvider>
+	);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
+	() => ({
+		config: {
+			availableViewportSizes: {
+				desktop: {label: 'Desktop'},
+				tablet: {label: 'tablet'},
+			},
+			commonStyles: [],
+			responsiveEnabled: true,
+		},
+	})
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig',
+	() => jest.fn()
+);
+
+jest.mock(
+	'../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns',
+	() => jest.fn()
+);
+
+describe('RowStylesPanel', () => {
+	afterEach(() => {
+		cleanup();
+		config.responsiveEnabled = true;
+		updateItemConfig.mockClear();
+		updateRowColumns.mockClear();
+	});
+
+	it('shows custom styles panel', async () => {
+		const {getByText} = renderComponent({});
+
+		expect(getByText('custom-styles')).toBeInTheDocument();
+	});
+
+	it('allows changing the modules per row', async () => {
+		const {getByLabelText} = renderComponent({});
+		const input = getByLabelText('layout');
+
+		await fireEvent.change(input, {
+			target: {value: '2'},
+		});
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {
+				modulesPerRow: 2,
+			},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+
+	it('allows custom value in modules per row when row is customized', async () => {
+		const {getByLabelText} = renderComponent({});
+		const input = getByLabelText('layout');
+
+		expect(input).toHaveValue('2');
+	});
+
+	it('change label to custom when the column configuration is customized', async () => {
+		const {getByLabelText} = renderComponent({
+			state: {
+				layoutData: {
+					items: {
+						'item-1': {
+							config: {
+								size: 5,
+							},
+						},
+						'item-2': {
+							config: {
+								size: 7,
+							},
+						},
+					},
+				},
+			},
+		});
+		const input = getByLabelText('layout');
+
+		expect(input).toHaveValue('custom');
+	});
+
+	it('allows changing the vertical alignment', async () => {
+		const {getByLabelText} = renderComponent({});
+		const input = getByLabelText('vertical-alignment');
+
+		await fireEvent.change(input, {
+			target: {value: 'middle'},
+		});
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {
+				verticalAlignment: 'middle',
+			},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+
+	it('allows inverse order when number of modules is 2 and modules per row is 1', async () => {
+		const {getByLabelText} = renderComponent({
+			config: {
+				modulesPerRow: 1,
+			},
+			state: {
+				layoutData: {
+					items: {
+						'item-1': {
+							config: {
+								size: 12,
+							},
+						},
+						'item-2': {
+							config: {
+								size: 12,
+							},
+						},
+					},
+				},
+			},
+		});
+		const input = getByLabelText('inverse-order');
+
+		await fireEvent.click(input);
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {
+				reverseOrder: true,
+			},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+
+	it('allows changing custom styles for a given viewport', async () => {
+		const {getByLabelText} = renderComponent({
+			state: {
+				selectedViewportSize: 'tablet',
+			},
+		});
+		const input = getByLabelText('layout');
+
+		await fireEvent.change(input, {
+			target: {value: '1'},
+		});
+
+		expect(updateItemConfig).toHaveBeenCalledWith({
+			itemConfig: {
+				tablet: {modulesPerRow: 1},
+			},
+			itemId: '0',
+			segmentsExperienceId: '0',
+		});
+	});
+});

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -354,7 +354,8 @@ public class AuthVerifierPipeline {
 							authVerifierResult.getUserId()));
 				}
 
-				return null;
+				authVerifierResult.setState(
+					AuthVerifierResult.State.UNSUCCESSFUL);
 			}
 
 			Map<String, Object> settings = _mergeSettings(

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -343,24 +343,15 @@ public class AuthVerifierPipeline {
 			User user = UserLocalServiceUtil.fetchUser(
 				authVerifierResult.getUserId());
 
-			if ((user == null) || !user.isActive()) {
+			if ((user != null) && !user.isActive()) {
 				if (_log.isDebugEnabled()) {
 					Class<?> authVerifierClass = authVerifier.getClass();
 
-					if (user == null) {
-						_log.debug(
-							StringBundler.concat(
-								"Auth verifier ", authVerifierClass.getName(),
-								" returned null user",
-								authVerifierResult.getUserId()));
-					}
-					else {
-						_log.debug(
-							StringBundler.concat(
-								"Auth verifier ", authVerifierClass.getName(),
-								" returned inactive user",
-								authVerifierResult.getUserId()));
-					}
+					_log.debug(
+						StringBundler.concat(
+							"Auth verifier ", authVerifierClass.getName(),
+							" returned inactive user",
+							authVerifierResult.getUserId()));
 				}
 
 				return null;

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -272,6 +272,14 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		String friendlyName = StringPool.BLANK;
 
 		if (nameMap != null) {
+			for (Map.Entry<Locale, String> entry : nameMap.entrySet()) {
+				String value = entry.getValue();
+
+				if (Validator.isNotNull(value)) {
+					nameMap.replace(entry.getKey(), StringUtil.trim(value));
+				}
+			}
+
 			groupKey = nameMap.get(LocaleUtil.getDefault());
 			friendlyName = nameMap.get(LocaleUtil.getDefault());
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -703,6 +703,23 @@ definition {
 		}
 	}
 
+	macro assertLocalizableFieldUnchecked {
+		AssertClick.assertPartialTextClickAt(
+			key_fieldFieldLabel = "${fieldFieldLabel}",
+			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
+			value1 = "${fieldFieldLabel}");
+
+		if (IsElementNotPresent(locator1 = "NavTab#ACTIVE_TAB_LINK", key_tab = "Advanced")) {
+			Navigator.gotoNavTab(navTab = "Advanced");
+		}
+
+		AssertElementPresent(
+			checkboxName = "Localizable",
+			locator1 = "Checkbox#ANY_CHECKBOX_UNCHECKED");
+
+		Click(locator1 = "Sidebar#BACK");
+	}
+
 	macro assertNonLocalizableField {
 		AssertElementPresent(
 			key_fieldName = "${fieldFieldName}",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Checkbox.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Checkbox.path
@@ -69,6 +69,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ANY_CHECKBOX_UNCHECKED</td>
+	<td>//label[contains(.,'${checkboxName}')]/input[@type='checkbox' and not(@checked)]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>BLOGS_ENTRY</td>
 	<td>//input[contains(@id,'BlogsEntry')]</td>
 	<td></td>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130936

Hello @SamZiemer ,

See LPS-130936 for issue description. Unless there are legitimate reasons, I do not see why we should allow leading and trailing white-spaces in group names. This causes issues as seen in LPS-130936 where you can have multiple sites with the exact same name, but are only differentiated by either trailing or leading white-spaces.