### PR TITLE
LPS-141258 com.liferay.portal.upgrade.test.UpgradeReportLogAppenderTest randomly fails

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java
@@ -70,10 +70,10 @@ public class UpgradeReportLogAppenderTest {
 
 		_db.runSQL(
 			"create table " + _TABLE_NAME_1 +
-				" (id LONG not null primary key)");
+				" (id_ LONG not null primary key)");
 		_db.runSQL(
 			"create table " + _TABLE_NAME_2 +
-				" (id LONG not null primary key)");
+				" (id_ LONG not null primary key)");
 	}
 
 	@AfterClass
@@ -103,14 +103,14 @@ public class UpgradeReportLogAppenderTest {
 
 	@Test
 	public void testDatabaseTablesCounts() throws Exception {
-		_db.runSQL("insert into " + _TABLE_NAME_2 + " (id) values (1)");
+		_db.runSQL("insert into " + _TABLE_NAME_2 + " (id_) values (1)");
 
 		_appender.start();
 
 		_db.runSQL(
 			new String[] {
-				"insert into " + _TABLE_NAME_1 + " (id) values (1)",
-				"delete from " + _TABLE_NAME_2 + " where id = 1"
+				"insert into " + _TABLE_NAME_1 + " (id_) values (1)",
+				"delete from " + _TABLE_NAME_2 + " where id_ = 1"
 			});
 
 		_appender.stop();


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-141258>

__Notes:__
According to the QA test results, the test that randomly fails is `UpgradeReportLogAppenderTest.testDatabaseTablesCounts()`. Specifically, the test fails here:

* <https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogAppenderTest.java#L142>

It seems that the test tables are not created before the unit test is executed. I've made adjustments so that the test tables are created and dropped before the unit tests. I wonder if we should check if the test tables exist before running the unit test. I've written a version that does this: <https://github.com/kevhlee/liferay-portal/compare/LPS-141258...kevhlee:LPS-141258-v2>. Let me know if you have any questions/thoughts.