### PR TITLE
[TS]LPS-160305 Check if type is null, continue upgrade if null

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
@@ -531,11 +531,23 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 
 		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
 
+		String type = null;
+
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			try {
+				type = ddmFormFieldValue.getType();
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(exception);
+				}
+			}
+
 			if (!ListUtil.isEmpty(
 					ddmFormFieldValue.getNestedDDMFormFieldValues()) &&
+				(type != null) &&
 				!com.liferay.portal.kernel.util.StringUtil.equals(
-					ddmFormFieldValue.getType(), "fieldset")) {
+					type, "fieldset")) {
 
 				DDMFormFieldValue newDDMFormFieldValue =
 					new DDMFormFieldValue() {


### PR DESCRIPTION
Ticket:[LPS-160305](https://issues.liferay.com/browse/LPS-160305)

Issue:
If a Forms field is removed after entries are already added for that form, then during the upgrade when attempting to get the field's type, will throw a null exception since the field no longer exists on the form.


Solution:
We determined that the upgrade process should still continue even if the form field no longer exists in the form.  The entry will still be added to the database to retain that data even though the portal/user will not be able to view it from the portal.  
