### PR TITLE
LPS-140833 Delete Virtual Instance in Liferay Online

### DIFF
--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -148,7 +148,7 @@ public class DBPartitionUtil {
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
 			try (ResultSet resultSet = databaseMetaData.getTables(
-					dbInspector.getCatalog(), dbInspector.getSchema(), null,
+					_defaultSchemaName, dbInspector.getSchema(), null,
 					new String[] {"TABLE"});
 				Statement statement = connection.createStatement()) {
 


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-140833>

__Notes:__
The issue is that, upon removal of the virtual instance, tables from the virtual instance database partition, instead of those from the default schema, were being iterated, which would cause `DBPartitionUtil` to attempt to migrate tables that do not exist in the default schema.

Let me know if you have any thoughts/questions.