### PR TITLE
LPS-131851

### DIFF
--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java
@@ -18,8 +18,8 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.style.book.internal.upgrade.v1_1_0.StyleBookEntryUpgradeProcess;
-import com.liferay.style.book.internal.upgrade.v1_3_0.StyleBookEntryVersionUpgradeProcess;
-import com.liferay.style.book.internal.upgrade.v1_3_0.util.UpgradeMVCCVersion;
+import com.liferay.style.book.internal.upgrade.v1_2_0.StyleBookEntryVersionUpgradeProcess;
+import com.liferay.style.book.internal.upgrade.v1_2_0.util.UpgradeMVCCVersion;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -39,11 +39,11 @@ public class StyleBookServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register("1.0.0", "1.1.0", new StyleBookEntryUpgradeProcess());
 
 		registry.register(
-			"1.1.0", "1.2.0", new UpgradeCTModel("StyleBookEntry"));
+			"1.1.0", "1.2.0", new UpgradeMVCCVersion(),
+			new StyleBookEntryVersionUpgradeProcess());
 
 		registry.register(
-			"1.2.0", "1.3.0", new UpgradeMVCCVersion(),
-			new StyleBookEntryVersionUpgradeProcess());
+			"1.2.0", "1.3.0", new UpgradeCTModel("StyleBookEntry"));
 
 		registry.register(
 			"1.3.0", "1.4.0", new UpgradeCTModel("StyleBookEntryVersion"));

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/StyleBookEntryVersionUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/StyleBookEntryVersionUpgradeProcess.java
@@ -12,13 +12,13 @@
  * details.
  */
 
-package com.liferay.style.book.internal.upgrade.v1_3_0;
+package com.liferay.style.book.internal.upgrade.v1_2_0;
 
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
-import com.liferay.style.book.internal.upgrade.v1_3_0.util.StyleBookEntryVersionTable;
+import com.liferay.style.book.internal.upgrade.v1_2_0.util.StyleBookEntryVersionTable;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/StyleBookEntryVersionTable.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/StyleBookEntryVersionTable.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.style.book.internal.upgrade.v1_3_0.util;
+package com.liferay.style.book.internal.upgrade.v1_2_0.util;
 
 import java.sql.Types;
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/UpgradeMVCCVersion.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_2_0/util/UpgradeMVCCVersion.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.style.book.internal.upgrade.v1_3_0.util;
+package com.liferay.style.book.internal.upgrade.v1_2_0.util;
 
 /**
  * @author Víctor Galán


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-131851>

**Notes:**
Users that upgrade from 7.3 GA1 to 7.3 DXP-1 will no longer be able to create Style Book entries. This is because new columns were added to the `StyleBookEntryVersion` table (`uuid_`, `modifiedDate`) and there are currently no upgrade processes in 7.3 that adds these new columns to the table. This is not an issue when upgrading to master due to [LPS-127285](https://issues.liferay.com/browse/LPS-127285), which created a upgrade process for adding these missing columns: 1600bfeddb88d0a541606c2f1338940732e3233b. As a result, performing a partial backport of [LPS-127285](https://issues.liferay.com/browse/LPS-127285) would resolve this issue for 7.3.

However, before [LPS-127285](https://issues.liferay.com/browse/LPS-127285) was created, [LPS-120859](https://issues.liferay.com/browse/LPS-120859) added an upgrade process to `StyleBookServiceUpgrade.java` that cannot be backported:

- <https://github.com/liferay/liferay-portal/blob/7.4.0-ga1/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java#L41-L42>

As a result, backporting [LPS-127285](https://issues.liferay.com/browse/LPS-127285) to 7.3 would cause a conflict with the schema versions as 7.3.x is currently on schema version `1.1.0` and the [LPS-127285](https://issues.liferay.com/browse/LPS-127285) upgrade process is on schema version `1.3.0`:

- 7.3.x: <https://github.com/liferay/liferay-portal/blob/7.3.x/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java#L34-L36>
- master: <https://github.com/liferay/liferay-portal/blob/master/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/StyleBookServiceUpgrade.java#L37-L49>

The solution I'm proposing is to switch the schema versions of the upgrade processes on master. Let me know if you have any questions.