### PR TITLE
LPS-131302 Don't use simple view for file entries

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp
@@ -16,34 +16,18 @@
 
 <%@ include file="/document_library/init.jsp" %>
 
-<%
-FileEntry fileEntry = (FileEntry)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FILE_ENTRY);
-
-boolean showExtraInfo = ParamUtil.getBoolean(request, "showExtraInfo");
-
-DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext = dlDisplayContextProvider.getDLViewFileVersionDisplayContext(request, response, fileEntry.getFileVersion());
-%>
-
 <liferay-util:html-top
 	outputKey="document_library_preview_css"
 >
 	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/document_library/css/document_library_preview.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
-<c:choose>
-	<c:when test="<%= PropsValues.DL_FILE_ENTRY_PREVIEW_ENABLED && !showExtraInfo && (fileEntry.getSize() > 0) && dlViewFileVersionDisplayContext.hasPreview() %>">
-		<liferay-util:include page="/document_library/view_file_entry_simple_view.jsp" servletContext="<%= application %>" />
-	</c:when>
-	<c:otherwise>
+<%
+DLAdminDisplayContextProvider dlAdminDisplayContextProvider = dlWebComponentProvider.getDlAdminDisplayContextProvider();
 
-		<%
-		DLAdminDisplayContextProvider dlAdminDisplayContextProvider = dlWebComponentProvider.getDlAdminDisplayContextProvider();
+renderRequest.setAttribute(DLViewFileEntryDisplayContext.class.getName(), new DLViewFileEntryDisplayContext(dlAdminDisplayContextProvider.getDLAdminDisplayContext(request, response), dlDisplayContextProvider, HtmlUtil.getHtml(), LanguageUtil.getLanguage(), PortalUtil.getPortal(), renderRequest, renderResponse));
+%>
 
-		renderRequest.setAttribute(DLViewFileEntryDisplayContext.class.getName(), new DLViewFileEntryDisplayContext(dlAdminDisplayContextProvider.getDLAdminDisplayContext(request, response), dlDisplayContextProvider, HtmlUtil.getHtml(), LanguageUtil.getLanguage(), PortalUtil.getPortal(), renderRequest, renderResponse));
-		%>
-
-		<liferay-util:include page="/document_library/view_file_entry.jsp" servletContext="<%= application %>">
-			<liferay-util:param name="addPortletBreadcrumbEntries" value="<%= Boolean.FALSE.toString() %>" />
-		</liferay-util:include>
-	</c:otherwise>
-</c:choose>
+<liferay-util:include page="/document_library/view_file_entry.jsp" servletContext="<%= application %>">
+	<liferay-util:param name="addPortletBreadcrumbEntries" value="<%= Boolean.FALSE.toString() %>" />
+</liferay-util:include>


### PR DESCRIPTION
From @noornajj :

> https://issues.liferay.com/browse/LPS-131302
> 
> The issue here is that the info button does not appear for searched documents that have a preview. This was occurring because all documents with a preview were being viewed by view_file_entry_simple_view.jsp. There is a condition to skip this view if showExtraInfo is equal to true, but this value was always set to false.
> To fix this, I removed the use of view_file_entry_simple_view.jsp and had all file entries be viewed by view_file_entry.jsp. I saw that view_file_entry_simple_view.jsp was introduced in LPS-42026 and tested the issue reported in this ticket and was not able to reproduce it with this change.
> After this change, there is no use for view_file_entry_simple_view.jsp. I will leave the decision on whether this fix is appropriate and if view_file_entry_simple_view.jsp should be deleted to the product team.

