### PR TITLE
LPS-139161 DB Partitioning should use the client session charset or the Db default one

### DIFF
--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -438,6 +440,10 @@ public class DBPartitionUtil {
 			return "utf8";
 		}
 		catch (Exception exception) {
+			_log.error(
+				"Unable to retrieve character set from database session",
+				exception);
+
 			return "utf8";
 		}
 	}
@@ -593,6 +599,9 @@ public class DBPartitionUtil {
 		GetterUtil.get(
 			PropsUtil.get("database.partition.schema.name.prefix"),
 			"lpartition_");
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DBPartitionUtil.class);
 
 	private static final Set<String> _controlTableNames = new HashSet<>(
 		Arrays.asList("Company", "VirtualHost"));


### PR DESCRIPTION
__Ticket:__
<https://issues.liferay.com/browse/LPS-139161>

__Notes:__
Instead of using `utf8` by default for the new partition schemas, we should use the character set encoding specified for the database session, which can be retrieved by reading the value set for the session variable `character_set_client`. Note that the `character_set_client` session variable is set when supplying the value for `characterEncoding` in the JDBC string. See following link for more information:

* <https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_character_set_client>
* <https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-session.html>

Let me know if you have any questions/thoughts.