### PR TITLE
LPS-128860 We can have warnings and errors in non upgrade classes during the upgrade and also, we must not tie this feature to upgrades only

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
@@ -199,7 +199,7 @@ public class UpgradeClient {
 
 		if (_report) {
 			jvmOptsCommands +=
-				" -Dgenerate.report=true " +
+				" -Dreport.generation=true " +
 					"-Dsystem.properties.set.override=false";
 		}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/UpgradeClient.java
@@ -122,8 +122,14 @@ public class UpgradeClient {
 				shell = true;
 			}
 
+			boolean report = false;
+
+			if (commandLine.hasOption("report")) {
+				report = true;
+			}
+
 			UpgradeClient upgradeClient = new UpgradeClient(
-				jvmOpts, logFile, shell);
+				jvmOpts, logFile, report, shell);
 
 			upgradeClient.upgrade();
 		}
@@ -139,11 +145,13 @@ public class UpgradeClient {
 		}
 	}
 
-	public UpgradeClient(String jvmOpts, File logFile, boolean shell)
+	public UpgradeClient(
+			String jvmOpts, File logFile, boolean report, boolean shell)
 		throws IOException {
 
 		_jvmOpts = jvmOpts;
 		_logFile = logFile;
+		_report = report;
 		_shell = shell;
 
 		_appServerPropertiesFile = new File(_jarDir, "app-server.properties");
@@ -188,6 +196,12 @@ public class UpgradeClient {
 			" -Dexternal-properties=portal-upgrade.properties " +
 				"-Dserver.detector.server.id=" +
 					_appServer.getServerDetectorServerId());
+
+		if (_report) {
+			jvmOptsCommands +=
+				" -Dgenerate.report=true " +
+					"-Dsystem.properties.set.override=false";
+		}
 
 		System.out.println("JVM arguments: " + jvmOptsCommands);
 
@@ -293,6 +307,9 @@ public class UpgradeClient {
 				"Set the JVM_OPTS used for the upgrade."));
 		options.addOption(
 			new Option("l", "log-file", true, "Set the name of log file."));
+		options.addOption(
+			new Option(
+				"r", "report", false, "Generate a report after upgrading"));
 		options.addOption(
 			new Option(
 				"s", "shell", false, "Automatically connect to GoGo shell."));
@@ -768,6 +785,7 @@ public class UpgradeClient {
 	private final File _portalUpgradeDatabasePropertiesFile;
 	private final Properties _portalUpgradeExtProperties;
 	private final File _portalUpgradeExtPropertiesFile;
+	private final boolean _report;
 	private final boolean _shell;
 
 }

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1143,6 +1143,9 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final boolean GENERATE_REPORT = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.GENERATE_REPORT));
+
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1143,9 +1143,6 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
-	public static final boolean GENERATE_REPORT = GetterUtil.getBoolean(
-		PropsUtil.get(PropsKeys.GENERATE_REPORT));
-
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 
@@ -2501,6 +2498,9 @@ public class PropsValues {
 	@Deprecated
 	public static final String REDIRECT_URL_SECURITY_MODE = PropsUtil.get(
 		PropsKeys.REDIRECT_URL_SECURITY_MODE);
+
+	public static final boolean REPORT_GENERATION = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.REPORT_GENERATION));
 
 	public static final boolean REQUEST_HEADER_AUTH_IMPORT_FROM_LDAP =
 		GetterUtil.getBoolean(

--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -334,7 +334,7 @@
     # Set this to true to generate a report of errors, warnings, and events
     # after from the Report Generator.
     #
-    generate.report=false
+    report.generation=false
 
 ##
 ## Security

--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -327,6 +327,16 @@
     org.terracotta.quartz.skipUpdateCheck=true
 
 ##
+## Report Generator
+##
+
+    #
+    # Set this to true to generate a report of errors, warnings, and events
+    # after from the Report Generator.
+    #
+    generate.report=false
+
+##
 ## Security
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/log/LogFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log/LogFactoryUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.log;
 
+import com.liferay.portal.kernel.util.StringUtil;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -41,7 +43,14 @@ public class LogFactoryUtil {
 		if (logWrapper == null) {
 			Log log = _logFactory.getLog(name);
 
-			if (SanitizerLogWrapper.isEnabled()) {
+			String className = StringUtil.toLowerCase(name);
+
+			if (ReportGeneratorLogWrapper.isEnabled() &&
+				className.contains("upgrade")) {
+
+				logWrapper = new ReportGeneratorLogWrapper(log, name);
+			}
+			else if (SanitizerLogWrapper.isEnabled()) {
 				logWrapper = new SanitizerLogWrapper(log);
 			}
 			else if (log instanceof LogWrapper) {

--- a/portal-kernel/src/com/liferay/portal/kernel/log/LogFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log/LogFactoryUtil.java
@@ -45,9 +45,7 @@ public class LogFactoryUtil {
 
 			String className = StringUtil.toLowerCase(name);
 
-			if (ReportGeneratorLogWrapper.isEnabled() &&
-				className.contains("upgrade")) {
-
+			if (ReportGeneratorLogWrapper.isEnabled()) {
 				logWrapper = new ReportGeneratorLogWrapper(log, name);
 			}
 			else if (SanitizerLogWrapper.isEnabled()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/log/ReportGeneratorLogWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log/ReportGeneratorLogWrapper.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.log;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.SystemProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Sam Ziemer
+ */
+public class ReportGeneratorLogWrapper extends LogWrapper {
+
+	public static Map<String, HashMap<String, Integer>> getWarnings() {
+		return _warnings;
+	}
+
+	public static boolean isEnabled() {
+		return _GENERATE_REPORT;
+	}
+
+	public ReportGeneratorLogWrapper(Log log, String name) {
+		super(log);
+
+		_className = name;
+
+		setLogWrapperClassName(ReportGeneratorLogWrapper.class.getName());
+	}
+
+	public void addWarning(Object msg, Throwable throwable) {
+		String warning = null;
+
+		if (throwable == null) {
+			if (msg != null) {
+				warning = (String)msg;
+			}
+			else {
+				return;
+			}
+		}
+		else if (msg == null) {
+			warning = throwable.getMessage();
+		}
+
+		Map<String, Integer> warnings = _warnings.computeIfAbsent(
+			_className, key -> new HashMap<>());
+
+		warnings.put(warning, warnings.getOrDefault(warning, 0) + 1);
+	}
+
+	@Override
+	public void warn(Object msg) {
+		super.warn(msg);
+
+		addWarning(msg, null);
+	}
+
+	@Override
+	public void warn(Object msg, Throwable throwable) {
+		super.warn(msg, throwable);
+
+		addWarning(msg, throwable);
+	}
+
+	@Override
+	public void warn(Throwable throwable) {
+		super.warn(throwable);
+
+		addWarning(null, throwable);
+	}
+
+	private static final boolean _GENERATE_REPORT = GetterUtil.getBoolean(
+		SystemProperties.get(PropsKeys.GENERATE_REPORT));
+
+	private static final Map<String, HashMap<String, Integer>> _warnings =
+		new HashMap<>();
+
+	private final String _className;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/log/ReportGeneratorLogWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log/ReportGeneratorLogWrapper.java
@@ -85,7 +85,7 @@ public class ReportGeneratorLogWrapper extends LogWrapper {
 	}
 
 	private static final boolean _GENERATE_REPORT = GetterUtil.getBoolean(
-		SystemProperties.get(PropsKeys.GENERATE_REPORT));
+		SystemProperties.get(PropsKeys.REPORT_GENERATION));
 
 	private static final Map<String, HashMap<String, Integer>> _warnings =
 		new HashMap<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/report/ReportEventPublisher.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/report/ReportEventPublisher.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.report;
+
+/**
+ * @author Jonathan McCann
+ */
+public interface ReportEventPublisher {
+
+	public void addError(String className, String error);
+
+	public void addEvent(String className, long duration);
+
+	public void addWarning(String className, String warning);
+
+	public void generateUpgradeReport();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/report/ReportEventPublisherUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/report/ReportEventPublisherUtil.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.report;
+
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
+
+/**
+ * @author Jonathan McCann
+ */
+public class ReportEventPublisherUtil {
+
+	public static void addError(String className, String error) {
+		_reportEventPublisher.addError(className, error);
+	}
+
+	public static void addEvent(String className, long duration) {
+		_reportEventPublisher.addEvent(className, duration);
+	}
+
+	public static void addWarning(String className, String warning) {
+		_reportEventPublisher.addWarning(className, warning);
+	}
+
+	public static void generateUpgradeReport() {
+		_reportEventPublisher.generateUpgradeReport();
+	}
+
+	private static volatile ReportEventPublisher _reportEventPublisher =
+		ServiceProxyFactory.newServiceTrackedInstance(
+			ReportEventPublisher.class, ReportEventPublisherUtil.class,
+			"_reportEventPublisher", false);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1273,6 +1273,8 @@ public interface PropsKeys {
 
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
+	public static final String GENERATE_REPORT = "generate.report";
+
 	public static final String GLOBAL_SHUTDOWN_EVENTS =
 		"global.shutdown.events";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1273,8 +1273,6 @@ public interface PropsKeys {
 
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
-	public static final String GENERATE_REPORT = "generate.report";
-
 	public static final String GLOBAL_SHUTDOWN_EVENTS =
 		"global.shutdown.events";
 
@@ -2778,6 +2776,8 @@ public interface PropsKeys {
 
 	public static final String RELEASE_INFO_PREVIOUS_BUILD_NUMBER =
 		"release.info.previous.build.number";
+
+	public static final String REPORT_GENERATION = "report.generation";
 
 	public static final String REQUEST_HEADER_AUTH_IMPORT_FROM_LDAP =
 		"request.header.auth.import.from.ldap";


### PR DESCRIPTION
Hi @SamZiemer,

We need to do some changes in the logic:
1. Should our LogWrapper extend from SanitizerLogWrapper? If the sanitizerWrapper is the default option and can solve issues with special characters, we should extend it. Please, analyze it and make a decision based on that.
2. The LogWrapper is not the proper place to store the [warnings map](https://github.com/SamZiemer/liferay-portal/pull/811/commits/6a76bac1e9de563a0236716a0568072829e205ec#diff-3bdff561f8d706de1b12cc16043c26392c895eced36ea3161f4eb9429e1b3e60R90), we should do it in the implementation of the ReportEventPublisher
3. The Wrapper API should also catch the errors.

I also expected the implementation of the API in this pull request. Without that it is going to be difficult to create a complete set of tests. We can create three LPS (instead of 2), one for the API, one for the API implementation and one for the Report implementation. That's ok to me but we are delayed to have the API ready by this week and invest the next two weeks in the report. 

Please, take care of this and send me another pull request with the changes.

Thanks.