### PR TITLE
LPS-137423 All related data should be deleted when a virtual instance is removed and DB Partition is enabled

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -131,28 +131,6 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
-	public void testRemoveDBPartition() throws Exception {
-		addDBPartition();
-
-		List<String> viewNames = _getObjectNames("VIEW");
-
-		Assert.assertNotEquals(0, viewNames.size());
-
-		int tablesCount = _getTablesCount();
-
-		_removeDBPartition();
-
-		Assert.assertEquals(tablesCount + viewNames.size(), _getTablesCount());
-		Assert.assertEquals(0, _getViewsCount());
-
-		for (String viewName : viewNames) {
-			Assert.assertEquals(
-				viewName + " count", _getCount(viewName, true),
-				_getCount(viewName, false));
-		}
-	}
-
-	@Test
 	public void testRemoveDBPartitionRollback() throws Exception {
 		addDBPartition();
 
@@ -167,7 +145,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 			createAndPopulateControlTable(fullTestTableName);
 
 			try {
-				_removeDBPartition();
+				_removeDBPartition(true);
 
 				Assert.fail("Should throw an exception");
 			}
@@ -178,6 +156,28 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		}
 		finally {
 			dropTable(TEST_CONTROL_TABLE_NAME);
+		}
+	}
+
+	@Test
+	public void testRemoveDBPartitionWithMigrateEnabled() throws Exception {
+		addDBPartition();
+
+		List<String> viewNames = _getObjectNames("VIEW");
+
+		Assert.assertNotEquals(0, viewNames.size());
+
+		int tablesCount = _getTablesCount();
+
+		_removeDBPartition(true);
+
+		Assert.assertEquals(tablesCount + viewNames.size(), _getTablesCount());
+		Assert.assertEquals(0, _getViewsCount());
+
+		for (String viewName : viewNames) {
+			Assert.assertEquals(
+				viewName + " count", _getCount(viewName, true),
+				_getCount(viewName, false));
 		}
 	}
 
@@ -238,7 +238,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		return viewNames.size();
 	}
 
-	private void _removeDBPartition() throws Exception {
+	private void _removeDBPartition(boolean migrateEnabled) throws Exception {
 		CurrentConnection defaultCurrentConnection =
 			CurrentConnectionUtil.getCurrentConnection();
 
@@ -248,6 +248,10 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 			ReflectionTestUtil.setFieldValue(
 				CurrentConnectionUtil.class, "_currentConnection",
 				currentConnection);
+
+			ReflectionTestUtil.setFieldValue(
+				DBPartitionUtil.class, "_DATABASE_PARTITION_MIGRATE_ENABLED",
+				migrateEnabled);
 
 			DBPartitionUtil.removeDBPartition(COMPANY_ID);
 		}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.db.partition.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
@@ -128,6 +129,23 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> Assert.assertEquals(
 				companyId, CompanyThreadLocal.getCompanyId()));
+	}
+
+	@Test
+	public void testRemoveDBPartition() throws Exception {
+		addDBPartition();
+
+		_removeDBPartition(false);
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select schema_name from information_schema.schemata ",
+					"where schema_name = '", getSchemaName(COMPANY_ID), "'"));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			Assert.assertFalse(resultSet.next());
+		}
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -148,7 +148,7 @@ public class DBPartitionUtil {
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
 			try (ResultSet resultSet = databaseMetaData.getTables(
-					dbInspector.getCatalog(), dbInspector.getSchema(), null,
+					_defaultSchemaName, dbInspector.getSchema(), null,
 					new String[] {"TABLE"});
 				Statement statement = connection.createStatement()) {
 

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -137,61 +137,11 @@ public class DBPartitionUtil {
 			return false;
 		}
 
-		Connection connection = CurrentConnectionUtil.getConnection(
-			InfrastructureUtil.getDataSource());
-
-		DBInspector dbInspector = new DBInspector(connection);
-
-		List<String> controlTableNames = new ArrayList<>();
-
-		try {
-			DatabaseMetaData databaseMetaData = connection.getMetaData();
-
-			try (ResultSet resultSet = databaseMetaData.getTables(
-					_defaultSchemaName, dbInspector.getSchema(), null,
-					new String[] {"TABLE"});
-				Statement statement = connection.createStatement()) {
-
-				while (resultSet.next()) {
-					String tableName = resultSet.getString("TABLE_NAME");
-
-					if (_isControlTable(dbInspector, tableName)) {
-						controlTableNames.add(tableName);
-
-						_migrateTable(
-							companyId, tableName, statement, dbInspector);
-					}
-				}
-			}
-		}
-		catch (Exception exception1) {
-			if (ListUtil.isEmpty(controlTableNames)) {
-				throw new PortalException(exception1);
-			}
-
-			try {
-				for (String tableName : controlTableNames) {
-					try (Statement statement = connection.createStatement()) {
-						_restoreTable(
-							companyId, tableName, statement, dbInspector);
-					}
-				}
-			}
-			catch (Exception exception2) {
-				throw new PortalException(
-					StringBundler.concat(
-						"Unable to rollback the removal of database ",
-						"partition. Recover a backup of the database schema ",
-						_getSchemaName(companyId), "."),
-					exception2);
-			}
-
-			throw new PortalException(
-				"Removal of database partition removal was rolled back",
-				exception1);
+		if (_DATABASE_PARTITION_MIGRATE_ENABLED) {
+			return _migrateDBPartition(companyId);
 		}
 
-		return true;
+		return _dropDBPartition(companyId);
 	}
 
 	public static void setDefaultCompanyId(Connection connection)
@@ -263,6 +213,12 @@ public class DBPartitionUtil {
 				"insert ", toSchemaName, StringPool.PERIOD, tableName,
 				" select * from ", fromSchemaName, StringPool.PERIOD, tableName,
 				whereClause));
+	}
+
+	private static boolean _dropDBPartition(long companyId)
+		throws PortalException {
+
+		throw new PortalException("Unable to drop database partition");
 	}
 
 	private static Connection _getConnectionWrapper(Connection connection) {
@@ -450,6 +406,66 @@ public class DBPartitionUtil {
 		return false;
 	}
 
+	private static boolean _migrateDBPartition(long companyId)
+		throws PortalException {
+
+		Connection connection = CurrentConnectionUtil.getConnection(
+			InfrastructureUtil.getDataSource());
+
+		DBInspector dbInspector = new DBInspector(connection);
+
+		List<String> controlTableNames = new ArrayList<>();
+
+		try {
+			DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+			try (ResultSet resultSet = databaseMetaData.getTables(
+					_defaultSchemaName, dbInspector.getSchema(), null,
+					new String[] {"TABLE"});
+				Statement statement = connection.createStatement()) {
+
+				while (resultSet.next()) {
+					String tableName = resultSet.getString("TABLE_NAME");
+
+					if (_isControlTable(dbInspector, tableName)) {
+						controlTableNames.add(tableName);
+
+						_migrateTable(
+							companyId, tableName, statement, dbInspector);
+					}
+				}
+			}
+		}
+		catch (Exception exception1) {
+			if (ListUtil.isEmpty(controlTableNames)) {
+				throw new PortalException(exception1);
+			}
+
+			try {
+				for (String tableName : controlTableNames) {
+					try (Statement statement = connection.createStatement()) {
+						_restoreTable(
+							companyId, tableName, statement, dbInspector);
+					}
+				}
+			}
+			catch (Exception exception2) {
+				throw new PortalException(
+					StringBundler.concat(
+						"Unable to rollback the removal of database ",
+						"partition. Recover a backup of the database schema ",
+						_getSchemaName(companyId), "."),
+					exception2);
+			}
+
+			throw new PortalException(
+				"Removal of database partition removal was rolled back",
+				exception1);
+		}
+
+		return true;
+	}
+
 	private static void _migrateTable(
 			long companyId, String tableName, Statement statement,
 			DBInspector dbInspector)
@@ -562,6 +578,10 @@ public class DBPartitionUtil {
 
 	private static final boolean _DATABASE_PARTITION_ENABLED =
 		GetterUtil.getBoolean(PropsUtil.get("database.partition.enabled"));
+
+	private static final boolean _DATABASE_PARTITION_MIGRATE_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get("database.partition.migrate.enabled"));
 
 	private static final String _DATABASE_PARTITION_SCHEMA_NAME_PREFIX =
 		GetterUtil.get(

--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -218,7 +218,43 @@ public class DBPartitionUtil {
 	private static boolean _dropDBPartition(long companyId)
 		throws PortalException {
 
-		throw new PortalException("Unable to drop database partition");
+		Connection connection = CurrentConnectionUtil.getConnection(
+			InfrastructureUtil.getDataSource());
+
+		try {
+			DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+			DBInspector dbInspector = new DBInspector(connection);
+
+			try (ResultSet resultSet = databaseMetaData.getTables(
+					_defaultSchemaName, dbInspector.getSchema(), null,
+					new String[] {"TABLE"});
+				Statement statement = connection.createStatement()) {
+
+				while (resultSet.next()) {
+					String tableName = resultSet.getString("TABLE_NAME");
+
+					if (_isControlTable(dbInspector, tableName) &&
+						dbInspector.hasColumn(tableName, "companyId")) {
+
+						statement.executeUpdate(
+							StringBundler.concat(
+								"delete from ", _defaultSchemaName,
+								StringPool.PERIOD, tableName,
+								" where companyId = ", companyId));
+					}
+				}
+
+				statement.executeUpdate(
+					"drop schema if exists " + _getSchemaName(companyId));
+			}
+		}
+		catch (Exception exception) {
+			throw new PortalException(
+				"Unable to delete database partition", exception);
+		}
+
+		return true;
 	}
 
 	private static Connection _getConnectionWrapper(Connection connection) {

--- a/portal-impl/src/portal-liferay-online.properties
+++ b/portal-impl/src/portal-liferay-online.properties
@@ -1,4 +1,5 @@
 database.partition.enabled=true
+database.partition.migrate.enabled=false
 enterprise.product.commerce.enabled=true
 session.timeout.auto.extend=true
 session.timeout.auto.extend.offset=300


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-137423>

__Notes:__
By setting the portal property `database.partition.migrate.enabled`, users can now choose between the following options when removing a virtual instance:

* Keep the database partition independent by copying control tables and migrating all relevant data from the default schema to the partition.
* Drop the database partition entirely.

For context, commit 1849ccc22986a8c43abdc8e5e5dc312b5ef0cfd8 fixes the bug described in [LPS-140833](https://issues.liferay.com/browse/LPS-140833). The issue is that, upon removal of the virtual instance, tables from the virtual instance database partition were being iterated, which would cause `DBPartitionUtil` to migrate tables that do not exist in the default schema.

Let me know if you have any questions/thoughts.