### PR TITLE
Prompt Front End - Removing Overflow Property

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -192,13 +192,14 @@ $productMenuWidth: 320px;
 				max-height: calc(
 					100vh - #{$controlMenuHeight + $portletLayoutMargin} - #{$toolbarHeight}
 				);
-				overflow: auto;
+				
 
 				@include media-breakpoint-up(lg) {
 					max-height: calc(
 						100vh - #{$controlMenuHeight + $portletLayoutMargin} - #{$toolbarDesktopHeight}
-					);
-				}
+						);
+					
+					}
 
 				@include media-breakpoint-down(md) {
 					margin: 0 auto;


### PR DESCRIPTION
Hi Sam! Removed the overflow property, as the overflow property specifies when the content of a block-level element should be clipped, displayed with scrollbars, or if it overflows the element, removed to leave only the largest DIV.